### PR TITLE
fix(models): stop a UID marker overwriting a PURL's own uuid qualifier

### DIFF
--- a/src/models/purl.rs
+++ b/src/models/purl.rs
@@ -145,37 +145,51 @@ fn lowercase_first_path_segment(purl: &str, prefix: &str) -> String {
     )
 }
 
-/// Add the `uuid` qualifier that turns a PURL into a UID, keeping it a
-/// qualifier.
+/// The qualifier a UID's instance marker normally uses.
+const UID_MARKER: &str = "uuid";
+
+/// The marker used when the PURL already carries a `uuid` qualifier of its own.
+///
+/// Julia's registry identity is exactly that — the spec requires it, and a Julia
+/// name alone is ambiguous without it. Appending a second `uuid` produced a PURL
+/// with a duplicate qualifier key, which a parser resolves last-wins: the
+/// package's own identity was silently discarded, and re-emitting dropped it
+/// from the string entirely.
+const UID_MARKER_ALT: &str = "uid";
+
+/// Add the qualifier that turns a PURL into a UID, keeping it a qualifier and
+/// leaving the PURL's own qualifiers intact.
 ///
 /// A PURL orders its parts `…?qualifiers#subpath`, so appending to the end of the
-/// string lands the uuid *inside the subpath* whenever one is present: a
+/// string lands the marker *inside the subpath* whenever one is present: a
 /// cocoapods subspec UID came out as `pkg:cocoapods/SwiftFormat@0.44.17#CLI?uuid=…`,
-/// where `?uuid=…` is no longer a qualifier and re-parsing yields the subpath
-/// `CLI?uuid=…`. Insert ahead of the subpath instead, and use `&` only when the
-/// PURL already carries a qualifier.
+/// where `?uuid=…` is no longer a qualifier at all. Insert ahead of the subpath
+/// instead, and use `&` only when the PURL already carries a qualifier.
 ///
 /// Non-PURL bases (the `generated-package:` fallback identity) carry neither
 /// qualifiers nor a subpath, so they simply take the `?uuid=` form.
 pub(crate) fn append_uuid_qualifier(base: &str, uuid: &str) -> String {
     let (head, subpath) = split_subpath(base);
     let separator = if head.contains('?') { '&' } else { '?' };
+    let marker = if has_qualifier(head, UID_MARKER) {
+        UID_MARKER_ALT
+    } else {
+        UID_MARKER
+    };
+
     match subpath {
-        Some(subpath) => format!("{head}{separator}uuid={uuid}#{subpath}"),
-        None => format!("{head}{separator}uuid={uuid}"),
+        Some(subpath) => format!("{head}{separator}{marker}={uuid}#{subpath}"),
+        None => format!("{head}{separator}{marker}={uuid}"),
     }
 }
 
-/// The UID with its `uuid` qualifier removed, restoring the underlying PURL.
+/// The UID with its instance marker removed, restoring the underlying PURL.
 ///
 /// Borrows whenever the UID has no subpath, which is the common case; only a
 /// subpath-carrying UID needs the two remaining parts rejoined.
 pub(crate) fn strip_uuid_qualifier(uid: &str) -> Cow<'_, str> {
     let (head, subpath) = split_subpath(uid);
-    let Some((prefix, _)) = head
-        .split_once("?uuid=")
-        .or_else(|| head.split_once("&uuid="))
-    else {
+    let Some((prefix, _)) = split_uid_marker(head) else {
         return Cow::Borrowed(uid);
     };
 
@@ -185,12 +199,41 @@ pub(crate) fn strip_uuid_qualifier(uid: &str) -> Cow<'_, str> {
     }
 }
 
