### PR TITLE
fix(license): keep detected_license_expression_spdx in step with the key form

### DIFF
--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -121,11 +121,33 @@ fn is_unknown_reference_like_match_public(match_item: &Match) -> bool {
     )
 }
 
+/// Recompute a file's `detected_license_expression` and its SPDX counterpart from
+/// the file's current `license_detections`.
+///
+/// Every pass that rewrites `license_detections` must refresh through here rather
+/// than assigning the key field alone: the two expression fields are one fact in
+/// two spellings, and updating only the key form leaves the SPDX field asserting a
+/// license the file no longer claims. The SPDX form mirrors the key expression's
+/// operator structure (see [`spdx_expression_mirroring_key`]) instead of
+/// independently recombining each detection's SPDX string, and is absent whenever
+/// the key form is absent or an operand carries no SPDX id.
+fn refresh_file_license_expressions(file: &mut FileInfo) {
+    file.detected_license_expression = combine_license_expressions(
+        file.license_detections
+            .iter()
+            .map(|detection| detection.license_expression.clone()),
+    );
+    file.detected_license_expression_spdx = file
+        .detected_license_expression
+        .as_deref()
+        .and_then(|key| spdx_expression_mirroring_key(key, &file.license_detections));
+}
+
 /// Move unresolved reference-placeholder detections out of `license_detections`
-/// and into `license_clues`, then recompute the file-level
-/// `detected_license_expression` from the surviving real detections. This keeps
-/// the placeholder matches visible as weak evidence (matching ScanCode's
-/// `license_clues`) while ensuring they no longer assert a license.
+/// and into `license_clues`, then recompute the file-level license expressions
+/// from the surviving real detections. This keeps the placeholder matches visible
+/// as weak evidence (matching ScanCode's `license_clues`) while ensuring they no
+/// longer assert a license in either expression field.
 fn demote_unresolved_reference_detections_to_clues(file: &mut FileInfo) {
     if !file
         .license_detections
@@ -145,11 +167,7 @@ fn demote_unresolved_reference_detections_to_clues(file: &mut FileInfo) {
     }
     file.license_detections = surviving;
 
-    file.detected_license_expression = combine_license_expressions(
-        file.license_detections
-            .iter()
-            .map(|detection| detection.license_expression.clone()),
-    );
+    refresh_file_license_expressions(file);
 }
 
 fn collect_referenced_file_paths(files: &[FileInfo]) -> HashSet<String> {
@@ -689,11 +707,7 @@ fn follow_references_for_file(file: &mut FileInfo, snapshot: &ReferenceFollowSna
     }
 
     if modified {
-        file.detected_license_expression = combine_license_expressions(
-            file.license_detections
-                .iter()
-                .map(|detection| detection.license_expression.clone()),
-        );
+        refresh_file_license_expressions(file);
     }
 
     modified
@@ -727,11 +741,7 @@ fn inherit_same_directory_legal_detections_for_file(
     }
 
     file.license_detections = inherited_detections;
-    file.detected_license_expression = combine_license_expressions(
-        file.license_detections
-            .iter()
-            .map(|detection| detection.license_expression.clone()),
-    );
+    refresh_file_license_expressions(file);
     true
 }
 
@@ -1983,6 +1993,39 @@ mod tests {
             font.license_detections[0].matches[0].from_file.as_deref(),
             Some("fonts/OFL.txt")
         );
+        // Inheritance replaces the asset's detections outright, so the SPDX field
+        // must follow the inherited license rather than keep whatever the asset
+        // carried before.
+        assert_eq!(
+            font.detected_license_expression_spdx.as_deref(),
+            Some("OFL-1.1")
+        );
+    }
+
+    #[test]
+    fn same_directory_legal_inheritance_replaces_a_stale_spdx_expression() {
+        // The asset arrives carrying its own (unresolved-reference) expressions.
+        // Inheriting the sibling legal file's license must overwrite *both*
+        // spellings; keeping the old SPDX form would name a different license
+        // than the key form.
+        let mut font = file("fonts/Scheherazade-Bold.ttf");
+        font.detected_license_expression = Some("unknown-license-reference".to_string());
+        font.detected_license_expression_spdx =
+            Some("LicenseRef-scancode-unknown-license-reference".to_string());
+
+        let mut legal = file("fonts/OFL.txt");
+        legal.license_detections = vec![detection("ofl-1.1", "OFL-1.1", "fonts/OFL.txt")];
+        legal.detected_license_expression = Some("ofl-1.1".to_string());
+
+        let mut files = vec![font, legal];
+        apply_package_reference_following(&mut files, &mut []);
+        let font = files.remove(0);
+
+        assert_eq!(font.detected_license_expression.as_deref(), Some("ofl-1.1"));
+        assert_eq!(
+            font.detected_license_expression_spdx.as_deref(),
+            Some("OFL-1.1")
+        );
     }
 
     fn placeholder_reference_match(expression: &str, rule_identifier: &str) -> Match {
@@ -2023,6 +2066,7 @@ mod tests {
             identifier: "free-unknown-id".to_string(),
         }];
         po.detected_license_expression = Some("free-unknown".to_string());
