### PR TITLE
fix(swift): drop URL userinfo when deriving package identity

### DIFF
--- a/src/parsers/swift_manifest_json.rs
+++ b/src/parsers/swift_manifest_json.rs
@@ -308,7 +308,7 @@ pub fn get_namespace_and_name(url: &str) -> (Option<String>, String) {
         .unwrap_or(path)
         .trim_end_matches('/');
 
-    if let Some(host) = hostname {
+    if let Some(host) = hostname.map(crate::parsers::utils::url_authority_host) {
         let canonical = format!("{}/{}", host, clean_path);
         match canonical.rsplit_once('/') {
             Some((ns, name)) => (Some(ns.to_string()), name.to_string()),

--- a/src/parsers/swift_manifest_json_test.rs
+++ b/src/parsers/swift_manifest_json_test.rs
@@ -187,6 +187,17 @@ mod tests {
     }
 
     #[test]
+    fn test_get_namespace_and_name_drops_clone_url_credentials() {
+        // The URL authority becomes the namespace, so userinfo from a CI clone
+        // URL would otherwise be carried into every emitted PURL.
+        let (ns, name) = get_namespace_and_name(
+            "https://x-access-token:ghp_examplevalue@github.com/apple/swift-argument-parser.git",
+        );
+        assert_eq!(ns, Some("github.com/apple".to_string()));
+        assert_eq!(name, "swift-argument-parser");
+    }
+
+    #[test]
     fn test_get_namespace_and_name_no_git_suffix() {
         let (ns, name) = get_namespace_and_name("https://github.com/vapor/vapor");
         assert_eq!(ns, Some("github.com/vapor".to_string()));

--- a/src/parsers/swift_show_dependencies.rs
+++ b/src/parsers/swift_show_dependencies.rs
@@ -309,7 +309,7 @@ fn parse_url_namespace_and_name(url: &str) -> Option<(String, String)> {
         .strip_prefix("https://")
         .or_else(|| trimmed.strip_prefix("http://"))?;
     let mut parts = without_scheme.split('/');
-    let host = parts.next()?;
+    let host = crate::parsers::utils::url_authority_host(parts.next()?);
     let owner = parts.next()?;
     let repo = parts.next()?;
 

--- a/src/parsers/swift_show_dependencies_test.rs
+++ b/src/parsers/swift_show_dependencies_test.rs
@@ -29,6 +29,50 @@ mod tests {
     }
 
     #[test]
+    fn test_clone_url_credentials_are_not_part_of_package_identity() {
+        // A CI checkout clones over `https://<user>:<token>@host/owner/repo.git`,
+        // and the URL authority is what becomes the package namespace. The
+        // credential is not identity and must not reach any emitted PURL.
+        let content = r#"{
+            "identity": "myroot",
+            "name": "MyRoot",
+            "url": "https://github.com/acme/myroot.git",
+            "version": "1.0.0",
+            "dependencies": [
+                {
+                    "identity": "alamofire",
+                    "name": "Alamofire",
+                    "url": "https://x-access-token:ghp_examplevalue@github.com/Alamofire/Alamofire.git",
+                    "version": "5.6.4",
+                    "dependencies": []
+                }
+            ]
+        }"#;
+        let pkg = parse_swift_show_dependencies(content);
+
+        let purls: Vec<String> = pkg
+            .dependencies
+            .iter()
+            .filter_map(|dependency| dependency.purl.clone())
+            .chain(pkg.purl.clone())
+            .collect();
+
+        assert!(!purls.is_empty(), "expected at least one emitted purl");
+        for purl in &purls {
+            assert!(
+                !purl.contains("ghp_examplevalue") && !purl.contains("x-access-token"),
+                "credential leaked into purl: {purl}"
+            );
+        }
+        assert!(
+            purls
+                .iter()
+                .any(|purl| purl == "pkg:swift/github.com/Alamofire/Alamofire@5.6.4"),
+            "expected the credential-free identity, got {purls:?}"
+        );
+    }
+
+    #[test]
     fn test_parse_basic() {
         let content = r#"{"name": "MyPackage"}"#;
         let pkg = parse_swift_show_dependencies(content);

--- a/src/parsers/utils.rs
+++ b/src/parsers/utils.rs
@@ -279,6 +279,24 @@ pub fn read_file_to_string(path: &Path, max_size: Option<u64>) -> Result<String>
     }
 }
 
+/// The host portion of a URL authority, dropping any `user:password@` userinfo.
+///
+/// Clone URLs carry credentials in that position — CI checkouts use
+/// `https://x-access-token:<token>@github.com/owner/repo.git` — and the authority
+/// is what parsers turn into a package namespace. Keeping the userinfo copies the
+/// credential into `purl`, `dependency_uid` and `package_uid`: identity a package
+/// does not have, propagated into an SBOM that is usually published. Split from
+/// the right so a password containing `@` still leaves the real host.
+///
+/// Parsers that resolve URLs through the `url` crate get this for free from
+/// `host_str`; this is for the ones that split the string themselves.
+pub fn url_authority_host(authority: &str) -> &str {
+    authority
+        .rsplit_once('@')
+        .map(|(_, host)| host)
+        .unwrap_or(authority)
+}
+
 /// Creates a correctly-formatted npm Package URL for scoped or regular packages.
 ///
 /// Handles namespace encoding for scoped packages (e.g., `@babel/core`) and ensures


### PR DESCRIPTION
## Summary

- Both Swift parsers that split a clone URL by hand (`swift_show_dependencies`, `swift_manifest_json`) took everything between the scheme and the first `/` as the host, so URL userinfo became part of the package namespace.
- A URL of the form `https://<user>:<token>@host/owner/repo.git` therefore put the userinfo into `purl`, `dependency_uid`, `package_uid` and the `package_data` dependency purls. That is the URL shape a CI checkout configures, so a value that only ever existed on the build host was copied into a scan result that is normally committed, uploaded, or attached to a release.
- Userinfo is not package identity regardless: two clones of the same repository with different tokens produced two different package identities.

## Scope and exclusions

- Included: one shared `url_authority_host` helper, used by both hand-rolled parsers.
- Explicit exclusions: `swift_resolved` already resolves URLs through the `url` crate and takes the host from `host_str`, so it was never affected and is unchanged. `.gitmodules` takes URLs the same way but emits no purl from them — verified, no change needed.

## How to verify

```sh
cat > /tmp/sw/swift-show-dependencies.deplock <<'JSON'
{"name":"Root","url":"https://github.com/acme/root.git","version":"1.0.0","dependencies":[
 {"identity":"alamofire","name":"Alamofire","version":"5.6.4",
  "url":"https://x-access-token:ghp_example@github.com/Alamofire/Alamofire.git","dependencies":[]}]}
JSON
provenant --package --json-pp - /tmp/sw | grep -c 'x-access-token'
```

Before: the userinfo appears in the dependency purl, its uid, and the package-data purl. After: zero occurrences anywhere in the output, and the identity resolves to `pkg:swift/github.com/Alamofire/Alamofire@5.6.4`.

Worth poking at a password containing `@` — the helper splits the authority from the right, so the real host still wins.

## Intentional differences from Python

- None.

## Expected-output fixture changes

- None; no fixture used a URL with userinfo. Covered by unit tests in both parsers, one asserting the resolved namespace directly and one asserting that no emitted purl contains the userinfo.
