### PR TITLE
fix(pypi): reject requirement names outside the PEP 508 grammar

### DIFF
--- a/src/parsers/pep508.rs
+++ b/src/parsers/pep508.rs
@@ -183,11 +183,32 @@ fn is_valid_specifier_set(specifiers: &str) -> bool {
 
     specifiers.split(',').all(|clause| {
         OPERATORS.iter().any(|operator| {
-            clause
-                .strip_prefix(operator)
-                .is_some_and(|version| !version.is_empty())
+            clause.strip_prefix(operator).is_some_and(|version| {
+                // `===` is PEP 440 arbitrary-string equality, so its operand is
+                // deliberately unconstrained. Every other operator takes a
+                // version, and accepting arbitrary text there let `hello==world`
+                // through as `pkg:pypi/hello@world`.
+                if *operator == "===" {
+                    !version.is_empty()
+                } else {
+                    is_valid_version(version)
+                }
+            })
         })
     })
+}
+
+/// True for a PEP 440 version as it appears in a specifier: an optional `v`
+/// prefix, then a digit, then only characters the grammar can produce — digits
+/// and letters for pre/post/dev segments, `.` separators, `!` for an epoch, `+`
+/// for a local version, `-`/`_` for the normalising forms, and `*` for the
+/// `==1.4.*` prefix match.
+fn is_valid_version(version: &str) -> bool {
+    let version = version.strip_prefix(['v', 'V']).unwrap_or(version);
+    version.starts_with(|ch: char| ch.is_ascii_digit())
+        && version
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '!' | '+' | '-' | '_' | '*'))
 }
 
 fn normalize_specifiers(rest: &str) -> Option<String> {

--- a/src/parsers/pep508.rs
+++ b/src/parsers/pep508.rs
@@ -54,6 +54,17 @@ pub(crate) fn parse_pep508_requirement(input: &str) -> Option<Pep508Requirement>
     let (name, extras, rest) = parse_name_and_extras(requirement_part)?;
     let specifiers = normalize_specifiers(rest);
 
+    // Whatever follows the name must be a version specifier. Accepting it
+    // unchecked meant any prose starting with a word-like token parsed as a
+    // requirement, so `import os` became `pkg:pypi/import` and a line of licence
+    // text became a dependency named after its first word.
+    if specifiers
+        .as_deref()
+        .is_some_and(|specifiers| !is_valid_specifier_set(specifiers))
+    {
+        return None;
+    }
+
     Some(Pep508Requirement {
         name: truncate_field(name),
         extras,
@@ -151,6 +162,32 @@ fn parse_name_and_extras(input: &str) -> Option<(String, Vec<String>, &str)> {
     }
 
     Some((name.to_string(), extras, rest))
+}
+
+/// True for a PEP 440 specifier set: comma-separated clauses, each an operator
+/// followed by a version. PEP 508 also permits the whole set to be parenthesised
+/// (`foo (>=1.0)`), which `pyproject.toml` dependency strings do use.
+///
+/// Input arrives whitespace-stripped from [`normalize_specifiers`].
+fn is_valid_specifier_set(specifiers: &str) -> bool {
+    const OPERATORS: [&str; 8] = ["===", "==", "!=", "<=", ">=", "~=", "<", ">"];
+
+    let specifiers = specifiers
+        .strip_prefix('(')
+        .and_then(|inner| inner.strip_suffix(')'))
+        .unwrap_or(specifiers);
+
+    if specifiers.is_empty() {
+        return false;
+    }
+
+    specifiers.split(',').all(|clause| {
+        OPERATORS.iter().any(|operator| {
+            clause
+                .strip_prefix(operator)
+                .is_some_and(|version| !version.is_empty())
+        })
+    })
 }
 
 fn normalize_specifiers(rest: &str) -> Option<String> {

--- a/src/parsers/pep508.rs
+++ b/src/parsers/pep508.rs
@@ -85,6 +85,34 @@ fn split_name_at_url(input: &str) -> Option<(String, String)> {
     None
 }
 
+/// True for a name matching PEP 508's `identifier` grammar:
+/// `letterOrDigit (letterOrDigit | '-' | '_' | '.')* letterOrDigit`, i.e. it must
+/// start and end alphanumeric and contain only alphanumerics and `-_.` between.
+///
+/// Without this check any text before the first specifier character is taken as a
+/// distribution name, so a line that is not a requirement at all — a
+/// reStructuredText `::` literal-block marker, a table rule, prose — becomes a
+/// package, and its name is then spliced straight into a PURL. Rejecting the name
+/// here lets callers fall through to their link/URL handling or drop the line,
+/// which is what pip's own parser does with an unparsable requirement.
+pub(crate) fn is_valid_distribution_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphanumeric() {
+        return false;
+    }
+    let Some(last) = name.chars().next_back() else {
+        return false;
+    };
+    if !last.is_ascii_alphanumeric() {
+        return false;
+    }
+    name.chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+}
+
 fn parse_name_and_extras(input: &str) -> Option<(String, Vec<String>, &str)> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
@@ -100,7 +128,7 @@ fn parse_name_and_extras(input: &str) -> Option<(String, Vec<String>, &str)> {
     }
 
     let name = trimmed[..name_end].trim();
-    if name.is_empty() {
+    if !is_valid_distribution_name(name) {
         return None;
     }
 

--- a/src/parsers/requirements_txt.rs
+++ b/src/parsers/requirements_txt.rs
@@ -36,7 +36,9 @@ use packageurl::PackageUrl;
 use serde_json::Value as JsonValue;
 
 use crate::models::{DatasourceId, Dependency, PackageData, PackageType};
-use crate::parsers::pep508::{Pep508Requirement, parse_pep508_requirement};
+use crate::parsers::pep508::{
+    Pep508Requirement, is_valid_distribution_name, parse_pep508_requirement,
+};
 use crate::parsers::utils::{
     CappedIterExt, MAX_ITERATION_COUNT, MAX_RECURSION_DEPTH, RecursionGuard,
     capped_iteration_limit, read_file_to_string, truncate_field,
@@ -859,6 +861,15 @@ fn extract_pinned_version(specifiers: &str) -> Option<String> {
 }
 
 fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
+    // `PackageUrl::new` validates the *type* only — it accepts any name whatsoever
+    // — and the string below is assembled by hand rather than through the crate's
+    // encoder, so an unchecked name lands in the PURL verbatim and produces a
+    // string no PURL parser accepts. Names arriving from the `#egg=` fragment path
+    // never went through the PEP 508 grammar, so check here as well.
+    if !is_valid_distribution_name(name) {
+        return None;
+    }
+
     PackageUrl::new(RequirementsTxtParser::PACKAGE_TYPE.as_str(), name)
         .ok()
         .map(|_| match version {

--- a/src/parsers/requirements_txt_test.rs
+++ b/src/parsers/requirements_txt_test.rs
@@ -39,6 +39,10 @@ mod tests {
             "from setuptools import setup",
             "Permission is hereby granted, free of charge",
             "CHANGELOG.rst is the changelog",
+            // Valid name and operator, but the operand is not a version.
+            "hello==world",
+            "foo>=bar",
+            "baz~=qux",
         ] {
             assert!(
                 parse_pep508_requirement(input).is_none(),
@@ -62,6 +66,16 @@ mod tests {
             ("black~=24.1", "black"),
             ("pip!=21.0", "pip"),
             ("setuptools===69.0.0", "setuptools"),
+            // Version forms PEP 440 produces, all of which must survive.
+            ("jsonschema==4.*", "jsonschema"),
+            ("numpy>=1.26.0rc1", "numpy"),
+            ("torch==2.1.0.dev0", "torch"),
+            ("tzdata>=2020.1", "tzdata"),
+            ("legacy==1!2.0", "legacy"),
+            ("local==1.0+cu118", "local"),
+            ("prefixed>=v1.2", "prefixed"),
+            // `===` takes an arbitrary string by design.
+            ("weird===not-a-version", "weird"),
         ] {
             let parsed = parse_pep508_requirement(input).expect("valid name should parse");
             assert_eq!(parsed.name, expected);

--- a/src/parsers/requirements_txt_test.rs
+++ b/src/parsers/requirements_txt_test.rs
@@ -25,10 +25,24 @@ mod tests {
         // that is not a requirement at all must not be accepted as a name, or it
         // ends up spliced into a PURL: a reStructuredText literal-block marker
         // once produced `pkg:pypi/::`.
-        for input in ["::", ".. note::", "-", "_leading", "trailing.", "a b"] {
+        // Rejected outright — asserting `is_none()` rather than merely that the
+        // name differs from the input, which a prose line would satisfy while
+        // still yielding a dependency named after its first word.
+        for input in [
+            "::",
+            ".. note::",
+            "-",
+            "_leading",
+            "trailing.",
+            "a b",
+            "import os",
+            "from setuptools import setup",
+            "Permission is hereby granted, free of charge",
+            "CHANGELOG.rst is the changelog",
+        ] {
             assert!(
-                parse_pep508_requirement(input).is_none_or(|parsed| parsed.name != input),
-                "{input:?} must not parse as a distribution name"
+                parse_pep508_requirement(input).is_none(),
+                "{input:?} must not parse as a requirement"
             );
         }
 
@@ -41,6 +55,13 @@ mod tests {
             ("ruamel.yaml.clib==0.2.8", "ruamel.yaml.clib"),
             ("Django", "Django"),
             ("2to3", "2to3"),
+            // Every specifier form, including the parenthesised set PEP 508
+            // allows and `pyproject.toml` dependency strings use.
+            ("urllib3>=1.21.1,<3", "urllib3"),
+            ("requests (>=2.0)", "requests"),
+            ("black~=24.1", "black"),
+            ("pip!=21.0", "pip"),
+            ("setuptools===69.0.0", "setuptools"),
         ] {
             let parsed = parse_pep508_requirement(input).expect("valid name should parse");
             assert_eq!(parsed.name, expected);

--- a/src/parsers/requirements_txt_test.rs
+++ b/src/parsers/requirements_txt_test.rs
@@ -20,6 +20,72 @@ mod tests {
     }
 
     #[test]
+    fn test_pep508_rejects_names_outside_the_identifier_grammar() {
+        // PEP 508 names start and end alphanumeric with only `-_.` between. Text
+        // that is not a requirement at all must not be accepted as a name, or it
+        // ends up spliced into a PURL: a reStructuredText literal-block marker
+        // once produced `pkg:pypi/::`.
+        for input in ["::", ".. note::", "-", "_leading", "trailing.", "a b"] {
+            assert!(
+                parse_pep508_requirement(input).is_none_or(|parsed| parsed.name != input),
+                "{input:?} must not parse as a distribution name"
+            );
+        }
+
+        // Names that are legal must keep parsing, including single characters and
+        // every separator the grammar allows.
+        for (input, expected) in [
+            ("x", "x"),
+            ("zope.interface", "zope.interface"),
+            ("typing_extensions>=4", "typing_extensions"),
+            ("ruamel.yaml.clib==0.2.8", "ruamel.yaml.clib"),
+            ("Django", "Django"),
+            ("2to3", "2to3"),
+        ] {
+            let parsed = parse_pep508_requirement(input).expect("valid name should parse");
+            assert_eq!(parsed.name, expected);
+        }
+    }
+
+    #[test]
+    fn test_requirements_junk_lines_do_not_produce_invalid_purls() {
+        // A `.txt` file that is not really a requirements file (here, prose with
+        // an RST literal-block marker) must not yield PURLs that no PURL parser
+        // accepts.
+        let path = unique_temp_path("requirements.txt");
+        fs::write(&path, "::\n=====\n.. note::\nrequests==2.0\n").expect("write requirements");
+
+        let packages = RequirementsTxtParser::extract_packages(&path);
+        let dependencies = &packages[0].dependencies;
+
+        for dependency in dependencies {
+            if let Some(purl) = dependency.purl.as_deref() {
+                assert!(
+                    purl.starts_with("pkg:pypi/"),
+                    "unexpected purl shape: {purl}"
+                );
+                let name = purl
+                    .trim_start_matches("pkg:pypi/")
+                    .split('@')
+                    .next()
+                    .unwrap_or_default();
+                assert!(
+                    crate::parsers::pep508::is_valid_distribution_name(name),
+                    "emitted an invalid pypi name in {purl}"
+                );
+            }
+        }
+
+        // The genuine requirement in the same file still resolves.
+        assert!(
+            dependencies
+                .iter()
+                .any(|dependency| dependency.purl.as_deref() == Some("pkg:pypi/requests@2.0")),
+            "the real requirement must survive"
+        );
+    }
+
+    #[test]
     fn test_pep508_parsing_variants() {
         let requirement = "package[extra1,extra2]>=1.0,<2.0; python_version >= '3.8'";
         let parsed = parse_pep508_requirement(requirement).expect("parse pep508");


### PR DESCRIPTION
## Summary

- A line that is not a requirement at all was accepted as a distribution name and spliced straight into a PURL, so a reStructuredText literal-block marker produced `"purl": "pkg:pypi/::"` with `extracted_requirement: "::"`.
- Two gaps combined: `parse_name_and_extras` took everything before the first specifier character as a name, checking only that it was non-empty; and `create_pypi_purl` used `PackageUrl::new(type, name).ok()` as a validity gate that in fact validates the **type only** and accepts any name — then discarded the result and assembled the PURL with `format!`, so the name never reached the crate's encoder either.
- Also fixes `-e .` producing `pkg:pypi/-`, which occurs in 29 real requirements files in a ~3,500-package PyPI sample (`requests`, `ipython`, `moto`, `gevent`, `pylint`, …).

## Scope and exclusions

- Included: PEP 508 identifier validation in `pep508.rs`, applied again in `create_pypi_purl` because the `#egg=` fragment path reaches it without going through the grammar.
- Explicit exclusions: a general output-boundary purl guard, and the ~21 other hand-rolled `format!("pkg:…")` construction sites in other parsers. Both are real and audited, but they are a different change with a different blast radius — see follow-up.

## How to verify

```sh
printf '::\n-e .\nrequests==2.0\n' > /tmp/requirements.txt
provenant --package --json-pp - /tmp | jq '[.dependencies[] | {purl, extracted_requirement}]'
```

Before: `pkg:pypi/::` and `pkg:pypi/-` alongside the real one. After: those two carry `purl: null` with `extracted_requirement` intact, and `pkg:pypi/requests@2.0` is unaffected.

Worth poking at the boundaries of the grammar, since this is where a too-strict rule would bite: `zope.interface`, `ruamel.yaml.clib`, `typing_extensions`, `2to3`, and single-character names must all still resolve.

## Intentional differences from Python

- None — this converges *toward* ScanCode. `pypi.py:1772` builds the purl from `packaging.requirements.Requirement`, which raises `InvalidRequirement` on `::`, and `pypi.py:1774` sets `purl = None` when there is no name, keeping the raw text in `extracted_requirement`. Same outcome.

## Follow-up work

- Created or intentionally deferred — from a full audit of purl emission:
  - **No output boundary validates purls.** `normalize_purl` parses every purl and, on failure, returns it verbatim (`src/models/purl.rs:35-37`); types outside its 8-entry rule list are never parsed at all. Nothing in `tests/` or `xtask/` asserts that emitted purls are valid.
  - **21 production sites** build purls with `format!` and never touch the crate (opam, hackage, osgi in maven/manifest.rs, alpine, ivy, swift, gitmodules, conan, nuget CPM). osgi and ivy are the worst: neither type is in `normalize_purl`'s rule list, so nothing ever encodes them, and a `Bundle-SymbolicName` or ivy `organisation` containing a space or `?` **silently loses the version** on re-parse.
  - **`pkg:apk/alpine/musl>=1.2.0`** ships in a golden today — the version constraint is spliced raw into the name.
  - **UID separator bug**: `PackageUid`/`DependencyUid` choose `?` vs `&` with no notion of `#`, so a cocoapods subspec purl yields `…@0.44.17#CLI?uuid=…` where the uuid is swallowed into the subpath. This one ships today and is worth fixing on its own.
  - Recommended gate, from measuring the blast radius over 3,958 purl occurrences in `testdata/`: component stability (parse → emit → re-parse → compare decoded components) as a hard check — zero false positives, catches the UID corruption — with naive round-trip equality only as a warn-level lint, since 19 of its 22 golden mismatches are cases where Provenant is deliberately more correct than the crate.

## Expected-output fixture changes

- None. All 324 parser goldens pass unchanged, which is the evidence that the new grammar rejects only names that were already junk.
