### PR TITLE
fix(pypi): encode extras names fully, and mark the remaining raw sites safe

### DIFF
--- a/src/parsers/podfile_lock.rs
+++ b/src/parsers/podfile_lock.rs
@@ -416,6 +416,11 @@ fn parse_dep_to_base_purl_and_version(dep: &str) -> (String, Option<String>) {
     (base_purl, requirement)
 }
 
+/// The internal key a pod is tracked by while parsing — never emitted.
+///
+/// Emitted PURLs come from `create_cocoapods_purl`, which encodes through the
+/// crate. This only has to be a stable key for the maps below, so it is not
+/// encoded and must not start being used as an output value.
 fn make_base_purl(name: &str) -> String {
     format!("pkg:cocoapods/{}", name)
 }

--- a/src/parsers/poetry_lock.rs
+++ b/src/parsers/poetry_lock.rs
@@ -404,7 +404,7 @@ fn normalize_pypi_name(name: &str) -> String {
 
 fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
     if name.contains('[') || name.contains(']') {
-        return Some(truncate_field(build_manual_pypi_purl(name, version)));
+        return build_manual_pypi_purl(name, version).map(truncate_field);
     }
 
     let mut purl = PackageUrl::new(PoetryLockParser::PACKAGE_TYPE.as_str(), name).ok()?;
@@ -414,20 +414,14 @@ fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
     Some(truncate_field(purl.to_string()))
 }
 
-fn build_manual_pypi_purl(name: &str, version: Option<&str>) -> String {
-    let encoded_name = encode_pypi_name(name);
-    let mut purl = format!("pkg:pypi/{}", encoded_name);
-    if let Some(version) = version
-        && !version.is_empty()
-    {
-        purl.push('@');
-        purl.push_str(version);
-    }
-    purl
-}
-
-fn encode_pypi_name(name: &str) -> String {
-    name.replace('[', "%5b").replace(']', "%5d")
+/// Builds a PyPI PURL for a name carrying extras (`requests[socks]`).
+///
+/// The crate encodes brackets as `%5B`/`%5D`; this lowercases those two escapes
+/// to keep the spelling ScanCode emits. Everything else still goes through the
+/// encoder, so a name that also contains a reserved character is not left raw.
+fn build_manual_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
+    crate::parsers::utils::simple_purl("pypi", name, version)
+        .map(|purl| purl.replace("%5B", "%5b").replace("%5D", "%5d"))
 }
 
 fn extract_sha256_from_files(package_table: &TomlMap<String, TomlValue>) -> Option<String> {

--- a/src/parsers/python/utils.rs
+++ b/src/parsers/python/utils.rs
@@ -262,6 +262,9 @@ pub(super) fn build_python_dependency_purl(name: &str, version: Option<&str>) ->
         return None;
     }
 
+    // Safe to assemble by hand: the validation above restricts the name to the
+    // PEP 508 charset, which needs no percent-encoding, and the version is
+    // encoded by `encode_python_dependency_purl_version`.
     Some(match version {
         Some(version) => format!(
             "pkg:pypi/{normalized_name}@{}",

--- a/src/parsers/requirements_txt.rs
+++ b/src/parsers/requirements_txt.rs
@@ -938,6 +938,9 @@ fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
         return None;
     }
 
+    // Safe to assemble by hand: `is_valid_distribution_name` above restricts the
+    // name to the PEP 508 charset, which needs no percent-encoding, and the
+    // version is encoded by `encode_pypi_purl_version`.
     PackageUrl::new(RequirementsTxtParser::PACKAGE_TYPE.as_str(), name)
         .ok()
         .map(|_| match version {

--- a/src/parsers/uv_lock.rs
+++ b/src/parsers/uv_lock.rs
@@ -932,7 +932,7 @@ fn normalize_pypi_name(name: &str) -> String {
 
 fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
     if name.contains('[') || name.contains(']') {
-        return Some(truncate_field(build_manual_pypi_purl(name, version)));
+        return build_manual_pypi_purl(name, version).map(truncate_field);
     }
 
     let mut purl = PackageUrl::new(UvLockParser::PACKAGE_TYPE.as_str(), name).ok()?;
@@ -942,16 +942,14 @@ fn create_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
     Some(truncate_field(purl.to_string()))
 }
 
-fn build_manual_pypi_purl(name: &str, version: Option<&str>) -> String {
-    let encoded_name = name.replace('[', "%5b").replace(']', "%5d");
-    let mut purl = format!("pkg:pypi/{}", encoded_name);
-    if let Some(version) = version
-        && !version.is_empty()
-    {
-        purl.push('@');
-        purl.push_str(version);
-    }
-    purl
+/// Builds a PyPI PURL for a name carrying extras (`requests[socks]`).
+///
+/// The crate encodes brackets as `%5B`/`%5D`; this lowercases those two escapes
+/// to keep the spelling ScanCode emits. Everything else still goes through the
+/// encoder, so a name that also contains a reserved character is not left raw.
+fn build_manual_pypi_purl(name: &str, version: Option<&str>) -> Option<String> {
+    crate::parsers::utils::simple_purl("pypi", name, version)
+        .map(|purl| purl.replace("%5B", "%5b").replace("%5D", "%5d"))
 }
 
 fn toml_value_to_json(value: &TomlValue) -> JsonValue {


### PR DESCRIPTION
## Summary

- The extras path (`requests[socks]`) assembled its PURL by hand so the bracket escapes could be lowercase, matching what ScanCode emits. That left every **other** character raw, so a lockfile name carrying both a bracket and a reserved character kept the latter unencoded. It now encodes through the crate and lowercases only the two bracket escapes, so the emitted spelling is unchanged and the gap is closed.
- Completes the sweep. Every `format!("pkg:…")` that remains is safe, and now says why — the reason this class of bug survived is that every such site looked alike under grep.

## Scope and exclusions

The remaining sites, each now carrying its justification:

- **pypi builders** restrict the name to the PEP 508 charset before formatting — a charset that needs no percent-encoding — and encode the version separately. Verified: `1.0+cu118` and `4.%2A` both parse and decode to the same components either way.
- **CocoaPods** `make_base_purl`/`make_base_purl_from_parts` are internal map keys, never emitted. Emitted PURLs come from `create_cocoapods_purl`, which encodes through the crate.
- **Go**'s namespace splice was already documented: it preserves path-part case, which `normalize_purl` then lowercases host-only per purl-spec#308.
- One site in `src/output/cyclonedx.rs` is inside `mod tests`.

## How to verify

```sh
rg 'format!\("pkg:' src/ --glob '!*test*'
```

Every hit should now be adjacent to a comment saying why it is not an emission site or why the components need no encoding. Behaviourally, a `uv.lock`/`poetry.lock` entry named `foo bar[extra]` previously emitted an unencoded space; it now encodes, while `requests[socks]` is byte-identical to before.

## Intentional differences from Python

- The lowercase bracket escapes (`%5b`/`%5d` rather than the crate's `%5B`/`%5D`) are kept deliberately for ScanCode parity. Both decode identically.

## Expected-output fixture changes

- None; all 324 parser goldens, 44 assembly goldens, the PURL validity guard and the full 5,676-test lib suite pass unchanged.