+        po.detected_license_expression_spdx = Some("LicenseRef-scancode-free-unknown".to_string());
 
         let mut files = vec![po];
         apply_package_reference_following(&mut files, &mut []);
@@ -2032,6 +2076,10 @@ mod tests {
         assert_eq!(po.license_clues.len(), 1);
         assert_eq!(po.license_clues[0].license_expression, "free-unknown");
         assert_eq!(po.detected_license_expression, None);
+        // The SPDX counterpart must be cleared with the key form. Leaving it set
+        // makes the file assert a license in one spelling that it denies in the
+        // other, which is what a clue-only file looked like before this fix.
+        assert_eq!(po.detected_license_expression_spdx, None);
     }
 
     #[test]
@@ -2075,6 +2123,8 @@ mod tests {
             },
         ];
         f.detected_license_expression = Some("apache-2.0 AND free-unknown".to_string());
+        f.detected_license_expression_spdx =
+            Some("Apache-2.0 AND LicenseRef-scancode-free-unknown".to_string());
 
         let mut files = vec![f];
         apply_package_reference_following(&mut files, &mut []);
@@ -2084,6 +2134,10 @@ mod tests {
         assert_eq!(f.license_detections[0].license_expression, "apache-2.0");
         assert_eq!(f.license_clues.len(), 1);
         assert_eq!(f.detected_license_expression.as_deref(), Some("apache-2.0"));
+        assert_eq!(
+            f.detected_license_expression_spdx.as_deref(),
+            Some("Apache-2.0")
+        );
     }
 
     fn detection(expression: &str, spdx: &str, from_file: &str) -> crate::models::LicenseDetection {

--- a/testdata/summarycode-golden/reference_following/unresolved_reference_clue_only/codebase/README.md
+++ b/testdata/summarycode-golden/reference_following/unresolved_reference_clue_only/codebase/README.md
@@ -1,0 +1,6 @@
+# Example Project
+
+A small example project.
+
+This software is distributed under the terms described in the file COPYING,
+which is not shipped in this tree.

--- a/testdata/summarycode-golden/reference_following/unresolved_reference_clue_only/expected.json
+++ b/testdata/summarycode-golden/reference_following/unresolved_reference_clue_only/expected.json
@@ -1,0 +1,91 @@
+{
+  "summary": {
+    "declared_license_expression": null,
+    "license_clarity_score": {
+      "score": 0,
+      "declared_license": false,
+      "identification_precision": false,
+      "has_license_text": false,
+      "declared_copyrights": false,
+      "conflicting_license_categories": false,
+      "ambiguous_compound_licensing": true
+    },
+    "declared_holder": null,
+    "primary_language": null,
+    "other_license_expressions": [],
+    "other_holders": [],
+    "other_languages": []
+  },
+  "tallies": {
+    "detected_license_expression": [
+      {
+        "value": "unknown-license-reference",
+        "count": 1
+      }
+    ],
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "programming_language": []
+  },
+  "tallies_of_key_files": {
+    "detected_license_expression": [
+      {
+        "value": "unknown-license-reference",
+        "count": 1
+      }
+    ],
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "programming_language": []
+  },
+  "license_detections": [],
+  "license_references": [
+    {
+      "key": "unknown-license-reference",
+      "language": "en",
+      "short_name": "Unknown License reference",
+      "name": "Unknown License file reference",
+      "owner": "Unspecified",
+      "homepage_url": null,
+      "spdx_license_key": "LicenseRef-scancode-unknown-license-reference",
+      "osi_license_key": null,
+      "text_urls": [],
+      "osi_url": null,
+      "faq_url": null,
+      "other_urls": [],
+      "category": "Unstated License",
+      "is_exception": false,
+      "is_unknown": true,
+      "is_generic": false,
+      "minimum_coverage": null,
+      "standard_notice": null
+    }
+  ],
+  "license_rule_references": [
+    {
+      "identifier": "license-intro_59.RULE",
+      "license_expression": "unknown-license-reference",
+      "language": null,
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/license-intro_59.RULE",
+      "is_synthetic": false,
+      "length": 3,
+      "referenced_filenames": []
+    }
+  ],
+  "packages": [],
+  "files": [
+    {
+      "path": "codebase/README.md",
+      "type": "file",
+      "is_top_level": true,
+      "is_key_file": true,
+      "is_manifest": false,
+      "detected_license_expression": null,
+      "detected_license_expression_spdx": null,
+      "license_detections": [],
+      "package_data": []
+    }
+  ]
+}

--- a/tests/post_processing_golden.rs
+++ b/tests/post_processing_golden.rs
@@ -474,6 +474,19 @@ Copyright - split out libs\0\xff",
     }
 
     #[test]
