### PR TITLE
feat(pypi): read egg-info requires.txt extra and marker sections

### DIFF
--- a/src/parsers/requirements_txt.rs
+++ b/src/parsers/requirements_txt.rs
@@ -346,6 +346,10 @@ fn parse_requirements_with_includes(
         }
     };
 
+    // Sections are file-scoped: an included file starts outside any section and
+    // does not carry one back to its includer.
+    let mut section = RequirementSection::default();
+
     let logical_lines = collect_logical_lines(&content);
     let limit = capped_iteration_limit(logical_lines.len(), "requirements.txt logical lines");
     for line in logical_lines.into_iter().take(limit) {
@@ -406,7 +410,12 @@ fn parse_requirements_with_includes(
             continue;
         }
 
-        if let Some(dependency) = build_dependency(trimmed, scope, is_runtime) {
+        if let Some(parsed_section) = RequirementSection::parse(trimmed) {
+            section = parsed_section;
+            continue;
+        }
+
+        if let Some(dependency) = build_dependency(trimmed, scope, is_runtime, &section) {
             if state.dependencies.len() >= MAX_ITERATION_COUNT {
                 warn!(
                     "Reached maximum dependency count ({}) in {:?}",
@@ -521,7 +530,58 @@ fn scope_from_filename(path: &Path) -> (String, bool) {
     ("install".to_string(), true)
 }
 
-fn build_dependency(line: &str, scope: &str, is_runtime: bool) -> Option<Dependency> {
+/// The `[extra]` / `[:marker]` / `[extra:marker]` grouping that setuptools writes
+/// into an egg-info `requires.txt`, and that everything after it belongs to.
+///
+/// pip's own requirements format has no sections, so a header line is not a
+/// requirement in any file it appears in; treating it as one produced a
+/// dependency whose `extracted_requirement` was literally `[dev]` or
+/// `[:python_version < "3.12"]`. Reading it instead recovers what the group
+/// actually means: an extra is an optional dependency group, and a section
+/// marker applies to every requirement under it.
+#[derive(Default)]
+struct RequirementSection {
+    extra: Option<String>,
+    marker: Option<String>,
+}
+
+impl RequirementSection {
+    /// Parses a `[...]` header, or returns `None` for any other line.
+    fn parse(line: &str) -> Option<Self> {
+        let inner = line.strip_prefix('[')?.strip_suffix(']')?;
+
+        let (extra, marker) = match inner.split_once(':') {
+            Some((extra, marker)) => (extra.trim(), Some(marker.trim())),
+            None => (inner.trim(), None),
+        };
+
+        Some(Self {
+            extra: (!extra.is_empty()).then(|| truncate_field(extra.to_string())),
+            marker: marker
+                .filter(|marker| !marker.is_empty())
+                .map(|marker| truncate_field(marker.to_string())),
+        })
+    }
+
+    /// The scope a requirement in this section belongs to: the extra's own name,
+    /// falling back to the scope derived from the filename outside any extra.
+    fn scope<'a>(&'a self, default_scope: &'a str) -> &'a str {
+        self.extra.as_deref().unwrap_or(default_scope)
+    }
+
+    /// Requirements under an extra are installed only when that extra is
+    /// requested, which is exactly what `is_optional` records.
+    fn is_optional(&self) -> bool {
+        self.extra.is_some()
+    }
+}
+
+fn build_dependency(
+    line: &str,
+    scope: &str,
+    is_runtime: bool,
+    section: &RequirementSection,
+) -> Option<Dependency> {
     let trimmed = line.trim();
     if trimmed.is_empty() {
         return None;
@@ -619,7 +679,15 @@ fn build_dependency(line: &str, scope: &str, is_runtime: bool) -> Option<Depende
             .unwrap_or(JsonValue::Null),
     );
 
-    if let Some(marker) = parsed.marker {
+    // A section marker applies to every requirement under it, so it combines with
+    // an inline one rather than replacing it.
+    let marker = match (parsed.marker, section.marker.as_deref()) {
+        (Some(inline), Some(section_marker)) => Some(format!("({inline}) and ({section_marker})")),
+        (Some(inline), None) => Some(inline),
+        (None, Some(section_marker)) => Some(section_marker.to_string()),
+        (None, None) => None,
+    };
+    if let Some(marker) = marker {
         extra_data.insert(
             "markers".to_string(),
             JsonValue::String(truncate_field(marker)),
@@ -629,9 +697,9 @@ fn build_dependency(line: &str, scope: &str, is_runtime: bool) -> Option<Depende
     Some(Dependency {
         purl,
         extracted_requirement: Some(truncate_field(extracted_requirement)),
-        scope: Some(scope.to_string()),
+        scope: Some(section.scope(scope).to_string()),
         is_runtime: Some(is_runtime),
-        is_optional: Some(false),
+        is_optional: Some(section.is_optional()),
         is_pinned: Some(is_pinned),
         is_direct: Some(true),
         resolved_package: None,

--- a/src/parsers/requirements_txt_test.rs
+++ b/src/parsers/requirements_txt_test.rs
@@ -121,6 +121,112 @@ mod tests {
     }
 
     #[test]
+    fn test_egg_info_requires_sections_group_dependencies_instead_of_becoming_them() {
+        // The shape setuptools writes into an egg-info `requires.txt`: bare
+        // requirements first, then `[extra]`, `[:marker]` and `[extra:marker]`
+        // groups. Header lines are not requirements — they used to be emitted as
+        // dependencies with `extracted_requirement: "[dev]"` and a null purl.
+        let path = unique_temp_path("requires.txt");
+        fs::write(
+            &path,
+            "requests>=2.0\n\
+             [dev]\n\
+             pytest>=7.0\n\
+             [:python_version < \"3.12\"]\n\
+             importlib-metadata\n\
+             [docs:python_version >= \"3.9\"]\n\
+             sphinx\n",
+        )
+        .expect("write requires.txt");
+
+        let package_data = RequirementsTxtParser::extract_first_package(&path);
+        let dependencies = &package_data.dependencies;
+
+        assert!(
+            dependencies.iter().all(|dependency| {
+                dependency
+                    .extracted_requirement
+                    .as_deref()
+                    .is_none_or(|requirement| !requirement.starts_with('['))
+            }),
+            "a section header must not become a dependency: {:?}",
+            dependencies
+                .iter()
+                .map(|dependency| dependency.extracted_requirement.clone())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(dependencies.len(), 4);
+
+        let find = |purl: &str| {
+            dependencies
+                .iter()
+                .find(|dependency| dependency.purl.as_deref() == Some(purl))
+                .unwrap_or_else(|| panic!("expected {purl}"))
+        };
+        let marker = |dependency: &crate::models::Dependency| {
+            dependency
+                .extra_data
+                .as_ref()
+                .and_then(|extra| extra.get("markers"))
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        };
+
+        // Outside any section: the file's own scope, not optional, no marker.
+        let requests = find("pkg:pypi/requests");
+        assert_eq!(requests.scope.as_deref(), Some("install"));
+        assert_eq!(requests.is_optional, Some(false));
+        assert_eq!(marker(requests), None);
+
+        // An extra names the scope and makes its members optional.
+        let pytest = find("pkg:pypi/pytest");
+        assert_eq!(pytest.scope.as_deref(), Some("dev"));
+        assert_eq!(pytest.is_optional, Some(true));
+        assert_eq!(marker(pytest), None);
+
+        // A bare `[:marker]` section carries a condition but no extra.
+        let importlib = find("pkg:pypi/importlib-metadata");
+        assert_eq!(importlib.scope.as_deref(), Some("install"));
+        assert_eq!(importlib.is_optional, Some(false));
+        assert_eq!(
+            marker(importlib).as_deref(),
+            Some("python_version < \"3.12\"")
+        );
+
+        // `[extra:marker]` carries both.
+        let sphinx = find("pkg:pypi/sphinx");
+        assert_eq!(sphinx.scope.as_deref(), Some("docs"));
+        assert_eq!(sphinx.is_optional, Some(true));
+        assert_eq!(marker(sphinx).as_deref(), Some("python_version >= \"3.9\""));
+    }
+
+    #[test]
+    fn test_section_marker_combines_with_an_inline_marker() {
+        let path = unique_temp_path("requires.txt");
+        fs::write(
+            &path,
+            "[docs:python_version >= \"3.9\"]\nsphinx; os_name == \"posix\"\n",
+        )
+        .expect("write requires.txt");
+
+        let package_data = RequirementsTxtParser::extract_first_package(&path);
+        let sphinx = package_data
+            .dependencies
+            .iter()
+            .find(|dependency| dependency.purl.as_deref() == Some("pkg:pypi/sphinx"))
+            .expect("expected sphinx");
+
+        assert_eq!(
+            sphinx
+                .extra_data
+                .as_ref()
+                .and_then(|extra| extra.get("markers"))
+                .and_then(|value| value.as_str()),
+            Some("(os_name == \"posix\") and (python_version >= \"3.9\")")
+        );
+    }
+
+    #[test]
     fn test_pep508_parsing_variants() {
         let requirement = "package[extra1,extra2]>=1.0,<2.0; python_version >= '3.8'";
         let parsed = parse_pep508_requirement(requirement).expect("parse pep508");


### PR DESCRIPTION
## Summary

- setuptools groups an egg-info `requires.txt` into `[extra]`, `[:marker]` and `[extra:marker]` sections. Every header line was parsed as if it were a requirement, producing a dependency with a null purl whose `extracted_requirement` was literally `[dev]` or `[:python_version < "3.12"]`.
- **1,678 such entries across 232 files** in a ~3,500-package PyPI sample — the largest single source of junk dependencies found while investigating the reported `pkg:pypi/::`.
- pip's requirements format has no sections, so a header is never a requirement in any file it appears in. Reading it rather than dropping it recovers what the group actually encodes.

## Scope and exclusions

- Included: an extra names the scope its members belong to and marks them optional; a section marker applies to every requirement under it and combines with an inline marker rather than replacing it; sections are file-scoped, so an included file starts outside any section.
- Explicit exclusions: no change to how `requirements.txt` proper is parsed beyond no longer emitting bracket lines as dependencies — they are not valid pip syntax there either.

## How to verify

Any installed distribution's egg-info works; IPython is a good one because it uses every section form:

```sh
provenant --package --json-pp - /path/to/ipython.egg-info \
  | jq '[.files[].package_data[].dependencies[] | select(.extra_data.markers != null or .is_optional)]'
```

Before: 10 dependencies with a null purl and `extracted_requirement` of `[:sys_platform == "win32"]` and friends. After: those become the conditions they encode — `psutil` under `sys_platform != "emscripten" and sys_platform != "cygwin"`, `colorama` under `sys_platform == "win32"` — and the `doc`, `test` and `black` extras are marked optional under their own scopes.

Worth poking at the combining rule: a requirement with its own `;` marker inside an `[extra:marker]` section should end up with both, `and`-joined.

## Intentional differences from Python

- **Provenant recovers more than ScanCode here.** `pip_requirements_parser` has no notion of these sections and reports the lines as unparsable, so ScanCode surfaces neither the extras nor the markers. The extra/optional/marker attribution is a Provenant-only improvement, and it is derived from the file rather than guessed — `is_optional` is set only where an extra genuinely gates the requirement.

## Expected-output fixture changes

- None. No golden covered a sectioned `requires.txt`; the behaviour is covered by two unit tests, one per section form and one for marker combination, plus a check against a real distribution's egg-info.