### PR TITLE
fix(assembly): report dependencies that resolve to no PURL

### DIFF
--- a/src/assembly/cargo_workspace_merge.rs
+++ b/src/assembly/cargo_workspace_merge.rs
@@ -483,7 +483,7 @@ fn create_member_packages(
         let mut deps: Vec<TopLevelDependency> = resolved_pkg_data
             .dependencies
             .iter()
-            .filter(|dep| dep.purl.is_some())
+            .filter(|dep| super::is_reportable_dependency(dep))
             .map(|dep| {
                 TopLevelDependency::from_dependency(
                     dep,
@@ -501,7 +501,7 @@ fn create_member_packages(
                 lock_pkg_data
                     .dependencies
                     .iter()
-                    .filter(|dep| dep.purl.is_some())
+                    .filter(|dep| super::is_reportable_dependency(dep))
                     .map(|dep| {
                         TopLevelDependency::from_dependency(
                             dep,
@@ -562,7 +562,7 @@ fn create_root_package(
     let mut deps: Vec<TopLevelDependency> = resolved_pkg_data
         .dependencies
         .iter()
-        .filter(|dep| dep.purl.is_some())
+        .filter(|dep| super::is_reportable_dependency(dep))
         .map(|dep| {
             TopLevelDependency::from_dependency(
                 dep,
@@ -580,7 +580,7 @@ fn create_root_package(
             lock_pkg_data
                 .dependencies
                 .iter()
-                .filter(|dep| dep.purl.is_some())
+                .filter(|dep| super::is_reportable_dependency(dep))
                 .map(|dep| {
                     TopLevelDependency::from_dependency(
                         dep,
@@ -633,7 +633,7 @@ fn hoist_root_lock_dependencies(
             pkg_data
                 .dependencies
                 .iter()
-                .filter(|dep| dep.purl.is_some())
+                .filter(|dep| super::is_reportable_dependency(dep))
                 .map(|dep| {
                     TopLevelDependency::from_dependency(
                         dep,

--- a/src/assembly/dart_workspace_merge.rs
+++ b/src/assembly/dart_workspace_merge.rs
@@ -145,7 +145,7 @@ pub(super) fn apply_dart_workspace_domain(
             root_data
                 .dependencies
                 .iter()
-                .filter(|dep| dep.purl.is_some())
+                .filter(|dep| super::is_reportable_dependency(dep))
                 .map(|dependency| {
                     TopLevelDependency::from_dependency(
                         dependency,
@@ -256,7 +256,7 @@ fn attribute_shared_lock(
         for dependency in lock_data
             .dependencies
             .iter()
-            .filter(|dep| dep.purl.is_some())
+            .filter(|dep| super::is_reportable_dependency(dep))
         {
             let name = dependency.purl.as_deref().and_then(purl_name);
             let owners = candidates.iter().filter(|candidate| {

--- a/src/assembly/debian_source_merge.rs
+++ b/src/assembly/debian_source_merge.rs
@@ -66,7 +66,7 @@ pub(super) fn assemble_debian_source_packages(
             let dependencies = pkg_data
                 .dependencies
                 .iter()
-                .filter(|dependency| dependency.purl.is_some())
+                .filter(|dependency| super::is_reportable_dependency(dependency))
                 .map(|dependency| {
                     TopLevelDependency::from_dependency(
                         dependency,

--- a/src/assembly/gradle_multiproject.rs
+++ b/src/assembly/gradle_multiproject.rs
@@ -309,7 +309,7 @@ fn ensure_gradle_package(
             dependencies.extend(
                 data.dependencies
                     .iter()
-                    .filter(|dep| dep.purl.is_some())
+                    .filter(|dep| super::is_reportable_dependency(dep))
                     .map(|dependency| {
                         TopLevelDependency::from_dependency(
                             dependency,

--- a/src/assembly/mix_umbrella_merge.rs
+++ b/src/assembly/mix_umbrella_merge.rs
@@ -490,7 +490,7 @@ fn emit_direct_dependencies(
             continue;
         }
 
-        if dep.purl.is_some() {
+        if super::is_reportable_dependency(dep) {
             dependencies.push(TopLevelDependency::from_dependency(
                 dep,
                 manifest_path.to_string(),

--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -45,7 +45,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-use crate::models::{DatasourceId, FileInfo, Package, PackageUid, TopLevelDependency};
+use crate::models::{DatasourceId, Dependency, FileInfo, Package, PackageUid, TopLevelDependency};
 
 pub use assemblers::ASSEMBLERS;
 
@@ -335,6 +335,21 @@ fn hoist_unassembled_file_dependencies(
     dependencies.extend(hoisted);
 }
 
+/// Whether a parsed dependency is worth reporting at the top level.
+///
+/// A dependency the parser could not resolve to a PURL is still a declared
+/// dependency as long as it carries the text it was declared with, and
+/// `extracted_requirement` is exactly that text. Dropping it discards the only
+/// record that the manifest asked for it.
+///
+/// Every assembler shares this rule. Testing the PURL alone — as most of them
+/// used to — made a purl-less dependency's visibility depend on which assembler
+/// happened to claim the datafile, so the same manifest reported it or not
+/// according to what sat next to it on disk.
+pub(super) fn is_reportable_dependency(dependency: &Dependency) -> bool {
+    dependency.purl.is_some() || dependency.extracted_requirement.is_some()
+}
+
 const HOIST_IF_UNOWNED_DATASOURCE_IDS: &[DatasourceId] = &[DatasourceId::PipRequirements];
 
 fn should_hoist_unassembled_dependencies(datasource_id: DatasourceId) -> bool {
@@ -405,7 +420,7 @@ fn assemble_one_per_package_data(
             let deps: Vec<TopLevelDependency> = pkg_data
                 .dependencies
                 .iter()
-                .filter(|dep| dep.purl.is_some() || dep.extracted_requirement.is_some())
+                .filter(|dep| is_reportable_dependency(dep))
                 .map(|dep| {
                     TopLevelDependency::from_dependency(
                         dep,

--- a/src/assembly/nested_merge.rs
+++ b/src/assembly/nested_merge.rs
@@ -247,7 +247,7 @@ fn assemble_from_indices(
                 }
 
                 for dep in &pkg_data.dependencies {
-                    if dep.purl.is_some() {
+                    if super::is_reportable_dependency(dep) {
                         pending_dependencies.push(PendingDependency {
                             dependency: dep.clone(),
                             datafile_path: datafile_path.clone(),

--- a/src/assembly/npm_workspace_merge.rs
+++ b/src/assembly/npm_workspace_merge.rs
@@ -583,7 +583,7 @@ fn create_member_packages(
         let deps: Vec<TopLevelDependency> = pkg_data
             .dependencies
             .iter()
-            .filter(|dep| dep.purl.is_some())
+            .filter(|dep| super::is_reportable_dependency(dep))
             .map(|dep| {
                 TopLevelDependency::from_dependency(
                     dep,
@@ -621,7 +621,7 @@ fn hoist_root_dependencies(
             .find(|pkg| pkg.datasource_id == Some(DatasourceId::NpmPackageJson))
         {
             for dep in &root_pkg_data.dependencies {
-                if dep.purl.is_some() {
+                if super::is_reportable_dependency(dep) {
                     let mut top_dep = TopLevelDependency::from_dependency(
                         dep,
                         root_file.path.clone(),
@@ -683,7 +683,7 @@ fn hoist_root_dependencies(
             }
 
             for dep in &pkg_data.dependencies {
-                if dep.purl.is_some() {
+                if super::is_reportable_dependency(dep) {
                     let mut top_dep = TopLevelDependency::from_dependency(
                         dep,
                         file.path.clone(),

--- a/src/assembly/python_requirements_assign.rs
+++ b/src/assembly/python_requirements_assign.rs
@@ -36,7 +36,7 @@ pub fn assign_python_requirements_to_projects(
             project_roots: &project_roots,
             is_relevant_file: is_requirements_subdir_file,
             find_root: find_nearest_project_root,
-            include_dependency: |dep: &Dependency| dep.purl.is_some(),
+            include_dependency: |dep: &Dependency| super::is_reportable_dependency(dep),
         },
     );
 }

--- a/src/assembly/sibling_merge.rs
+++ b/src/assembly/sibling_merge.rs
@@ -113,7 +113,7 @@ pub(super) fn assemble_single_sibling_package(
                 }
 
                 for dep in &pkg_data.dependencies {
-                    if dep.purl.is_some() {
+                    if super::is_reportable_dependency(dep) {
                         pending_dependencies.push(PendingDependency {
                             dependency: dep.clone(),
                             datafile_path: datafile_path.clone(),
@@ -241,7 +241,7 @@ pub(super) fn assemble_siblings_per_identity(
                     pkg_data
                         .dependencies
                         .iter()
-                        .filter(|dep| dep.purl.is_some())
+                        .filter(|dep| super::is_reportable_dependency(dep))
                         .map(|dep| PendingDependency {
                             dependency: dep.clone(),
                             datafile_path: datafile_path.clone(),
@@ -297,7 +297,7 @@ pub(super) fn collect_pending_dependencies(
     pkg_data
         .dependencies
         .iter()
-        .filter(|dep| dep.purl.is_some() || dep.extracted_requirement.is_some())
+        .filter(|dep| super::is_reportable_dependency(dep))
         .cloned()
         .map(|dependency| PendingDependency {
             dependency,

--- a/src/assembly/swift_merge.rs
+++ b/src/assembly/swift_merge.rs
@@ -198,7 +198,7 @@ fn hoist_dependencies(
 ) -> Vec<TopLevelDependency> {
     dependencies
         .iter()
-        .filter(|dependency| dependency.purl.is_some())
+        .filter(|dependency| super::is_reportable_dependency(dependency))
         .map(|dependency| {
             TopLevelDependency::from_dependency(
                 dependency,

--- a/src/parsers/carthage.rs
+++ b/src/parsers/carthage.rs
@@ -138,7 +138,16 @@ fn parse_cartfile_lines(content: &str, is_resolved: bool) -> Vec<Dependency> {
             OriginType::Binary => make_binary_dep_info(&parsed.source),
         };
 
-        let extracted_requirement = parsed.version_spec.map(truncate_field);
+        // `github` entries are identified by their PURL, so the version spec alone
+        // is the requirement. A `git` or `binary` entry has no PURL, and its
+        // source URL is the only thing identifying it, so an entry declared
+        // without a version would otherwise carry nothing addressable at all.
+        let extracted_requirement = match (&parsed.origin, parsed.version_spec) {
+            (OriginType::Github, version_spec) => version_spec,
+            (_, Some(version_spec)) => Some(version_spec),
+            (_, None) => Some(parsed.source.clone()),
+        }
+        .map(truncate_field);
 
         let is_pinned = if is_resolved { Some(true) } else { None };
 

--- a/src/parsers/carthage_scan_test.rs
+++ b/src/parsers/carthage_scan_test.rs
@@ -13,12 +13,29 @@ mod tests {
         let (files, result) = scan_and_assemble(Path::new("testdata/carthage"));
 
         assert!(result.packages.is_empty());
-        assert_eq!(result.dependencies.len(), 10);
+        assert_eq!(result.dependencies.len(), 13);
+
+        // `git` and `binary` entries resolve to no PURL — a GitHub Enterprise
+        // clone URL and a binary framework manifest are not addressable as one —
+        // but they are declared dependencies all the same, and each carries the
+        // name derived from its source. Reporting them is the point: dropping a
+        // dependency because it is self-hosted hides exactly the ones an SBOM
+        // consumer cannot look up elsewhere.
+        let purl_less: Vec<_> = result
+            .dependencies
+            .iter()
+            .filter(|dependency| dependency.purl.is_none())
+            .collect();
+        assert_eq!(purl_less.len(), 3);
         assert!(
-            result
-                .dependencies
-                .iter()
-                .all(|dependency| dependency.purl.is_some())
+            purl_less.iter().all(|dependency| {
+                dependency.extracted_requirement.is_some()
+                    && dependency
+                        .extra_data
+                        .as_ref()
+                        .is_some_and(|extra| extra.contains_key("name"))
+            }),
+            "every purl-less entry must still be identifiable: {purl_less:?}"
         );
         assert!(
             result

--- a/src/parsers/gitmodules_scan_test.rs
+++ b/src/parsers/gitmodules_scan_test.rs
@@ -13,7 +13,20 @@ mod tests {
         let (files, result) = scan_and_assemble(Path::new("testdata/gitmodules"));
 
         assert!(result.packages.is_empty());
-        assert_eq!(result.dependencies.len(), 3);
+        // Four submodules, including one on an arbitrary host that maps to no
+        // PURL. It is still a declared submodule of this repository, so it is
+        // reported with the source recorded in `extracted_requirement`.
+        assert_eq!(result.dependencies.len(), 4);
+        assert!(
+            result.dependencies.iter().any(|dependency| {
+                dependency.purl.is_none()
+                    && dependency
+                        .extracted_requirement
+                        .as_deref()
+                        .is_some_and(|requirement| requirement.contains("custom.example.com"))
+            }),
+            "the self-hosted submodule should be reported"
+        );
         assert_dependency_present(
             &result.dependencies,
             "pkg:github/example/dep1",

--- a/src/parsers/python/scan_test.rs
+++ b/src/parsers/python/scan_test.rs
@@ -716,4 +716,59 @@ license = { file = "LICENSE.txt" }
             "the package license detection should include a match from the referenced LICENSE.txt"
         );
     }
+
+    #[test]
+    fn test_requirements_url_dependency_reaches_the_top_level_exactly_once() {
+        // A bare URL requirement resolves to no PURL but carries the text it was
+        // declared with, so it is a real declared dependency. Assemblers that
+        // filtered on the PURL alone dropped it, which left the manifest's own
+        // record of it visible only inside `package_data`.
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        fs::write(
+            temp_dir.path().join("requirements.txt"),
+            "https://example.com/foo-1.0.tar.gz\nrequests==2.0\n",
+        )
+        .expect("write requirements.txt");
+
+        let (_files, result) = scan_and_assemble(temp_dir.path());
+
+        assert_dependency_present(
+            &result.dependencies,
+            "pkg:pypi/requests@2.0",
+            "requirements.txt",
+        );
+
+        let url_dependencies: Vec<_> = result
+            .dependencies
+            .iter()
+            .filter(|dependency| {
+                dependency.extracted_requirement.as_deref()
+                    == Some("https://example.com/foo-1.0.tar.gz")
+            })
+            .collect();
+        assert_eq!(
+            url_dependencies.len(),
+            1,
+            "the URL requirement should be reported once, got {:?}",
+            result
+                .dependencies
+                .iter()
+                .map(|dependency| (
+                    dependency.purl.clone(),
+                    dependency.extracted_requirement.clone()
+                ))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(url_dependencies[0].purl, None);
+
+        // The neighbouring requirement must not be duplicated either.
+        assert_eq!(
+            result
+                .dependencies
+                .iter()
+                .filter(|dependency| dependency.purl.as_deref() == Some("pkg:pypi/requests@2.0"))
+                .count(),
+            1
+        );
+    }
 }

--- a/testdata/carthage-golden/basic/Cartfile.expected
+++ b/testdata/carthage-golden/basic/Cartfile.expected
@@ -91,7 +91,7 @@
       },
       {
         "purl": null,
-        "extracted_requirement": null,
+        "extracted_requirement": "https://enterprise.local/ghe/desktop/git-error-translations2.git",
         "scope": "dependencies",
         "is_runtime": null,
         "is_optional": null,


### PR DESCRIPTION
## Summary

- Whether a purl-less dependency reached the top level depended on **which assembler claimed the datafile**. `assemble_one_per_package_data` and the per-identity orphan hoist kept it when it carried `extracted_requirement`; the sibling engines, the nested merge, and every workspace merger (cargo, npm, dart, swift, gradle, debian, mix) filtered on the PURL alone and dropped it.
- A dependency the parser could not resolve to a PURL is still a declared dependency when it carries the text it was declared with — a bare URL requirement in a `requirements.txt` is the ordinary case.
- One shared `is_reportable_dependency` rule now governs all of them, so the outcome no longer depends on the path taken.

## Scope and exclusions

- Included: every dependency-**emission** filter across the generic engines and the ecosystem mergers.
- Explicit exclusions: `swift_merge`'s `resolved_dependency.purl.is_some()` is a value-copy guard, not an emission filter, and is unchanged. Package-identity checks (`pkg_data.purl.is_some()`) are a different question and untouched.

## Issues

- Repairs a regression introduced by #1338. That change suppressed the unassembled fallback once an assembler had emitted for a datafile — but the assembler it deferred to used the narrower filter. Measured on the same input across three points:

| | top-level dependencies |
|---|---|
| before #1338 | URL requirement **reported**, `requests` **duplicated** |
| current `main` | duplication fixed, URL requirement **dropped** |
| this branch | both correct, once each |

So the loss is live in `main` today and is worth landing ahead of the next release.

## How to verify

```sh
printf 'https://example.com/foo-1.0.tar.gz\nrequests==2.0\n' > /tmp/r/requirements.txt
provenant --package --json-pp - /tmp/r | jq '[.dependencies[] | {purl, extracted_requirement}]'
```

Before: only `requests`. After: both, once each, with the URL entry carrying `purl: null`.

Worth poking at the ecosystem mergers, since they are the widest part of the change — a cargo or npm workspace whose members declare a dependency the parser cannot resolve should now surface it rather than silently omit it.

## Intentional differences from Python

- None.

## Expected-output fixture changes

- **None**, across all five golden suites. Nothing in `testdata` currently exercises a purl-less dependency through these paths, so the new rule reaches only the cases that were being dropped — which is also why no fixture caught the #1338 regression.