### PR TITLE
fix(copyright): stop reading PEP 643 field names as authors

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -1772,6 +1772,19 @@ pub(in super::super) fn extract_parenthesized_inline_by_authors(
     authors
 }
 
+/// Whether the text is Python core metadata.
+///
+/// Field names are case-insensitive — the format inherits RFC 822 headers — even
+/// though tools write the canonical `Metadata-Version`.
+fn looks_like_python_core_metadata(prepared_cache: &PreparedLines<'_>) -> bool {
+    prepared_cache.iter().any(|line| {
+        line.prepared
+            .trim_start()
+            .to_ascii_lowercase()
+            .starts_with("metadata-version:")
+    })
+}
+
 /// Python core-metadata fields whose value is a field or extra *name*, never a
 /// person.
 ///
@@ -1792,11 +1805,7 @@ pub(in super::super) fn drop_metadata_field_listing_authors(
     prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
-    let has_metadata = prepared_cache
-        .iter()
-        .any(|line| line.prepared.trim_start().starts_with("Metadata-Version:"));
-
-    if !has_metadata {
+    if !looks_like_python_core_metadata(prepared_cache) {
         return;
     }
 
@@ -1830,11 +1839,7 @@ pub(in super::super) fn merge_metadata_author_and_email_lines(
     prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,
 ) {
-    let has_metadata = prepared_cache
-        .iter()
-        .any(|line| line.prepared.trim_start().starts_with("Metadata-Version:"));
-
-    if !has_metadata {
+    if !looks_like_python_core_metadata(prepared_cache) {
         return;
     }
 

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -1772,6 +1772,60 @@ pub(in super::super) fn extract_parenthesized_inline_by_authors(
     authors
 }
 
+/// Python core-metadata fields whose value is a field or extra *name*, never a
+/// person.
+///
+/// PEP 643's `Dynamic:` lists which fields a build may fill in, so
+/// `Dynamic: author` declares that the *author field* is dynamic — it does not
+/// name anybody. `Provides-Extra:` names an optional dependency group the same
+/// way.
+const NAME_LISTING_METADATA_FIELDS: &[&str] = &["dynamic:", "provides-extra:"];
+
+/// Drop authors read entirely out of field-name declarations.
+///
+/// The tagger sees the bare word `author` and tags it as an author keyword with
+/// no idea it is a field's *value*, so the lines following `Dynamic: author`
+/// were read as the name — a wheel `METADATA` reported an author of
+/// `Dynamic classifier Dynamic`. Line context only exists out here, which is why
+/// the filter lives at this stage rather than in the tagger or the grammar.
+pub(in super::super) fn drop_metadata_field_listing_authors(
+    prepared_cache: &PreparedLines<'_>,
+    authors: &mut Vec<AuthorDetection>,
+) {
+    let has_metadata = prepared_cache
+        .iter()
+        .any(|line| line.prepared.trim_start().starts_with("Metadata-Version:"));
+
+    if !has_metadata {
+        return;
+    }
+
+    authors.retain(|author| {
+        let mut line_number = author.start_line;
+        let mut saw_line = false;
+
+        while line_number <= author.end_line {
+            let Some(line) = prepared_cache.line(line_number) else {
+                break;
+            };
+            let lower = line.prepared.trim_start().to_ascii_lowercase();
+            if !lower.is_empty() {
+                saw_line = true;
+                if !NAME_LISTING_METADATA_FIELDS
+                    .iter()
+                    .any(|field| lower.starts_with(field))
+                {
+                    // Some source line is ordinary prose, so keep the author.
+                    return true;
+                }
+            }
+            line_number = line_number.next();
+        }
+
+        !saw_line
+    });
+}
+
 pub(in super::super) fn merge_metadata_author_and_email_lines(
     prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -110,6 +110,7 @@ fn run_author_extraction_and_repairs(
 
     let a_before = authors.len();
     super::author_heuristics::merge_metadata_author_and_email_lines(prepared_cache, authors);
+    super::author_heuristics::drop_metadata_field_listing_authors(prepared_cache, authors);
     seen.dedup_new_authors(authors, a_before);
 
     let mut new_a = super::author_heuristics::extract_debian_maintainer_authors(prepared_cache);

--- a/src/copyright/detector/tests_structured_metadata.rs
+++ b/src/copyright/detector/tests_structured_metadata.rs
@@ -545,3 +545,24 @@ fn test_a_real_author_survives_alongside_dynamic_field_names() {
 
     assert_eq!(values, vec!["Jane Smith"]);
 }
+
+#[test]
+fn test_lowercase_metadata_version_still_gates_the_field_name_filter() {
+    // Core metadata inherits RFC 822 header semantics, so field names are
+    // case-insensitive even though tools write the canonical spelling.
+    let input = concat!(
+        "metadata-version: 2.2\n",
+        "name: kubernetes\n",
+        "Dynamic: author\n",
+        "Dynamic: classifier\n",
+        "Dynamic: description\n",
+    );
+
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+
+    assert!(
+        values.is_empty(),
+        "no author is declared here, got {values:?}"
+    );
+}

--- a/src/copyright/detector/tests_structured_metadata.rs
+++ b/src/copyright/detector/tests_structured_metadata.rs
@@ -504,3 +504,44 @@ fn test_wheel_metadata_author_email_with_a_value_still_merges() {
     // only evidence the pairing happened at all.
     assert_eq!(authors[0].end_line, authors[0].start_line.next());
 }
+
+#[test]
+fn test_dynamic_metadata_field_names_are_not_authors() {
+    // PEP 643's `Dynamic:` lists which fields a build may fill in, so
+    // `Dynamic: author` declares that the author *field* is dynamic. The tagger
+    // sees only the bare word and read the following lines as a name, giving a
+    // wheel METADATA an author of "Dynamic classifier Dynamic".
+    let input = concat!(
+        "Metadata-Version: 2.2\n",
+        "Name: kubernetes\n",
+        "Dynamic: author\n",
+        "Dynamic: classifier\n",
+        "Dynamic: description\n",
+    );
+
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+
+    assert!(
+        values.is_empty(),
+        "no author is declared here, got {values:?}"
+    );
+}
+
+#[test]
+fn test_a_real_author_survives_alongside_dynamic_field_names() {
+    // The filter must key on the source lines, not on the presence of `Dynamic:`
+    // anywhere in the file.
+    let input = concat!(
+        "Metadata-Version: 2.2\n",
+        "Author: Jane Smith\n",
+        "Author-email: jane@example.com\n",
+        "Dynamic: author\n",
+        "Dynamic: classifier\n",
+    );
+
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+
+    assert_eq!(values, vec!["Jane Smith"]);
+}


### PR DESCRIPTION
## Summary

The same `python36-kubernetes` metadata that hangs a copyright scan (#1360) also reports a bogus author:

```
authors: ["Dynamic classifier Dynamic"]
```

PEP 643's `Dynamic:` lists which fields a build may fill in, so `Dynamic: author` declares that the *author field* is dynamic — it names nobody. The tagger sees only the bare word `author` and tags it as an author keyword with no notion that it is a field's **value**, so the grammar read the following lines as the name. `Provides-Extra:` names an optional dependency group the same way.

Pre-existing and independent of the hang — it reproduces on the current release binary — which is why it is a separate PR.

## Scope and exclusions

- Filters the result where line context exists, rather than teaching the tagger or the grammar about field syntax. The tagger matches single tokens and has no line context; the grammar rules for `Auth` are used by dozens of patterns, so changing either to fix one false positive risks far more than it repairs.
- Drops an author only when **every** source line behind it is a name-listing metadata declaration. Any ordinary prose line keeps the author, so a real `Author:` in the same file is untouched.
- Gated on the file being Python core metadata (`Metadata-Version:` present), so nothing outside that format changes.

## How to verify

```sh
printf 'Metadata-Version: 2.2\nName: kubernetes\nDynamic: author\nDynamic: classifier\nDynamic: description\n' > /tmp/m
provenant scan --json-pp - --copyright /tmp/m | jq '.files[].authors'
```

Before: `["Dynamic classifier Dynamic"]`. After: empty.

Worth poking at the case that must not regress: the same file with a real `Author: Jane Smith` / `Author-email:` pair *and* the `Dynamic:` lines still reports `Jane Smith`.

## Follow-up work

- Created or intentionally deferred: the root cause is that `author` is tagged as a keyword without knowing whether it is a field's key or its value. `Foo: author` followed by a name still produces an author outside Python metadata — plausible in some formats, wrong in others, and not something this report gives evidence to settle. Narrowing the tag itself would need line context threaded into the tagger and revalidation against the whole copyright corpus; that is a much larger change than this false positive justifies.

## Expected-output fixture changes

- None. All 36 copyright goldens, 324 parser goldens and the full 5,681-test lib suite pass unchanged; covered by two new unit tests, one per direction.