### PR TITLE
fix(license): back a file's expression with detections after demotion

### DIFF
--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -167,6 +167,19 @@ fn demote_unresolved_reference_detections_to_clues(file: &mut FileInfo) {
     }
     file.license_detections = surviving;
 
+    // `FileInfo::new` adopts a file's own package data's detections when the file
+    // has none of its own, so a manifest's declared licence is backed by visible
+    // evidence. A file whose only detection was the unresolved reference skipped
+    // that adoption at construction and would be left asserting its package's
+    // licence with an empty `license_detections` — the same expression-without-
+    // evidence shape this demotion exists to prevent. Adopt them now instead.
+    if file.license_detections.is_empty() {
+        for package_data in &file.package_data {
+            file.license_detections
+                .extend(package_data.license_detections.clone());
+        }
+    }
+
     refresh_file_license_expressions(file);
 }
 
@@ -2080,6 +2093,56 @@ mod tests {
         // makes the file assert a license in one spelling that it denies in the
         // other, which is what a clue-only file looked like before this fix.
         assert_eq!(po.detected_license_expression_spdx, None);
+    }
+
+    #[test]
+    fn demoting_the_only_detection_adopts_the_file_package_data_detections() {
+        // A wheel `METADATA` declaring `License-Expression: MIT` and referencing a
+        // `License-File` too far away to group into one detection: the reference
+        // is the file's only own detection, so it skipped the package-data
+        // adoption `FileInfo::new` performs, and demoting it left the file
+        // asserting `mit` with an empty `license_detections` — an expression with
+        // no evidence behind it, which is what this demotion exists to prevent.
+        let mut metadata = file("demo-1.0.dist-info/METADATA");
+        metadata.license_detections = vec![crate::models::LicenseDetection {
+            license_expression: "unknown-license-reference".to_string(),
+            license_expression_spdx: "LicenseRef-scancode-unknown-license-reference".to_string(),
+            matches: vec![placeholder_reference_match(
+                "unknown-license-reference",
+                "unknown-license-reference_see_license_at_manifest_1.RULE",
+            )],
+            detection_log: vec!["unknown-reference-to-local-file".to_string()],
+            identifier: "unknown-ref-id".to_string(),
+        }];
+        metadata.detected_license_expression = Some("mit".to_string());
+        metadata.detected_license_expression_spdx = Some("MIT".to_string());
+        metadata.package_data = vec![crate::models::PackageData {
+            declared_license_expression: Some("mit".to_string()),
+            declared_license_expression_spdx: Some("MIT".to_string()),
+            license_detections: vec![detection("mit", "MIT", "demo-1.0.dist-info/METADATA")],
+            ..Default::default()
+        }];
+
+        let mut files = vec![metadata];
+        apply_package_reference_following(&mut files, &mut []);
+        let metadata = files.remove(0);
+
+        // The reference stays visible as a clue.
+        assert_eq!(metadata.license_clues.len(), 1);
+        assert_eq!(
+            metadata.license_clues[0].license_expression,
+            "unknown-license-reference"
+        );
+
+        // And the declared licence is now backed by a detection rather than
+        // asserted on its own.
+        assert_eq!(metadata.detected_license_expression.as_deref(), Some("mit"));
+        assert_eq!(
+            metadata.detected_license_expression_spdx.as_deref(),
+            Some("MIT")
+        );
+        assert_eq!(metadata.license_detections.len(), 1);
+        assert_eq!(metadata.license_detections[0].license_expression, "mit");
     }
 
     #[test]

--- a/src/post_processing/reference_following.rs
+++ b/src/post_processing/reference_following.rs
@@ -167,12 +167,9 @@ fn demote_unresolved_reference_detections_to_clues(file: &mut FileInfo) {
     }
     file.license_detections = surviving;
 
