### PR TITLE
fix(assembly): stop hoisting a datafile's dependencies twice

### DIFF
--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -2493,6 +2493,47 @@ mod tests {
     }
 
     #[test]
+    fn test_assemble_hoists_standalone_requirements_txt_dependencies_exactly_once() {
+        // `requirements.txt` matches the Python assembler's `requirements*.txt`
+        // sibling pattern, so the sibling merge hoists its dependencies even
+        // though the purl-less record yields no package to own them. The file
+        // therefore stays unowned, and the unassembled fallback used to hoist the
+        // very same dependencies a second time. (The neighbouring test's
+        // `min_requirements.txt` does not match that pattern, so only the
+        // fallback ever ran for it.)
+        let mut files = vec![create_test_file_info(
+            "requirements.txt",
+            DatasourceId::PipRequirements,
+            None,
+            None,
+            None,
+            vec![
+                create_test_dependency("pkg:pypi/requests@2.0", Some("==2.0"), None),
+                create_test_dependency("pkg:pypi/sphinx@3.4.3", Some("==3.4.3"), None),
+            ],
+        )];
+
+        let result = assemble(&mut files);
+
+        assert!(result.packages.is_empty());
+        assert_eq!(result.dependencies.len(), 2);
+        let mut purls: Vec<&str> = result
+            .dependencies
+            .iter()
+            .filter_map(|dependency| dependency.purl.as_deref())
+            .collect();
+        purls.sort_unstable();
+        assert_eq!(purls, ["pkg:pypi/requests@2.0", "pkg:pypi/sphinx@3.4.3"]);
+        assert!(
+            result
+                .dependencies
+                .iter()
+                .all(|dependency| dependency.for_package_uid.is_none())
+        );
+        assert!(files[0].for_packages.is_empty());
+    }
+
+    #[test]
     fn test_assemble_does_not_hoist_unowned_nuget_cpm_metadata_dependencies() {
         let mut files = vec![create_test_file_info(
             "repo/Directory.Packages.props",

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -287,10 +287,27 @@ fn apply_directory_merge_results(
     }
 }
 
+/// Last-resort visibility for datafiles that no assembler emitted dependencies
+/// for, so a dep-bearing manifest is never silently dropped.
+///
+/// An empty `for_packages` does not by itself mean "not assembled": an assembler
+/// can hoist a purl-less record's dependencies (`for_package_uid: None`) without
+/// creating a package to own them, which leaves the file unowned even though its
+/// dependencies are already in the list. A standalone `requirements.txt` is
+/// exactly that shape, and hoisting on the `for_packages` signal alone emitted
+/// every one of its dependencies twice. Skip any datafile+datasource that already
+/// contributed, and keep intra-file duplicates (a requirement genuinely listed
+/// twice) intact by never deduplicating individual entries.
 fn hoist_unassembled_file_dependencies(
     files: &[FileInfo],
     dependencies: &mut Vec<TopLevelDependency>,
 ) {
+    let already_emitted: HashSet<(&str, DatasourceId)> = dependencies
+        .iter()
+        .map(|dependency| (dependency.datafile_path.as_str(), dependency.datasource_id))
+        .collect();
+
+    let mut hoisted = Vec::new();
     for file in files {
         if !file.for_packages.is_empty() {
             continue;
@@ -305,11 +322,17 @@ fn hoist_unassembled_file_dependencies(
                 continue;
             }
 
-            dependencies.extend(pkg_data.dependencies.iter().map(|dep| {
+            if already_emitted.contains(&(file.path.as_str(), datasource_id)) {
+                continue;
+            }
+
+            hoisted.extend(pkg_data.dependencies.iter().map(|dep| {
                 TopLevelDependency::from_dependency(dep, file.path.clone(), datasource_id, None)
             }));
         }
     }
+
+    dependencies.extend(hoisted);
 }
 
 const HOIST_IF_UNOWNED_DATASOURCE_IDS: &[DatasourceId] = &[DatasourceId::PipRequirements];


### PR DESCRIPTION
## Summary

- A standalone `requirements.txt` emitted every dependency **twice** at the top level, each copy with its own `dependency_uid`, while the file's own `package_data` listed them once.
- `hoist_unassembled_file_dependencies` uses an empty `for_packages` as its "no assembler handled this datafile" signal. That proxy stopped holding once assemblers began hoisting purl-less records' dependencies: `assemble_single_sibling_package` emits them with `for_package_uid: None` and creates no package, so nothing is recorded on `for_packages` and the fallback ran on top of work already done.
- `requirements.txt` matches the Python assembler's `requirements*.txt` sibling pattern and carries no identity of its own, so it takes exactly that path.

## Scope and exclusions

- Included: skip any datafile+datasource that already contributed dependencies, keyed on the datafile rather than on individual entries so a requirement genuinely listed twice in one file still yields two dependencies.
- Explicit exclusions: the malformed `pkg:pypi/::` purl visible in the same output is a separate parser-level defect, fixed on its own branch.

## How to verify

```sh
mkdir -p /tmp/reqs && printf 'requests==2.0\n' > /tmp/reqs/requirements.txt
provenant --package --json-pp - /tmp/reqs | jq '{deps: [.dependencies[].purl], package_data_deps: [.files[].package_data[].dependencies[].purl]}'
```

Before: two identical top-level entries for one `package_data` dependency. After: one each.

Worth poking at: a directory where a purled Python manifest sits next to `requirements.txt`, and a `requirements/` directory with several files — the fallback must still hoist anything no assembler claimed, which is the behaviour #1180 restored.

## Intentional differences from Python

- None.

## Follow-up work

- Created or intentionally deferred: the `for_packages`-as-assembly-signal proxy is now guarded at the point of use rather than fixed at its source. A record that is hoisted-but-unowned has no representation in the file→package link by design (there is no package to link to), so a positive "this datafile was handled" signal threaded out of assembly would be the deeper fix if more datasources hit this.

## Expected-output fixture changes

- None. No golden covered a standalone `requirements.txt` in a directory matching the sibling pattern; the neighbouring unit test used `docs/min_requirements.txt`, which does not match `requirements*.txt`, so only the fallback ever ran for it and the duplication went unseen.