-/// The value of a UID's `uuid` qualifier, or `None` when it carries none.
+/// The value of a UID's instance marker, or `None` when it carries none.
 pub(crate) fn uuid_qualifier_value(uid: &str) -> Option<&str> {
     let (head, _) = split_subpath(uid);
-    head.split_once("?uuid=")
-        .or_else(|| head.split_once("&uuid="))
-        .map(|(_, uuid)| uuid)
+    split_uid_marker(head).map(|(_, uuid)| uuid)
+}
+
+/// Whether `head` already carries `key` as a qualifier.
+///
+/// Anchored on the qualifier separator so `uid` does not match inside `uuid`.
+fn has_qualifier(head: &str, key: &str) -> bool {
+    head.contains(&format!("?{key}=")) || head.contains(&format!("&{key}="))
+}
+
+/// Splits a UID's qualifier section into the PURL before its instance marker and
+/// the marker's value.
+///
+/// Prefers the alternate marker, which is only ever emitted when the PURL has a
+/// `uuid` of its own. Otherwise takes the *last* `uuid`, so a UID produced before
+/// the alternate marker existed still resolves to the appended one rather than to
+/// the package's registry identity.
+fn split_uid_marker(head: &str) -> Option<(&str, &str)> {
+    for marker in [UID_MARKER_ALT, UID_MARKER] {
+        let separator_index = [format!("?{marker}="), format!("&{marker}=")]
+            .iter()
+            .filter_map(|pattern| head.rfind(pattern.as_str()))
+            .max();
+
+        if let Some(index) = separator_index {
+            let value_start = index + marker.len() + 2;
+            let value = &head[value_start..];
+            let value = value.split_once('&').map_or(value, |(value, _)| value);
+            return Some((&head[..index], value));
+        }
+    }
+    None
 }
 
 fn split_subpath(purl: &str) -> (&str, Option<&str>) {
@@ -220,6 +263,55 @@ mod tests {
         assert_eq!(
             parsed.qualifiers().get("uuid").map(Cow::as_ref),
             Some("abc")
+        );
+    }
+
+    #[test]
+    fn uid_marker_does_not_collide_with_a_purls_own_uuid_qualifier() {
+        // julia's registry identity is a `uuid` qualifier and the spec requires
+        // it. A second one made the two indistinguishable: a parser resolves
+        // duplicate keys last-wins, so the package's own identity was discarded
+        // and re-emitting dropped it from the string.
+        let base = "pkg:julia/HTTP@1.0.0?uuid=cd3eb016-35fb-5094-929b-558a96fad6f3";
+        let uid = append_uuid_qualifier(base, "98920f38-6039-4eaf-925e-f1216f083eba");
+        assert_eq!(
+            uid,
+            "pkg:julia/HTTP@1.0.0?uuid=cd3eb016-35fb-5094-929b-558a96fad6f3&uid=98920f38-6039-4eaf-925e-f1216f083eba"
+        );
+
+        // The registry identity survives a parse, and the marker is separate.
+        let parsed = PackageUrl::from_str(&uid).expect("uid should parse");
+        assert_eq!(
+            parsed.qualifiers().get("uuid").map(Cow::as_ref),
+            Some("cd3eb016-35fb-5094-929b-558a96fad6f3")
+        );
+        assert_eq!(
+            parsed.qualifiers().get("uid").map(Cow::as_ref),
+            Some("98920f38-6039-4eaf-925e-f1216f083eba")
+        );
+
+        // And the PURL is recoverable, so two julia packages sharing a name and
+        // version no longer collapse to the same key.
+        assert_eq!(strip_uuid_qualifier(&uid), base);
+        assert_eq!(
+            uuid_qualifier_value(&uid),
+            Some("98920f38-6039-4eaf-925e-f1216f083eba")
+        );
+    }
+
+    #[test]
+    fn a_uid_written_before_the_alternate_marker_resolves_to_the_appended_one() {
+        // Reading back output produced when both markers were spelled `uuid`:
+        // the appended one is the last, so the package's own identity is what
+        // survives stripping.
+        let legacy = "pkg:julia/HTTP@1.0.0?uuid=cd3eb016-35fb-5094-929b-558a96fad6f3&uuid=98920f38-6039-4eaf-925e-f1216f083eba";
+        assert_eq!(
+            strip_uuid_qualifier(legacy),
+            "pkg:julia/HTTP@1.0.0?uuid=cd3eb016-35fb-5094-929b-558a96fad6f3"
+        );
+        assert_eq!(
+            uuid_qualifier_value(legacy),
+            Some("98920f38-6039-4eaf-925e-f1216f083eba")
         );
     }
 

--- a/tests/emitted_purl_validity_guard.rs
+++ b/tests/emitted_purl_validity_guard.rs
@@ -92,6 +92,21 @@ fn collect_purls(value: &Value, into: &mut BTreeSet<String>) {
     }
 }
 