-    // `FileInfo::new` adopts a file's own package data's detections when the file
-    // has none of its own, so a manifest's declared licence is backed by visible
-    // evidence. A file whose only detection was the unresolved reference skipped
-    // that adoption at construction and would be left asserting its package's
-    // licence with an empty `license_detections` — the same expression-without-
-    // evidence shape this demotion exists to prevent. Adopt them now instead.
+    // Keep the expression backed by evidence. `FileInfo::new` adopts package-data
+    // detections only for a file that starts with none, which a file whose sole
+    // detection was this reference did not.
     if file.license_detections.is_empty() {
         for package_data in &file.package_data {
             file.license_detections
@@ -2097,12 +2094,9 @@ mod tests {
 
     #[test]
     fn demoting_the_only_detection_adopts_the_file_package_data_detections() {
-        // A wheel `METADATA` declaring `License-Expression: MIT` and referencing a
-        // `License-File` too far away to group into one detection: the reference
-        // is the file's only own detection, so it skipped the package-data
-        // adoption `FileInfo::new` performs, and demoting it left the file
-        // asserting `mit` with an empty `license_detections` — an expression with
-        // no evidence behind it, which is what this demotion exists to prevent.
+        // A wheel `METADATA` whose `License-File` reference is its only own
+        // detection, so demoting it would leave the package's declared `mit`
+        // asserted with an empty `license_detections`.
         let mut metadata = file("demo-1.0.dist-info/METADATA");
         metadata.license_detections = vec![crate::models::LicenseDetection {
             license_expression: "unknown-license-reference".to_string(),

--- a/testdata/summarycode-golden/reference_following/wheel_metadata_license_file_reference/codebase/demo-1.0.dist-info/METADATA
+++ b/testdata/summarycode-golden/reference_following/wheel_metadata_license_file_reference/codebase/demo-1.0.dist-info/METADATA
@@ -1,0 +1,16 @@
+Metadata-Version: 2.4
+Name: demo
+License-Expression: MIT
+Version: 1.0
+Summary: A demo package
+Author-email: Someone <someone@example.com>
+Requires-Python: >=3.9
+Classifier: Programming Language :: Python :: 3
+Classifier: Operating System :: OS Independent
+Requires-Dist: flask
+Requires-Dist: werkzeug
+Project-URL: Homepage, https://example.com
+Description-Content-Type: text/markdown
+License-File: LICENSE
+
+# demo

--- a/testdata/summarycode-golden/reference_following/wheel_metadata_license_file_reference/codebase/demo-1.0.dist-info/licenses/LICENSE
+++ b/testdata/summarycode-golden/reference_following/wheel_metadata_license_file_reference/codebase/demo-1.0.dist-info/licenses/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Example Author
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/testdata/summarycode-golden/reference_following/wheel_metadata_license_file_reference/expected.json
+++ b/testdata/summarycode-golden/reference_following/wheel_metadata_license_file_reference/expected.json
@@ -1,0 +1,290 @@
+{
+  "summary": {
+    "declared_license_expression": "mit",
+    "license_clarity_score": {
+      "score": 0,
+      "declared_license": false,
+      "identification_precision": false,
+      "has_license_text": false,
+      "declared_copyrights": false,
+      "conflicting_license_categories": false,
+      "ambiguous_compound_licensing": true
+    },
+    "declared_holder": null,
+    "primary_language": "Python",
+    "other_license_expressions": [],
+    "other_holders": [],
+    "other_languages": []
+  },
+  "tallies": {
+    "detected_license_expression": [
+      {
+        "value": "mit",
+        "count": 2
+      },
+      {
+        "value": "unknown-license-reference",
+        "count": 1
+      }
+    ],
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "programming_language": []
+  },
+  "tallies_of_key_files": {
+    "detected_license_expression": [
+      {
+        "value": "mit",
+        "count": 1
+      },
+      {
+        "value": "unknown-license-reference",
+        "count": 1
+      }
+    ],
+    "copyrights": [],
+    "holders": [],
+    "authors": [],
+    "programming_language": []
+  },
+  "license_detections": [
+    {
+      "identifier": "mit-0417f034-29de-3369-3be1-60a79938d91c",
+      "license_expression": "mit",
+      "license_expression_spdx": "MIT",
+      "detection_count": 1,
+      "detection_log": [],
+      "reference_matches": [
+        {
+          "from_file": "codebase/demo-1.0.dist-info/licenses/LICENSE",
+          "license_expression": "mit",
+          "license_expression_spdx": "MIT",
+          "rule_identifier": "mit_14.RULE"
+        },
+        {
+          "from_file": "codebase/demo-1.0.dist-info/licenses/LICENSE",
+          "license_expression": "mit",
+          "license_expression_spdx": "MIT",
+          "rule_identifier": "mit.LICENSE"
+        }
+      ]
+    },
+    {
+      "identifier": "mit-baa8883e-2a3e-91b8-cdd5-5b082d60e708",
+      "license_expression": "mit",
+      "license_expression_spdx": "MIT",
+      "detection_count": 1,
+      "detection_log": [],
+      "reference_matches": [
+        {
+          "from_file": "codebase/demo-1.0.dist-info/METADATA",
+          "license_expression": "mit",
+          "license_expression_spdx": "MIT",
+          "rule_identifier": "parser-declared-license"
+        }
+      ]
+    }
+  ],
+  "license_references": [
+    {
+      "key": "mit",
+      "language": "en",
+      "short_name": "MIT License",
+      "name": "MIT License",
+      "owner": "MIT",
+      "homepage_url": "http://opensource.org/licenses/mit-license.php",
+      "spdx_license_key": "MIT",
+      "osi_license_key": null,
+      "text_urls": ["http://opensource.org/licenses/mit-license.php"],
+      "osi_url": "http://www.opensource.org/licenses/MIT",
+      "faq_url": "https://ieeexplore.ieee.org/document/9263265",
+      "other_urls": [
+        "https://opensource.com/article/18/3/patent-grant-mit-license",
+        "https://opensource.com/article/19/4/history-mit-license",
+        "https://opensource.org/licenses/MIT"
+      ],
+      "category": "Permissive",
+      "is_exception": false,
+      "is_unknown": false,
+      "is_generic": false,
+      "minimum_coverage": null,
+      "standard_notice": null
+    },
+    {
+      "key": "unknown-license-reference",
+      "language": "en",
+      "short_name": "Unknown License reference",
+      "name": "Unknown License file reference",
+      "owner": "Unspecified",
+      "homepage_url": null,
+      "spdx_license_key": "LicenseRef-scancode-unknown-license-reference",
+      "osi_license_key": null,
+      "text_urls": [],
+      "osi_url": null,
+      "faq_url": null,
+      "other_urls": [],
+      "category": "Unstated License",
+      "is_exception": false,
+      "is_unknown": true,
+      "is_generic": false,
+      "minimum_coverage": null,
+      "standard_notice": null
+    }
+  ],
+  "license_rule_references": [
+    {
+      "identifier": "mit.LICENSE",
+      "license_expression": "mit",
+      "language": null,
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+      "is_synthetic": false,
+      "length": 161,
+      "referenced_filenames": []
+    },
+    {
+      "identifier": "mit_14.RULE",
+      "license_expression": "mit",
+      "language": null,
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mit_14.RULE",
+      "is_synthetic": false,
+      "length": 2,
+      "referenced_filenames": []
+    },
+    {
+      "identifier": "unknown-license-reference_see_license_at_manifest_1.RULE",
+      "license_expression": "unknown-license-reference",
+      "language": null,
+      "rule_url": "https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules/unknown-license-reference_see_license_at_manifest_1.RULE",
+      "is_synthetic": false,
+      "length": 3,
+      "referenced_filenames": ["LICENSE"]
+    }
+  ],
+  "packages": [
+    {
+      "type": "pypi",
+      "name": "demo",
+      "version": "1.0",
+      "declared_license_expression": "mit",
+      "declared_license_expression_spdx": "MIT",
+      "other_license_expression": null,
+      "other_license_expression_spdx": null,
+      "datafile_paths": ["codebase/demo-1.0.dist-info/METADATA"],
+      "license_detections": [
+        {
+          "license_expression": "mit",
+          "license_expression_spdx": "MIT",
+          "detection_log": [],
+          "identifier": "mit-baa8883e-2a3e-91b8-cdd5-5b082d60e708",
+          "matches": [
+            {
+              "from_file": "codebase/demo-1.0.dist-info/METADATA",
+              "matched_text": "MIT",
+              "license_expression": "mit",
+              "license_expression_spdx": "MIT",
+              "rule_identifier": "parser-declared-license",
+              "referenced_filenames": ["LICENSE"]
+            }
+          ]
+        }
+      ],
+      "other_license_detections": []
+    }
+  ],
+  "files": [
+    {
+      "path": "codebase/demo-1.0.dist-info/METADATA",
+      "type": "file",
+      "is_top_level": true,
+      "is_key_file": true,
+      "is_manifest": true,
+      "detected_license_expression": "mit",
+      "detected_license_expression_spdx": "MIT",
+      "license_detections": [
+        {
+          "license_expression": "mit",
+          "license_expression_spdx": "MIT",
+          "detection_log": [],
+          "identifier": "mit-baa8883e-2a3e-91b8-cdd5-5b082d60e708",
+          "matches": [
+            {
+              "from_file": "codebase/demo-1.0.dist-info/METADATA",
+              "matched_text": "MIT",
+              "license_expression": "mit",
+              "license_expression_spdx": "MIT",
+              "rule_identifier": "parser-declared-license",
+              "referenced_filenames": ["LICENSE"]
+            }
+          ]
+        }
+      ],
+      "package_data": [
+        {
+          "type": "pypi",
+          "name": "demo",
+          "version": "1.0",
+          "declared_license_expression": "mit",
+          "declared_license_expression_spdx": "MIT",
+          "other_license_expression": null,
+          "other_license_expression_spdx": null,
+          "license_detections": [
+            {
+              "license_expression": "mit",
+              "license_expression_spdx": "MIT",
+              "detection_log": [],
+              "identifier": "mit-baa8883e-2a3e-91b8-cdd5-5b082d60e708",
+              "matches": [
+                {
+                  "from_file": "codebase/demo-1.0.dist-info/METADATA",
+                  "matched_text": "MIT",
+                  "license_expression": "mit",
+                  "license_expression_spdx": "MIT",
+                  "rule_identifier": "parser-declared-license",
+                  "referenced_filenames": ["LICENSE"]
+                }
+              ]
+            }
+          ],
+          "other_license_detections": []
+        }
+      ]
+    },
+    {
+      "path": "codebase/demo-1.0.dist-info/licenses/LICENSE",
+      "type": "file",
+      "is_top_level": false,
+      "is_key_file": false,
+      "is_manifest": false,
+      "detected_license_expression": "mit",
+      "detected_license_expression_spdx": "MIT",
+      "license_detections": [
+        {
+          "license_expression": "mit",
+          "license_expression_spdx": "MIT",
+          "detection_log": [],
+          "identifier": "mit-0417f034-29de-3369-3be1-60a79938d91c",
+          "matches": [
+            {
+              "from_file": "codebase/demo-1.0.dist-info/licenses/LICENSE",
+              "matched_text": null,
+              "license_expression": "mit",
+              "license_expression_spdx": "MIT",
+              "rule_identifier": "mit_14.RULE",
+              "referenced_filenames": []
+            },
+            {
+              "from_file": "codebase/demo-1.0.dist-info/licenses/LICENSE",
+              "matched_text": null,
+              "license_expression": "mit",
+              "license_expression_spdx": "MIT",
+              "rule_identifier": "mit.LICENSE",
+              "referenced_filenames": []
+            }
+          ]
+        }
+      ],
+      "package_data": []
+    }
+  ]
+}

--- a/tests/post_processing_golden.rs
+++ b/tests/post_processing_golden.rs
@@ -474,11 +474,9 @@ Copyright - split out libs\0\xff",
     }
 
     #[test]
-    // A wheel `METADATA` whose `License-Expression` and `License-File` sit too far
-    // apart to group into one detection. The unresolved reference is demoted to a
-    // clue, which would leave the file asserting the package's declared license
-    // with no detection behind it; the package data's own detection is adopted
-    // instead, so the expression stays backed by visible evidence.
+    // `License-Expression` and `License-File` too far apart to group into one
+    // detection: demoting the reference must not leave the declared license
+    // asserted with an empty `license_detections`.
     fn test_golden_reference_follow_wheel_metadata_license_file_reference() {
         assert_reference_follow_fixture_matches_expected(
             "testdata/summarycode-golden/reference_following/wheel_metadata_license_file_reference",

--- a/tests/post_processing_golden.rs
+++ b/tests/post_processing_golden.rs
@@ -474,6 +474,19 @@ Copyright - split out libs\0\xff",
     }
 
     #[test]
+    // A wheel `METADATA` whose `License-Expression` and `License-File` sit too far
+    // apart to group into one detection. The unresolved reference is demoted to a
+    // clue, which would leave the file asserting the package's declared license
+    // with no detection behind it; the package data's own detection is adopted
+    // instead, so the expression stays backed by visible evidence.
+    fn test_golden_reference_follow_wheel_metadata_license_file_reference() {
+        assert_reference_follow_fixture_matches_expected(
+            "testdata/summarycode-golden/reference_following/wheel_metadata_license_file_reference",
+            "testdata/summarycode-golden/reference_following/wheel_metadata_license_file_reference/expected.json",
+        );
+    }
+
+    #[test]
     // A file whose only license evidence is an unresolvable reference ("see the
     // file COPYING", with no such file in the tree) keeps that evidence as a
     // clue and asserts no license. Both `detected_license_expression` and its


### PR DESCRIPTION
## Summary

- A second variant of the reported inconsistency, from the same user after 1.0.4. This time the two expression fields agree with each other, but nothing backs them:

```json
"detected_license_expression": "mit",
"detected_license_expression_spdx": "MIT",
"license_detections": [],
"license_clues": [
  { "license_expression": "unknown-license-reference",
    "start_line": 14, "matched_text": "License-File: LICENSE" }
]
```

- Reproduced exactly, down to the line number: a wheel `METADATA` carrying both `License-Expression: MIT` and a `License-File:` reference **far enough apart not to group into one detection**. When they are adjacent they form a single `mit` detection and nothing is wrong — which is why the reporter saw it in some places and not others.

## Root cause

`FileInfo::new` adopts a file's own package data's detections when the file has none of its own, so a manifest's declared licence is backed by visible evidence. A file whose *sole* detection was the unresolved reference skipped that adoption at construction — at that point it did have a detection — and nothing re-ran it once the demotion emptied the list.

So whether a manifest's package detections appeared at file level depended on whether the file happened to also carry an unresolvable reference. Adopting them in the demotion path too removes that dependency.

## Scope and exclusions

- Included: adopt the file's package-data detections when demotion empties `license_detections`.
- Explicit exclusions: files with **no** package data are untouched — a clue-only source file still reports no expression in either spelling, which is what #1337 established and is verified by the existing golden.
- The demotion itself is unchanged: the reference stays visible as a clue.

## How to verify

```sh
mkdir -p /tmp/w/demo-1.0.dist-info/licenses
printf 'Metadata-Version: 2.4\nName: demo\nLicense-Expression: MIT\nVersion: 1.0\nSummary: s\nAuthor-email: a@b.c\nRequires-Python: >=3.9\nClassifier: X\nClassifier: Y\nRequires-Dist: flask\nRequires-Dist: werkzeug\nProject-URL: Homepage, https://e.com\nDescription-Content-Type: text/markdown\nLicense-File: LICENSE\n' > /tmp/w/demo-1.0.dist-info/METADATA
# plus an MIT LICENSE under demo-1.0.dist-info/licenses/
provenant --license --package --json-pp - /tmp/w | jq '.files[] | select(.path|endswith("METADATA")) | {detected_license_expression, detections: [.license_detections[].license_expression], clues: [.license_clues[].license_expression]}'
```

Before: `"detected_license_expression": "mit"` with `detections: []`. After: `detections: ["mit"]`, clue unchanged.

Worth poking at the adjacent-field arrangement too, since that path was already correct and must stay byte-identical.

## Expected-output fixture changes

- One new fixture, `testdata/summarycode-golden/reference_following/wheel_metadata_license_file_reference/`. No existing expected file changes, and all 424 goldens pass — this shape was simply not covered, which is why neither the earlier fix nor its golden caught it.