### PR TITLE
docs: record three contracts that were being mistaken for defects

### DIFF
--- a/src/assembly/mod.rs
+++ b/src/assembly/mod.rs
@@ -298,6 +298,11 @@ fn apply_directory_merge_results(
 /// every one of its dependencies twice. Skip any datafile+datasource that already
 /// contributed, and keep intra-file duplicates (a requirement genuinely listed
 /// twice) intact by never deduplicating individual entries.
+///
+/// Correctness rests on what was actually emitted, not on `for_packages`, which
+/// is why no separate "this datafile was handled" signal needs threading out of
+/// assembly: a hoisted-but-unowned record has no package to link to, so it
+/// cannot be represented in the file→package link by construction.
 fn hoist_unassembled_file_dependencies(
     files: &[FileInfo],
     dependencies: &mut Vec<TopLevelDependency>,

--- a/src/parsers/metadata.rs
+++ b/src/parsers/metadata.rs
@@ -14,7 +14,27 @@
 pub struct ParserMetadata {
     /// Human-readable description (e.g., "npm package.json manifest")
     pub description: &'static str,
-    /// File patterns this parser matches (e.g., ["**/package.json"])
+    /// File patterns this parser matches (e.g., `["**/package.json"]`).
+    ///
+    /// Documentation of the intended surface, not an executable contract, and
+    /// deliberately not asserted against `is_match`. The two cannot be held
+    /// equal: many parsers gate on content or path context rather than the
+    /// filename alone — an `.apk` is claimed only if its magic bytes match, a
+    /// `METADATA` only inside a wheel's dist-info — so a pattern describes what
+    /// a user should expect to be recognised, while `is_match` decides whether a
+    /// specific file on disk actually is.
+    ///
+    /// Two consequences worth knowing when editing these:
+    ///
+    /// - A pattern here can be *broader* than `is_match`, and legitimately so.
+    ///   Keep it recognisable to a user reading `docs/SUPPORTED_FORMATS.md`
+    ///   rather than mechanically exact.
+    /// - A surface that is not expressible as a glob at all — detector-driven,
+    ///   scanner-gated, or resolved relative to the scan root — uses the
+    ///   `<...>` convention instead (e.g.
+    ///   `"<compiled Go binaries with Go build info>"`), which the generated
+    ///   table renders as prose. Prefer that over a glob that would advertise
+    ///   files the parser declines.
     pub file_patterns: &'static [&'static str],
     /// Package type identifier (e.g., "npm", "pypi", "maven")
     pub package_type: &'static str,

--- a/src/post_processing/tallies.rs
+++ b/src/post_processing/tallies.rs
@@ -401,6 +401,13 @@ fn merge_non_null_entries_into_counts(
     }
 }
 
+/// The values a file contributes to the `detected_license_expression` tally.
+///
+/// Clues are counted alongside detections even though a clue-only file reports
+/// no `detected_license_expression` of its own. That is deliberate and matches
+/// ScanCode's `license_tallies`, which appends every `license_clues` match's
+/// expression to the same list: the tally answers "what license evidence did
+/// this tree contain", which is a broader question than what each file asserts.
 fn detected_license_values(file: &FileInfo) -> Vec<String> {
     let mut detection_expressions: Vec<String> = file
         .license_detections


### PR DESCRIPTION
## Summary

Three items on the follow-up list looked like drift or inconsistency worth fixing. Investigating each showed the current behaviour is intended — so the fix is to write the reasoning down where the code lives, rather than leave three open questions that get re-opened.

- **`ParserMetadata::file_patterns` vs `is_match`.** These cannot be held equal, and a check enforcing it is not worth building: many parsers gate on content or path context rather than the filename — an `.apk` is claimed only if its magic bytes match, a `METADATA` only inside a wheel's dist-info. I prototyped the check; roughly twenty parsers "failed" it purely because a synthetic path can never satisfy a content gate. A pattern documents what a user should expect to be recognised; `is_match` decides whether a specific file on disk actually is. The note also points at the `<...>` convention for surfaces that are not globs at all.
- **Tallies counting `license_clues`.** A clue-only file contributes a value to the `detected_license_expression` tally while reporting no expression of its own, which reads as the same inconsistency #1337 fixed one layer down. It is not: ScanCode's `license_tallies` appends every `license_clues` match's expression to exactly that list (`summarycode/tallies.py:161-172`). The tally answers what evidence a tree contained, which is a broader question than what each file asserts.
- **`for_packages` as an assembly signal.** Flagged as needing a positive "this datafile was handled" signal threaded out of assembly. It does not: since #1338 the guard keys on the dependencies actually emitted, so `for_packages` is no longer load-bearing for correctness. A hoisted-but-unowned record has no package to link to and therefore cannot appear in that link by construction.

## Scope and exclusions

- Doc comments only; no behaviour change, no test changes.

## How to verify

Nothing to exercise — `cargo test --doc` and a build are the whole check. The claims are verifiable at `reference/scancode-toolkit/src/summarycode/tallies.py:161-172` for the tallies parity and at `src/assembly/mod.rs` for the hoisting guard.

## Intentional differences from Python

- None; one of these notes records an exact parity that was about to be broken.