### PR TITLE
fix(models): keep the uuid a qualifier in package and dependency UIDs

### DIFF
--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -231,7 +231,7 @@ pub fn assemble(files: &mut [FileInfo]) -> AssemblyResult {
 
     for file in files.iter_mut() {
         file.for_packages
-            .sort_by(|left, right| left.stable_key().cmp(right.stable_key()));
+            .sort_by(|left, right| left.stable_key().cmp(&right.stable_key()));
         file.for_packages.dedup();
     }
 

--- a/src/models/dependency_uid.rs
+++ b/src/models/dependency_uid.rs
@@ -16,11 +16,10 @@ impl DependencyUid {
     /// Creates a new `DependencyUid` by appending a UUID to the given purl.
     pub fn new(purl: &str) -> Self {
         let uuid = Uuid::new_v4();
-        if purl.contains('?') {
-            DependencyUid(format!("{}&uuid={}", purl, uuid))
-        } else {
-            DependencyUid(format!("{}?uuid={}", purl, uuid))
-        }
+        DependencyUid(crate::models::purl::append_uuid_qualifier(
+            purl,
+            &uuid.to_string(),
+        ))
     }
 
     /// Wraps an existing UID string without validation or UUID generation.
@@ -36,16 +35,12 @@ impl DependencyUid {
         DependencyUid(String::new())
     }
 
-    /// Returns a new `DependencyUid` with the purl base replaced, preserving the UUID suffix.
+    /// Returns a new `DependencyUid` with the purl base replaced, preserving the UUID.
     pub fn replace_base(&self, new_purl: &str) -> Self {
-        if let Some((_, suffix)) = self.0.split_once("?uuid=") {
-            return DependencyUid(format!("{}?uuid={}", new_purl, suffix));
-        }
-        if let Some((_, suffix)) = self.0.split_once("&uuid=") {
-            let separator = if new_purl.contains('?') { '&' } else { '?' };
-            return DependencyUid(format!("{}{separator}uuid={suffix}", new_purl));
-        }
-        DependencyUid(self.0.clone())
+        let Some(uuid) = crate::models::purl::uuid_qualifier_value(&self.0) else {
+            return DependencyUid(self.0.clone());
+        };
+        DependencyUid(crate::models::purl::append_uuid_qualifier(new_purl, uuid))
     }
 }
 

--- a/src/models/file_info.rs
+++ b/src/models/file_info.rs
@@ -1558,10 +1558,14 @@ impl TopLevelDependency {
         datasource_id: DatasourceId,
         for_package_uid: Option<PackageUid>,
     ) -> Self {
+        // Derive the UID from the canonical PURL. The `purl` field is normalized
+        // at the output boundary, so building the UID from the raw parser string
+        // let the two disagree within one record — `pkg:pypi/typing-extensions`
+        // beside a `dependency_uid` of `pkg:pypi/typing_extensions?uuid=…`.
         let dependency_uid = dep
             .purl
             .as_ref()
-            .map(|p| DependencyUid::new(p))
+            .map(|purl| DependencyUid::new(&crate::models::normalize_purl(purl)))
             .unwrap_or_else(DependencyUid::empty);
 
         TopLevelDependency {

--- a/src/models/package_uid.rs
+++ b/src/models/package_uid.rs
@@ -26,11 +26,10 @@ impl PackageUid {
     }
 
     fn with_uuid_suffix(base: &str, uuid: Uuid) -> Self {
-        if base.contains('?') {
-            PackageUid(format!("{}&uuid={}", base, uuid))
-        } else {
-            PackageUid(format!("{}?uuid={}", base, uuid))
-        }
+        PackageUid(crate::models::purl::append_uuid_qualifier(
+            base,
+            &uuid.to_string(),
+        ))
     }
 
     /// Wraps an existing UID string without validation or UUID generation.
@@ -46,25 +45,19 @@ impl PackageUid {
         PackageUid(String::new())
     }
 
-    /// Returns the purl portion by stripping the UUID suffix.
-    pub fn stable_key(&self) -> &str {
-        self.0
-            .split_once("?uuid=")
-            .map(|(prefix, _)| prefix)
-            .or_else(|| self.0.split_once("&uuid=").map(|(prefix, _)| prefix))
-            .unwrap_or(&self.0)
+    /// Returns the purl portion by stripping the UUID qualifier. Borrows unless
+    /// the purl carries a subpath, which has to be rejoined to what precedes the
+    /// qualifier.
+    pub fn stable_key(&self) -> std::borrow::Cow<'_, str> {
+        crate::models::purl::strip_uuid_qualifier(&self.0)
     }
 
-    /// Returns a new `PackageUid` with the purl base replaced, preserving the UUID suffix.
+    /// Returns a new `PackageUid` with the purl base replaced, preserving the UUID.
     pub fn replace_base(&self, new_purl: &str) -> Self {
-        if let Some((_, suffix)) = self.0.split_once("?uuid=") {
-            return PackageUid(format!("{}?uuid={}", new_purl, suffix));
-        }
-        if let Some((_, suffix)) = self.0.split_once("&uuid=") {
-            let separator = if new_purl.contains('?') { '&' } else { '?' };
-            return PackageUid(format!("{}{separator}uuid={suffix}", new_purl));
-        }
-        PackageUid(self.0.clone())
+        let Some(uuid) = crate::models::purl::uuid_qualifier_value(&self.0) else {
+            return PackageUid(self.0.clone());
+        };
+        PackageUid(crate::models::purl::append_uuid_qualifier(new_purl, uuid))
     }
 
     /// Returns the inner string slice.

--- a/src/models/purl.rs
+++ b/src/models/purl.rs
@@ -22,6 +22,7 @@
 //! owning parser. Unlisted types are returned unchanged, preserving the
 //! case-sensitive types (npm, maven, cargo, gem, …).
 
+use std::borrow::Cow;
 use std::str::FromStr;
 
 use packageurl::PackageUrl;
@@ -144,9 +145,112 @@ fn lowercase_first_path_segment(purl: &str, prefix: &str) -> String {
     )
 }
 
+/// Add the `uuid` qualifier that turns a PURL into a UID, keeping it a
+/// qualifier.
+///
+/// A PURL orders its parts `…?qualifiers#subpath`, so appending to the end of the
+/// string lands the uuid *inside the subpath* whenever one is present: a
+/// cocoapods subspec UID came out as `pkg:cocoapods/SwiftFormat@0.44.17#CLI?uuid=…`,
+/// where `?uuid=…` is no longer a qualifier and re-parsing yields the subpath
+/// `CLI?uuid=…`. Insert ahead of the subpath instead, and use `&` only when the
+/// PURL already carries a qualifier.
+///
+/// Non-PURL bases (the `generated-package:` fallback identity) carry neither
+/// qualifiers nor a subpath, so they simply take the `?uuid=` form.
+pub(crate) fn append_uuid_qualifier(base: &str, uuid: &str) -> String {
+    let (head, subpath) = split_subpath(base);
+    let separator = if head.contains('?') { '&' } else { '?' };
+    match subpath {
+        Some(subpath) => format!("{head}{separator}uuid={uuid}#{subpath}"),
+        None => format!("{head}{separator}uuid={uuid}"),
+    }
+}
+
+/// The UID with its `uuid` qualifier removed, restoring the underlying PURL.
+///
+/// Borrows whenever the UID has no subpath, which is the common case; only a
+/// subpath-carrying UID needs the two remaining parts rejoined.
+pub(crate) fn strip_uuid_qualifier(uid: &str) -> Cow<'_, str> {
+    let (head, subpath) = split_subpath(uid);
+    let Some((prefix, _)) = head
+        .split_once("?uuid=")
+        .or_else(|| head.split_once("&uuid="))
+    else {
+        return Cow::Borrowed(uid);
+    };
+
+    match subpath {
+        Some(subpath) => Cow::Owned(format!("{prefix}#{subpath}")),
+        None => Cow::Borrowed(prefix),
+    }
+}
+
+/// The value of a UID's `uuid` qualifier, or `None` when it carries none.
+pub(crate) fn uuid_qualifier_value(uid: &str) -> Option<&str> {
+    let (head, _) = split_subpath(uid);
+    head.split_once("?uuid=")
+        .or_else(|| head.split_once("&uuid="))
+        .map(|(_, uuid)| uuid)
+}
+
+fn split_subpath(purl: &str) -> (&str, Option<&str>) {
+    match purl.split_once('#') {
+        Some((head, subpath)) => (head, Some(subpath)),
+        None => (purl, None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn uuid_qualifier_stays_a_qualifier_when_the_purl_has_a_subpath() {
+        let uid = append_uuid_qualifier("pkg:cocoapods/SwiftFormat@0.44.17#CLI", "abc");
+        assert_eq!(uid, "pkg:cocoapods/SwiftFormat@0.44.17?uuid=abc#CLI");
+        assert_eq!(
+            strip_uuid_qualifier(&uid),
+            "pkg:cocoapods/SwiftFormat@0.44.17#CLI"
+        );
+
+        // The parsed UID must still expose the original subpath rather than one
+        // with the uuid swallowed into it.
+        let parsed = PackageUrl::from_str(&uid).expect("uid should parse as a purl");
+        assert_eq!(parsed.subpath(), Some("CLI"));
+        assert_eq!(
+            parsed.qualifiers().get("uuid").map(Cow::as_ref),
+            Some("abc")
+        );
+    }
+
+    #[test]
+    fn uuid_qualifier_joins_existing_qualifiers_with_an_ampersand() {
+        let uid = append_uuid_qualifier("pkg:generic/x?arch=amd64", "abc");
+        assert_eq!(uid, "pkg:generic/x?arch=amd64&uuid=abc");
+        assert_eq!(strip_uuid_qualifier(&uid), "pkg:generic/x?arch=amd64");
+    }
+
+    #[test]
+    fn uuid_qualifier_round_trips_plain_purls_and_opaque_bases() {
+        for base in [
+            "pkg:pypi/requests@2.0",
+            "pkg:npm/%40scope/name@1.0.0",
+            "generated-package:cargo/unknown@unknown",
+        ] {
+            let uid = append_uuid_qualifier(base, "abc");
+            assert_eq!(uid, format!("{base}?uuid=abc"));
+            assert_eq!(strip_uuid_qualifier(&uid), base);
+        }
+    }
+
+    #[test]
+    fn strip_uuid_qualifier_leaves_a_uid_without_one_untouched() {
+        assert_eq!(
+            strip_uuid_qualifier("pkg:pypi/requests@2.0"),
+            "pkg:pypi/requests@2.0"
+        );
+        assert_eq!(strip_uuid_qualifier(""), "");
+    }
 
     /// Spec-rule matrix: representative PURL per type asserted against the
     /// canonical form. Guards every parser against drift.


### PR DESCRIPTION
## Summary

- `PackageUid` and `DependencyUid` were built by appending `?uuid=` / `&uuid=` to the end of the PURL string. A PURL orders its parts `…?qualifiers#subpath`, so whenever a subpath was present the uuid landed *inside it*.
- A cocoapods subspec shipped as `pkg:cocoapods/SwiftFormat@0.44.17#CLI?uuid=…`, which re-parses with subpath `CLI?uuid=…` and **no uuid qualifier at all** — the marker that makes the UID unique is destroyed, and two UIDs for the same subspec are indistinguishable to any consumer that parses them.
- Separately, `dependency_uid` was derived from the raw parser PURL while the neighbouring `purl` field is normalized at the output boundary, so one record could carry `pkg:pypi/typing-extensions` beside a `dependency_uid` of `pkg:pypi/typing_extensions?uuid=…`.

## Scope and exclusions

- Included: one pair of helpers in the central PURL module for adding and reading back the qualifier, used by both UID types, plus deriving `dependency_uid` from the normalized PURL.
- Explicit exclusions: the broader purl-emission work — converting parsers that build PURLs with `format!`, and any output-boundary validation gate. This change is a prerequisite for the latter, since a gate would otherwise fail on the UIDs themselves.

## How to verify

```sh
provenant --package --json-pp - testdata/cocoapods-golden/assemble/many-podspecs \
  | jq -r '.dependencies[].dependency_uid | select(contains("#"))'
```

Before: `pkg:cocoapods/SwiftFormat@0.44.17#CLI?uuid=…`. After: `pkg:cocoapods/SwiftFormat@0.44.17?uuid=…#CLI`, which parses with subpath `CLI` and a `uuid` qualifier.

Worth poking at `stable_key`, which changed return type: it is used only for sorting `for_packages`, and now borrows unless the PURL carries a subpath.

## Intentional differences from Python

- None.

## Follow-up work

- Created or intentionally deferred: `fallback_package_uid` emits `generated-package:{datasource}/{name}@{version}?uuid=…`, which is deliberately not a PURL and propagates into `package_uid`, `for_package_uid` and `files[].for_packages` (3 swift goldens carry it today). Left as-is here — it is unambiguously not a PURL, so a consumer fails loudly rather than mis-parsing — but it deserves an explicit decision rather than drift.

## Expected-output fixture changes

- None. UIDs are uuid-normalized in golden fixtures, so no expected file moves; the behaviour change is verified against a live scan of `testdata/cocoapods-golden/assemble` and by unit tests that parse the emitted UID with the `packageurl` crate and assert the subpath and qualifier separately.
