### PR TITLE
fix(purl): encode gitmodules PURLs and drop pnpm's unreachable fallback

### DIFF
--- a/src/parsers/gitmodules.rs
+++ b/src/parsers/gitmodules.rs
@@ -192,7 +192,7 @@ fn parse_github_url(url: &str) -> Option<String> {
         return None;
     };
 
-    Some(truncate_field(format!("pkg:github/{}/{}", namespace, name)))
+    crate::parsers::utils::namespaced_purl("github", &namespace, &name, None).map(truncate_field)
 }
 
 fn parse_gitlab_url(url: &str) -> Option<String> {
@@ -206,7 +206,7 @@ fn parse_gitlab_url(url: &str) -> Option<String> {
         return None;
     };
 
-    Some(truncate_field(format!("pkg:gitlab/{}/{}", namespace, name)))
+    crate::parsers::utils::namespaced_purl("gitlab", &namespace, &name, None).map(truncate_field)
 }
 
 fn parse_repo_path(path: &str) -> Option<(String, String)> {

--- a/src/parsers/pnpm_lock.rs
+++ b/src/parsers/pnpm_lock.rs
@@ -500,7 +500,7 @@ fn create_simple_dependency(
     let is_optional = scope.as_deref() == Some("optional");
 
     Some(Dependency {
-        purl: Some(purl),
+        purl,
         extracted_requirement: Some(version),
         scope,
         is_runtime: Some(is_runtime),
@@ -631,7 +631,7 @@ pub fn extract_dependency(
     };
 
     let dependency = Dependency {
-        purl: Some(purl),
+        purl,
         extracted_requirement: Some(version),
         scope,
         is_runtime: Some(is_runtime),
@@ -726,7 +726,14 @@ pub fn parse_purl_fields(
     }
 }
 
-pub fn create_purl(namespace: &Option<String>, name: &str, version: &str) -> String {
+/// Builds the npm PURL for a lockfile entry.
+///
+/// Returns `None` only if the components cannot form a PURL at all. This
+/// previously fell back to a hand-formatted string, which could never be reached
+/// — `npm_purl`'s three fallible calls are all infallible in practice, since the
+/// type is a literal and `with_version` has no error path — and would have
+/// emitted an unencoded PURL if it somehow were.
+pub fn create_purl(namespace: &Option<String>, name: &str, version: &str) -> Option<String> {
     let full_name = match namespace {
         Some(ns) if !ns.is_empty() => {
             let ns_with_at = if ns.starts_with('@') {
@@ -738,7 +745,7 @@ pub fn create_purl(namespace: &Option<String>, name: &str, version: &str) -> Str
         }
         _ => name.to_string(),
     };
-    npm_purl(&full_name, Some(version)).unwrap_or_else(|| format!("pkg:npm/{}", name))
+    npm_purl(&full_name, Some(version))
 }
 
 fn parse_integrity(

--- a/src/parsers/pnpm_lock.rs
+++ b/src/parsers/pnpm_lock.rs
@@ -726,13 +726,8 @@ pub fn parse_purl_fields(
     }
 }
 
-/// Builds the npm PURL for a lockfile entry.
-///
-/// Returns `None` only if the components cannot form a PURL at all. This
-/// previously fell back to a hand-formatted string, which could never be reached
-/// — `npm_purl`'s three fallible calls are all infallible in practice, since the
-/// type is a literal and `with_version` has no error path — and would have
-/// emitted an unencoded PURL if it somehow were.
+/// Builds the npm PURL for a lockfile entry, or `None` when the components
+/// cannot form one.
 pub fn create_purl(namespace: &Option<String>, name: &str, version: &str) -> Option<String> {
     let full_name = match namespace {
         Some(ns) if !ns.is_empty() => {

--- a/src/parsers/pnpm_lock_test.rs
+++ b/src/parsers/pnpm_lock_test.rs
@@ -211,7 +211,8 @@ fn test_parse_purl_fields_v9_multiple_at_symbols() {
 
 #[test]
 fn test_create_purl_scoped() {
-    let purl = create_purl(&Some("@babel".to_string()), "runtime", "7.18.9");
+    let purl = create_purl(&Some("@babel".to_string()), "runtime", "7.18.9")
+        .expect("a scoped package should yield a purl");
     assert!(purl.contains("pkg:npm"));
     assert!(purl.contains("%40babel"));
     assert!(purl.contains("runtime"));
@@ -220,7 +221,8 @@ fn test_create_purl_scoped() {
 
 #[test]
 fn test_create_purl_non_scoped() {
-    let purl = create_purl(&None, "express", "4.18.2");
+    let purl =
+        create_purl(&None, "express", "4.18.2").expect("a plain package should yield a purl");
     assert!(purl.contains("pkg:npm"));
     assert!(purl.contains("express"));
     assert!(purl.contains("4.18.2"));


### PR DESCRIPTION
## Summary

- `.gitmodules` built `pkg:github/{ns}/{name}` and the gitlab equivalent with `format!`, so a repository path needing percent-encoding produced a PURL that did not survive a round trip.
- pnpm's `create_purl` fell back to a hand-formatted string when `npm_purl` returned `None`. That branch **cannot be reached** — the type is a literal, `with_namespace` rejects only namespace-prohibited types, and `with_version` has no error path at all — and it would have emitted an unencoded PURL if it somehow were. It now returns the `Option` rather than inventing a value.

This completes the sweep: no production site builds a PURL with `format!("pkg:…")` any more.

## Scope and exclusions

Case is unaffected for gitmodules, which is what made this safe to do mechanically: `normalize_purl` already lowercases namespace and name for `github`, `gitlab` and `bitbucket` at the output boundary, so only the encoding half was missing.

Two sites are deliberately left as they are, because both are documented decisions rather than hand-rolled strings — each already builds through the crate and then does one targeted, explained edit:

- **CocoaPods** appends the subspec literally so a conventional `+` in a subspec name (`NSData+zlib`) is not escaped to `%2B`.
- **Go** splices its namespace in to preserve path-part case, which `normalize_purl` then lowercases host-only, per the acknowledged spec direction (purl-spec#308).

## How to verify

```sh
printf '[submodule "x"]\n\tpath = x\n\turl = https://github.com/My Org/repo.git\n' > /tmp/g/.gitmodules
provenant --package --json-pp - /tmp/g | jq '[.files[].package_data[].dependencies[].purl]'
```

The whole-sweep check is the useful one: `rg 'format!\("pkg:' src/ --glob '!*test*'` should return nothing.

## Intentional differences from Python

- None.

## Expected-output fixture changes

- None; all 324 parser goldens, 44 assembly goldens and the full 5,671-test lib suite pass unchanged. Two pnpm unit tests now unwrap the `Option` that `create_purl` always returned in practice.