### PR TITLE
fix(nuget): match central package versions on an encoded PURL

### DIFF
--- a/src/assembly/assembly_test.rs
+++ b/src/assembly/assembly_test.rs
@@ -1877,6 +1877,61 @@ mod tests {
     }
 
     #[test]
+    fn test_assemble_nuget_cpm_resolves_a_central_version_for_a_name_needing_encoding() {
+        // The central version is matched to the project reference by PURL, so both
+        // sides have to spell the PURL the same way. Assembly used to hand-format
+        // it while the project parser built it through the PURL encoder, so any
+        // name with a character needing percent-encoding silently failed to match
+        // and the reference kept no version at all.
+        let mut props_file = create_test_file_info(
+            "repo/Directory.Packages.props",
+            DatasourceId::NugetDirectoryPackagesProps,
+            None,
+            None,
+            None,
+            vec![],
+        );
+        props_file.package_data[0].extra_data = Some(HashMap::from([
+            (
+                "property_values".to_string(),
+                json!({ "ManagePackageVersionsCentrally": "true" }),
+            ),
+            (
+                "package_versions".to_string(),
+                json!([
+                    {
+                        "name": "My Package",
+                        "version": "2.0.0",
+                        "condition": null
+                    }
+                ]),
+            ),
+        ]));
+
+        let mut files = vec![
+            create_test_file_info(
+                "repo/app/Contoso.Utility.csproj",
+                DatasourceId::NugetCsproj,
+                Some("pkg:nuget/Contoso.Utility@1.0.0"),
+                Some("Contoso.Utility"),
+                Some("1.0.0"),
+                // The project parser emits the encoded form.
+                vec![create_test_dependency("pkg:nuget/My%20Package", None, None)],
+            ),
+            props_file,
+        ];
+
+        let result = assemble(&mut files);
+
+        let dependency = result
+            .dependencies
+            .iter()
+            .find(|dependency| dependency.purl.as_deref() == Some("pkg:nuget/My%20Package"))
+            .expect("the project reference should be reported");
+        assert_eq!(dependency.extracted_requirement.as_deref(), Some("2.0.0"));
+    }
+
+    #[test]
     fn test_assemble_nuget_cpm_uses_composed_central_versions() {
         let mut props_file = create_test_file_info(
             "repo/Directory.Packages.props",

--- a/src/assembly/nuget_cpm_resolve.rs
+++ b/src/assembly/nuget_cpm_resolve.rs
@@ -657,7 +657,12 @@ fn build_central_dependency(
     }
 
     Some(Dependency {
-        purl: Some(format!("pkg:nuget/{name}")),
+        // Build the PURL exactly as the csproj parser does. This value is a join
+        // key — `resolve_central_package_version` matches it against the
+        // dependency the project file produced — so hand-formatting it here made
+        // any name needing percent-encoding fail to match, and the central
+        // `PackageVersion` silently failed to resolve.
+        purl: crate::parsers::build_nuget_purl(Some(&name), None),
         extracted_requirement: Some(version),
         scope: Some("package_version".to_string()),
         is_runtime: Some(true),

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -718,6 +718,9 @@ pub use self::nix::{NixDefaultParser, NixFlakeLockParser, NixFlakeParser};
 pub use self::npm::NpmParser;
 pub use self::npm_lock::NpmLockParser;
 pub use self::npm_workspace::NpmWorkspaceParser;
+/// Shared so assembly builds NuGet PURLs the same way the project parsers do;
+/// the value is a join key between the two.
+pub(crate) use self::nuget::build_nuget_purl;
 pub use self::nuget::{
     CentralPackageManagementPropsParser, DirectoryBuildPropsParser, DotNetDepsJsonParser,
     NupkgParser, NuspecParser, PackageReferenceProjectParser, PackagesConfigParser,

--- a/src/parsers/nuget/mod.rs
+++ b/src/parsers/nuget/mod.rs
@@ -169,7 +169,7 @@ pub(super) fn build_nuget_urls(
     )
 }
 
-pub(super) fn build_nuget_purl(name: Option<&str>, version: Option<&str>) -> Option<String> {
+pub(crate) fn build_nuget_purl(name: Option<&str>, version: Option<&str>) -> Option<String> {
     let name = name?;
     let mut package_url = PackageUrl::new("nuget", name).ok()?;
 


### PR DESCRIPTION
## Summary

- Central Package Management resolves a versionless `PackageReference` by matching its PURL against the `PackageVersion` entries. The two sides spelled that PURL differently: the project parser builds it through the PURL encoder (`build_nuget_purl`), while assembly hand-formatted `pkg:nuget/{name}`.
- Any package name containing a character that needs percent-encoding therefore never matched, and the reference silently kept no version at all.
- Not a malformed-PURL bug — the emitted PURL was fine. The PURL is used here as a **join key**, so the mismatch is a functional one: `<PackageVersion Include="My Package" Version="2.0.0"/>` left the project's reference with `extracted_requirement: null`.

## Scope and exclusions

- Included: build the candidate through the same helper the project parsers use, so both sides are identical by construction rather than by convention.
- Explicit exclusions: no change to which references CPM resolves, the condition/override precedence rules, or anything else in the pass.

## How to verify

```
Directory.Build.props    <SerilogVersion>3.1.1</…><MyVersion>2.0.0</…>
Directory.Packages.props ManagePackageVersionsCentrally=true
                         <PackageVersion Include="Serilog"    Version="$(SerilogVersion)"/>
                         <PackageVersion Include="My Package" Version="$(MyVersion)"/>
proj/app.csproj          <PackageReference Include="Serilog"/> <PackageReference Include="My Package"/>
```

```sh
provenant --package --json-pp - . | jq '[.dependencies[] | {purl, extracted_requirement}]'
```

Before: `pkg:nuget/Serilog` → `3.1.1`, but `pkg:nuget/My%20Package` → `null`. After: `2.0.0`. A control fixture with the space removed from the name resolves both either way, which isolates the encoding as the sole cause.

Note this is visible in the **top-level** `dependencies[]`, which is what the pass rewrites — `files[].package_data[].dependencies[]` keeps the unresolved form in both cases.

## Intentional differences from Python

- None; ScanCode does not implement CPM version resolution at all.

## Expected-output fixture changes

- None. No fixture used a central package name needing encoding; covered by a new assembly test alongside the existing CPM cases.