### PR TITLE
fix(copyright): terminate on an Author-email field with no value

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -1814,12 +1814,19 @@ pub(in super::super) fn merge_metadata_author_and_email_lines(
                 next_line_number = next_line_number.next();
                 continue;
             }
+
+            // This is the `Author-email` field belonging to the author above, so
+            // the search ends here either way. Anything unusable in it — a field
+            // written without a value, as `python36-kubernetes`'s wheel metadata
+            // does, or without a colon at all — means there is simply no address
+            // to merge. Continuing without consuming the line would re-read it
+            // forever.
             let Some((_, email_raw)) = email_line.split_once(':') else {
-                continue;
+                break;
             };
             let email = email_raw.trim();
             if email.is_empty() {
-                continue;
+                break;
             }
 
             let combined_raw = format!("{name} Author-email {email}");

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -1815,12 +1815,9 @@ pub(in super::super) fn merge_metadata_author_and_email_lines(
                 continue;
             }
 
-            // This is the `Author-email` field belonging to the author above, so
-            // the search ends here either way. Anything unusable in it — a field
-            // written without a value, as `python36-kubernetes`'s wheel metadata
-            // does, or without a colon at all — means there is simply no address
-            // to merge. Continuing without consuming the line would re-read it
-            // forever.
+            // The field belongs to the author above, so the search ends at the
+            // first one found: an unusable field means there is no address, not
+            // that a later field might supply one.
             let Some((_, email_raw)) = email_line.split_once(':') else {
                 break;
             };

--- a/src/copyright/detector/tests_structured_metadata.rs
+++ b/src/copyright/detector/tests_structured_metadata.rs
@@ -471,11 +471,8 @@ fn test_json_description_keeps_explicit_anchor_attribution() {
 
 #[test]
 fn test_wheel_metadata_author_email_without_a_value_terminates() {
-    // An `Author-email` field written with no value re-read the same line
-    // forever, so a 58-byte wheel `METADATA` never finished a copyright scan.
-    // Reaching the assertions at all is the regression this guards: the deadline
-    // cannot help, because it is checked between phases and this loop never
-    // returned to one.
+    // Reaching the assertions at all is the regression: this input used to loop
+    // forever on the empty field.
     let input = concat!(
         "Metadata-Version: 2.2\n",
         "Author: Jane Smith\n",
@@ -483,18 +480,16 @@ fn test_wheel_metadata_author_email_without_a_value_terminates() {
     );
 
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
-    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
 
-    assert_eq!(values, vec!["Jane Smith"]);
-    assert!(
-        !values.iter().any(|value| value.contains("Author-email")),
-        "an empty field has no address to merge, got {values:?}"
-    );
+    assert_eq!(authors.len(), 1);
+    assert_eq!(authors[0].author, "Jane Smith");
+    // The empty field is not consumed, so the detection covers the author line
+    // alone — the span is what distinguishes this from a merge.
+    assert_eq!(authors[0].start_line, authors[0].end_line);
 }
 
 #[test]
 fn test_wheel_metadata_author_email_with_a_value_still_merges() {
-    // The pairing the heuristic exists for must keep working.
     let input = concat!(
         "Metadata-Version: 2.2\n",
         "Author: Jane Smith\n",
@@ -502,7 +497,10 @@ fn test_wheel_metadata_author_email_with_a_value_still_merges() {
     );
 
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
-    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
 
-    assert_eq!(values, vec!["Jane Smith"]);
+    assert_eq!(authors.len(), 1);
+    assert_eq!(authors[0].author, "Jane Smith");
+    // Refinement drops the address from the text, so the widened span is the
+    // only evidence the pairing happened at all.
+    assert_eq!(authors[0].end_line, authors[0].start_line.next());
 }

--- a/src/copyright/detector/tests_structured_metadata.rs
+++ b/src/copyright/detector/tests_structured_metadata.rs
@@ -468,3 +468,41 @@ fn test_json_description_keeps_explicit_anchor_attribution() {
         "holders: {h:?}"
     );
 }
+
+#[test]
+fn test_wheel_metadata_author_email_without_a_value_terminates() {
+    // An `Author-email` field written with no value re-read the same line
+    // forever, so a 58-byte wheel `METADATA` never finished a copyright scan.
+    // Reaching the assertions at all is the regression this guards: the deadline
+    // cannot help, because it is checked between phases and this loop never
+    // returned to one.
+    let input = concat!(
+        "Metadata-Version: 2.2\n",
+        "Author: Jane Smith\n",
+        "Author-email:\n",
+    );
+
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+
+    assert_eq!(values, vec!["Jane Smith"]);
+    assert!(
+        !values.iter().any(|value| value.contains("Author-email")),
+        "an empty field has no address to merge, got {values:?}"
+    );
+}
+
+#[test]
+fn test_wheel_metadata_author_email_with_a_value_still_merges() {
+    // The pairing the heuristic exists for must keep working.
+    let input = concat!(
+        "Metadata-Version: 2.2\n",
+        "Author: Jane Smith\n",
+        "Author-email: jane@example.com\n",
+    );
+
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+
+    assert_eq!(values, vec!["Jane Smith"]);
+}


### PR DESCRIPTION
## Summary

A copyright scan never finished on a **58-byte** wheel `METADATA`, at 100% CPU:

```
Metadata-Version: 2.2
Author: Kubernetes
Author-email:
```

The loop pairing an `Author` with its `Author-email` advanced its cursor on every path except two — a field written with no value, and one written without a colon. Both took a bare `continue`, re-reading the same line forever.

Reported against `python36-kubernetes`' metadata, where `Author-email:` is empty. Reproduced from the reported file and bisected to those three lines; the other 47 are irrelevant.

## Scope and exclusions

- The field belongs to the author above it, so the search ends when it is reached either way: an unusable one means there is simply no address to merge. Both paths now `break`.
- Explicit exclusion: the same file also produces a bogus author, `Dynamic classifier Dynamic`, from PEP 643 `Dynamic:` field-name declarations. That is a pre-existing false positive in a different subsystem — it reproduces on the current release binary — and is fixed separately.

## Issues

- Covers: hang reported on `python36-kubernetes` `METADATA`.

## How to verify

```sh
printf 'Metadata-Version: 2.2\nAuthor: Kubernetes\nAuthor-email:\n' > /tmp/m
provenant scan --json-pp - --copyright /tmp/m
```

Before: never returns. After: completes, and the author is reported without a fabricated address. A named author with a real address still merges, which is what the heuristic exists for.

## Follow-up work

- Created or intentionally deferred: **the per-file deadline cannot interrupt a hang inside a phase.** It is checked *between* phases (`src/copyright/detector/mod.rs:397`), which assumes each phase terminates — reasonable, and exactly the assumption this loop broke. So the user-facing timeout could not fire, and a 58-byte file hung indefinitely rather than being abandoned.

  Auditing the rest of the module found no second instance: of 59 `continue`-bearing `while` loops in `src/copyright/`, every other one advances its cursor, shrinks its input, or is bounded by its condition. So this defect is a one-off — but the *architecture* still allows any future non-advancing loop to be unkillable. Threading the deadline into the postprocess phase and checking it between heuristics would convert that from a hang into a truncated result. Left out here deliberately: it changes signatures on a hot path and deserves its own review rather than riding along with a two-line fix.

## Expected-output fixture changes

- None. Covered by two unit tests: one asserting the reported shape terminates and merges nothing, one asserting a real address still pairs.