+    // A file whose only license evidence is an unresolvable reference ("see the
+    // file COPYING", with no such file in the tree) keeps that evidence as a
+    // clue and asserts no license. Both `detected_license_expression` and its
+    // SPDX counterpart must be null: reporting a license in one spelling while
+    // denying it in the other is the inconsistency this fixture guards.
+    fn test_golden_reference_follow_unresolved_reference_clue_only() {
+        assert_reference_follow_fixture_matches_expected(
+            "testdata/summarycode-golden/reference_following/unresolved_reference_clue_only",
+            "testdata/summarycode-golden/reference_following/unresolved_reference_clue_only/expected.json",
+        );
+    }
+
+    #[test]
     fn test_golden_reference_follow_root_fallback_no_package() {
         assert_reference_follow_fixture_matches_expected(
             "testdata/summarycode-golden/reference_following/root_fallback_no_package",


### PR DESCRIPTION
## Summary

- Three reference-following passes rewrote a file's `detected_license_expression` without touching `detected_license_expression_spdx`, leaving the SPDX field asserting a license the file no longer claims.
- The user-visible symptom: a file whose only license evidence is an unresolvable reference is emitted with `detected_license_expression: null` next to `detected_license_expression_spdx: "LicenseRef-scancode-unknown-license-reference"` — the two fields contradicting each other, with the license coming from a `license_clues` entry rather than any detection.
- Regression introduced by #1182, which correctly demoted unresolved reference placeholders to clues but recomputed only the key-form expression.

## Scope and exclusions

- Included: all three file-level expression rewrites in `src/post_processing/reference_following.rs` — the clue demotion, the file-level package-data adopt, and same-directory legal inheritance — routed through one `refresh_file_license_expressions` helper.
- Included: a reference-following golden for a clue-only file, a case the golden suite did not cover.
- Explicit exclusions: package-level `declared_license_expression_spdx` (already mirrors correctly via `spdx_expression_mirroring_key`), and the tallies treatment of `license_clues`, which is pre-existing behaviour and unchanged here.

## How to verify

Scan a file whose only license evidence is a reference to a file that is not in the tree:

```sh
mkdir -p /tmp/clue && printf '/*\n * See the file COPYING for the full license text.\n */\nint main(void){return 0;}\n' > /tmp/clue/main.c
provenant --license --json-pp - /tmp/clue | jq '.files[] | select(.type=="file") | {path, detected_license_expression, detected_license_expression_spdx, clues: [.license_clues[].license_expression]}'
```

Before: `detected_license_expression: null` with `detected_license_expression_spdx: "LicenseRef-scancode-unknown-license-reference"`.
After: both null, with the evidence still visible in `license_clues`.

Worth poking at the third site specifically: a font asset next to an `OFL.txt` sibling, where inheritance replaces the asset's detections outright — there the stale SPDX value could name a *different* license than the key form, not just an extra one.

## Intentional differences from Python

- None. ScanCode reports an unresolved reference group as `license_clues` with no combined expression in either spelling; this brings the SPDX field in line with that.

## Expected-output fixture changes

- Files changed: one new fixture, `testdata/summarycode-golden/reference_following/unresolved_reference_clue_only/` (codebase + `expected.json`). No existing expected file changes.
- Why the new expected output is correct: the file's only evidence is an unresolvable "see the file COPYING" reference, so it asserts no license and both expression fields are null. That no existing golden moved is itself the signal that this touches only the inconsistent cases.
