### PR TITLE
fix(alpine,hackage): keep constraints out of PURL names and encode components

### DIFF
--- a/src/parsers/alpine.rs
+++ b/src/parsers/alpine.rs
@@ -232,7 +232,9 @@ fn parse_alpine_package_paragraph(
         build_alpine_license_data(extracted_license_statement.as_deref());
 
     let source_packages = if let Some(origin) = get_first(headers, "o") {
-        vec![format!("pkg:apk/alpine/{}", origin)]
+        crate::parsers::utils::namespaced_purl("apk", "alpine", &origin, None)
+            .into_iter()
+            .collect()
     } else {
         Vec::new()
     };
@@ -256,9 +258,10 @@ fn parse_alpine_package_paragraph(
                 break 'dep_loop;
             }
 
+            let (dep_name, declared) = split_apk_dependency(dep_str);
             dependencies.push(Dependency {
-                purl: Some(format!("pkg:apk/alpine/{}", dep_str)),
-                extracted_requirement: None,
+                purl: crate::parsers::utils::namespaced_purl("apk", "alpine", dep_name, None),
+                extracted_requirement: declared.map(str::to_string),
                 scope: Some("install".to_string()),
                 is_runtime: Some(true),
                 is_optional: Some(false),
@@ -886,6 +889,23 @@ fn parse_apkbuild_checksums(value: &str) -> Vec<(String, String)> {
         .collect()
 }
 
+/// Splits an apk dependency token into its package name and the full declared
+/// token.
+///
+/// apk writes constraints inline — `musl>=1.2.0`, `busybox=1.36.1-r5`,
+/// `zlib~1.3` — so the token is not a package name. Treating it as one put the
+/// constraint inside the PURL (`pkg:apk/alpine/musl>=1.2.0`, which re-parses to
+/// a name of `musl>=1.2.0`) and left the requirement unrecorded.
+fn split_apk_dependency(token: &str) -> (&str, Option<&str>) {
+    match token.find(['<', '>', '=', '~']) {
+        // The whole token is the declared requirement, constraint included; a
+        // bare name carries no requirement beyond the identity already in the
+        // PURL, so it stays unset rather than repeating itself.
+        Some(name_end) => (&token[..name_end], Some(token)),
+        None => (token, None),
+    }
+}
+
 fn build_alpine_license_data(
     extracted: Option<&str>,
 ) -> (Option<String>, Option<String>, Vec<LicenseDetection>) {
@@ -1345,8 +1365,9 @@ fn parse_pkginfo(content: &str) -> PackageData {
                 break;
             }
             let dep_name = dep_str.split_whitespace().next().unwrap_or(dep_str);
+            let (dep_name, _) = split_apk_dependency(dep_name);
             dependencies.push(Dependency {
-                purl: Some(format!("pkg:apk/alpine/{}", dep_name)),
+                purl: crate::parsers::utils::namespaced_purl("apk", "alpine", dep_name, None),
                 extracted_requirement: Some(dep_str.to_string()),
                 scope: Some("runtime".to_string()),
                 is_runtime: Some(true),
@@ -1389,6 +1410,29 @@ mod tests {
     use std::io::Write;
     use std::path::PathBuf;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_apk_dependency_constraints_stay_out_of_the_purl_name() {
+        // apk writes constraints inline, so the token is not a package name.
+        // Treating it as one produced `pkg:apk/alpine/musl>=1.2.0`, which
+        // re-parses to a name of `musl>=1.2.0`, and left the constraint recorded
+        // nowhere else.
+        assert_eq!(
+            split_apk_dependency("musl>=1.2.0"),
+            ("musl", Some("musl>=1.2.0"))
+        );
+        assert_eq!(
+            split_apk_dependency("busybox=1.36.1-r5"),
+            ("busybox", Some("busybox=1.36.1-r5"))
+        );
+        assert_eq!(split_apk_dependency("zlib~1.3"), ("zlib", Some("zlib~1.3")));
+        // A bare name carries no requirement beyond the PURL's identity.
+        assert_eq!(split_apk_dependency("musl"), ("musl", None));
+
+        let purl = crate::parsers::utils::namespaced_purl("apk", "alpine", "musl", None)
+            .expect("purl should build");
+        assert_eq!(purl, "pkg:apk/alpine/musl");
+    }
 
     /// Creates a temp file mimicking the Alpine installed db path structure.
     /// Returns the TempDir (must be kept alive) and path to the file.

--- a/src/parsers/hackage.rs
+++ b/src/parsers/hackage.rs
@@ -724,7 +724,7 @@ fn parse_hackage_spec_dependency(
         }
 
         return Some(Dependency {
-            purl: Some(truncate_field(format!("pkg:hackage/{}@{}", name, version))),
+            purl: build_hackage_purl(Some(&name), Some(&version)).map(truncate_field),
             extracted_requirement: Some(truncate_field(version)),
             scope: scope.map(str::to_string),
             is_runtime: component.map(component_is_runtime).or(is_runtime),
@@ -754,14 +754,8 @@ fn parse_hackage_spec_dependency(
             .as_ref()
             .map(|(_, version)| version.clone())
     });
-    let purl = if let Some(version) = exact_version.as_deref() {
-        Some(truncate_field(format!(
-            "pkg:hackage/{}@{}",
-            resolved_name, version
-        )))
-    } else {
-        Some(truncate_field(format!("pkg:hackage/{}", resolved_name)))
-    };
+    let purl =
+        build_hackage_purl(Some(resolved_name), exact_version.as_deref()).map(truncate_field);
 
     let mut extra_data = HashMap::new();
     if let Some(component) = component {
@@ -1003,12 +997,13 @@ fn build_party(value: &str, role: &str) -> Option<Party> {
     })
 }
 
-fn build_hackage_purl(name: Option<&str>, version: Option<&str>) -> Option<String> {
-    match (name, version) {
-        (Some(name), Some(version)) => Some(format!("pkg:hackage/{}@{}", name, version)),
-        (Some(name), None) => Some(format!("pkg:hackage/{}", name)),
-        _ => None,
-    }
+/// Builds a hackage PURL through the encoder.
+///
+/// A `.cabal` `name:` field is free text, so a `/` in it would otherwise be read
+/// back as a namespace separator — which hackage prohibits, making the PURL
+/// unparsable.
+pub(super) fn build_hackage_purl(name: Option<&str>, version: Option<&str>) -> Option<String> {
+    crate::parsers::utils::simple_purl("hackage", name?, version)
 }
 
 fn split_hackage_name_version(spec: &str) -> Option<(String, String)> {

--- a/src/parsers/hackage_test.rs
+++ b/src/parsers/hackage_test.rs
@@ -372,3 +372,20 @@ library
         assert_eq!(dependency.is_pinned, Some(false));
     }
 }
+
+#[test]
+fn test_hackage_purl_encodes_the_name() {
+    use std::str::FromStr;
+
+    // A `.cabal` `name:` field is free text; a `/` in it would be read back as a
+    // namespace separator, which hackage prohibits, making the PURL unparsable.
+    let purl =
+        super::hackage::build_hackage_purl(Some("ns/pkg"), Some("2.0")).expect("purl should build");
+    assert_eq!(purl, "pkg:hackage/ns%2Fpkg@2.0");
+
+    let parsed = packageurl::PackageUrl::from_str(&purl).expect("purl should parse");
+    assert_eq!(parsed.name(), "ns/pkg");
+    assert_eq!(parsed.namespace(), None);
+    assert_eq!(parsed.version(), Some("2.0"));
+    assert_eq!(parsed.to_string(), purl);
+}

--- a/testdata/alpine/apk/basic/test-package-1.0-r0.apk.expected.json
+++ b/testdata/alpine/apk/basic/test-package-1.0-r0.apk.expected.json
@@ -35,7 +35,7 @@
     },
     "dependencies": [
       {
-        "purl": "pkg:apk/alpine/musl>=1.2.0",
+        "purl": "pkg:apk/alpine/musl",
         "extracted_requirement": "musl>=1.2.0",
         "scope": "runtime",
         "is_runtime": true,


### PR DESCRIPTION
## Summary

- An apk dependency token carries its constraint inline — `musl>=1.2.0`, `busybox=1.36.1-r5`, `zlib~1.3` — so it is **not** a package name. Treating it as one put the constraint inside the PURL: `pkg:apk/alpine/musl>=1.2.0` re-parses to a name of `musl>=1.2.0`, and this form **ships in a golden today**.
- On the installed-db path it was worse: the constraint went into the PURL *and* `extracted_requirement` was left null, so the version requirement was recorded nowhere usable.
- hackage takes its name from a free-text `.cabal` field. A `/` there is read back as a namespace separator, which hackage prohibits — so the PURL does not parse at all.

## Scope and exclusions

- Included: split the apk token so the name identifies the package and the full token becomes the declared requirement; route apk and hackage PURLs through the shared encoders.
- A bare `D:musl` keeps `extracted_requirement` unset — repeating the identity the PURL already carries would be noise, and "prefer honest unknowns" applies: there is no version requirement to record.

## How to verify

```sh
provenant --package --json-pp - some.apk | jq '[.files[].package_data[].dependencies[] | {purl, extracted_requirement}]'
```

Before: `{"purl": "pkg:apk/alpine/musl>=1.2.0", ...}`. After: `{"purl": "pkg:apk/alpine/musl", "extracted_requirement": "musl>=1.2.0"}`.

For hackage, a `.cabal` with `name: ns/pkg` gave `pkg:hackage/ns/pkg@2.0` (rejected by any PURL parser) and now gives `pkg:hackage/ns%2Fpkg@2.0`, which decodes back to the literal name.

## Intentional differences from Python

- None.

## Expected-output fixture changes

- Files changed: `testdata/alpine/apk/basic/test-package-1.0-r0.apk.expected.json`, one line.
- Why the new expected output is correct: `pkg:apk/alpine/musl>=1.2.0` was never a valid identity — the PURL name is the package, and `>=1.2.0` is a constraint. The same entry already carried `"extracted_requirement": "musl>=1.2.0"`, so the constraint is not lost; it simply stops being part of the package's identity. No other fixture moves, including the alpine assembly golden, whose fixture declares a bare `D:musl`.