### PR TITLE
chore: ignore lockfiles from non-npm package managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,14 @@ dist/
 !.env.example
 node_modules/
 
+# This project's Node tooling is npm-managed and pinned by package-lock.json.
+# Running another package manager here leaves a competing lockfile behind, which
+# is both committable by accident and picked up as a real package by Provenant's
+# own parsers when it scans this repository.
+pnpm-lock.yaml
+yarn.lock
+bun.lockb
+
 # Test fixtures should always be reviewable and trackable, even when they use
 # names like dist/, node_modules/, *.log, or *.exe.
 !testdata/

--- a/.gitignore
+++ b/.gitignore
@@ -50,10 +50,11 @@ node_modules/
 # This project's Node tooling is npm-managed and pinned by package-lock.json.
 # Running another package manager here leaves a competing lockfile behind, which
 # is both committable by accident and picked up as a real package by Provenant's
-# own parsers when it scans this repository.
-pnpm-lock.yaml
-yarn.lock
-bun.lockb
+# own parsers when it scans this repository. Anchored to the root so a nested
+# project's own lockfile stays visible.
+/pnpm-lock.yaml
+/yarn.lock
+/bun.lockb
 
 # Test fixtures should always be reviewable and trackable, even when they use
 # names like dist/, node_modules/, *.log, or *.exe.


### PR DESCRIPTION
## Summary

- Node tooling here is npm-managed and pinned by `package-lock.json`, but running any other package manager in the tree leaves its own lockfile at the repo root. One turned up during a hook run, listing the same three devDependencies `package-lock.json` already pins.

## Scope and exclusions

- Included: `pnpm-lock.yaml`, `yarn.lock`, `bun.lockb`.
- Explicit exclusions: nothing changes about which package manager the project uses, and `testdata/` is unaffected — the existing `!testdata/**` re-inclusion keeps lockfile fixtures tracked, which matters because several parsers are tested against exactly these filenames.

## How to verify

```sh
touch pnpm-lock.yaml && git status --short   # no longer listed
git check-ignore -v pnpm-lock.yaml
git status --short testdata/                 # fixtures still tracked
```

## Follow-up work

- Created or intentionally deferred: not investigated *why* a hook run reached for another package manager — the ignore is worthwhile regardless, since a stray lockfile is one `git add -A` from being committed, and Provenant's own parsers read it as a real pnpm package whenever the project scans itself.