+/// Every PURL-shaped value in the checked-in expected fixtures.
+fn collect_fixture_purls() -> BTreeSet<String> {
+    let mut purls = BTreeSet::new();
+    for fixture in expected_fixture_files(Path::new("testdata")) {
+        let Ok(contents) = fs::read_to_string(&fixture) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(&contents) else {
+            continue;
+        };
+        collect_purls(&value, &mut purls);
+    }
+    purls
+}
+
 #[test]
 fn every_emitted_purl_in_expected_fixtures_parses() {
     let fixtures = expected_fixture_files(Path::new("testdata"));
@@ -134,6 +149,48 @@ fn every_emitted_purl_in_expected_fixtures_parses() {
             .map(|purl| purl.as_str())
             .collect::<Vec<_>>()
             .join("\n  ")
+    );
+}
+
+/// The qualifier keys carried by a PURL string, in the order written.
+///
+/// Read from the raw text rather than a parsed PURL on purpose: parsing is where
+/// a duplicate key is resolved away, so a parsed value can never reveal one.
+fn qualifier_keys(purl: &str) -> Vec<&str> {
+    let head = purl.split('#').next().unwrap_or(purl);
+    let Some((_, qualifiers)) = head.split_once('?') else {
+        return Vec::new();
+    };
+    qualifiers
+        .split('&')
+        .filter_map(|pair| pair.split_once('='))
+        .map(|(key, _)| key)
+        .collect()
+}
+
+#[test]
+fn no_emitted_purl_repeats_a_qualifier_key() {
+    // A repeated key is silently resolved last-wins, so whatever the earlier one
+    // held is discarded on the first parse. Appending a UID's `uuid` marker to a
+    // julia PURL — whose spec-required `uuid` qualifier *is* its registry
+    // identity — destroyed that identity exactly this way.
+    //
+    // The component-stability check below cannot see this: it compares a parsed
+    // PURL against a re-parsed one, and both have already lost the earlier value.
+    let mut duplicated = Vec::new();
+    for purl in collect_fixture_purls() {
+        let keys = qualifier_keys(&purl);
+        let unique: BTreeSet<&str> = keys.iter().copied().collect();
+        if unique.len() != keys.len() {
+            duplicated.push(purl.clone());
+        }
+    }
+
+    assert!(
+        duplicated.is_empty(),
+        "these emitted PURLs repeat a qualifier key, so the earlier value is \
+         discarded when they are parsed:\n  {}",
+        duplicated.join("\n  ")
     );
 }
 


### PR DESCRIPTION
## Summary

Found by an invariant sweep over a live scan of the full `testdata` corpus, not by a fixture — the fixtures normalise UID values away, which is why nothing caught it.

Julia's registry identity **is** a `uuid` qualifier, and the purl spec requires it: a Julia name alone is ambiguous without it. The UID's instance marker used the same key, so the two became indistinguishable and a parser resolves duplicate keys last-wins:

```
pkg:julia/HTTP?uuid=<registry>&uuid=<instance>
  parsed     -> uuid = <instance>   ← registry identity silently discarded
  re-emitted -> pkg:julia/HTTP?uuid=<instance>
```

`stable_key` split at the *first* marker, returning `pkg:julia/HTTP`, so two distinct packages sharing a name and version collapsed to one dedup key. It affected `package_uid`, `dependency_uid` and `files[].for_packages` — the whole identity surface for that ecosystem.

## Scope and exclusions

- Use a distinct `uid` marker **only** when the PURL already carries a `uuid` qualifier. Every other type is untouched and keeps the ScanCode-compatible `?uuid=` form.
- Read the marker from the last occurrence, so output written before this still resolves to the appended marker rather than to the package's registry identity.
- ScanCode has no Julia handler at all, so there is no parity constraint on the format here.

## How to verify

```sh
provenant --package --json-pp - testdata/julia | jq -r '.packages[].package_uid, .dependencies[].dependency_uid'
```

Before: `pkg:julia/HTTP?uuid=cd3eb016-…&uuid=98920f38-…` — parses to a single `uuid` holding the instance value. After: `…?uuid=cd3eb016-…&uid=98920f38-…`, where the registry qualifier and the marker are separate and both survive a parse.

## Follow-up work

- None. The sweep that found this also checked the rest of the class and came back clean: over 19,750 scanned files and 4,264 unique PURL values, zero expression-without-detections, zero key/SPDX disagreements, zero dangling package references, zero credential-shaped values, zero parse failures, zero component instability. Two other candidates were investigated and dismissed — the "duplicate" composer dependencies carry distinct version constraints, and the one Julia stable-key collision is two fixture directories holding the same synthetic package, which is exactly what the instance marker is for.

## Expected-output fixture changes

- None. Fixture UIDs are normalised, so no expected file moves; covered by unit tests that assert both qualifiers survive a parse, plus a new guard check.