### PR TITLE
docs(copyright): record why the author keyword is narrowed to one format

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -1801,6 +1801,17 @@ const NAME_LISTING_METADATA_FIELDS: &[&str] = &["dynamic:", "provides-extra:"];
 /// were read as the name — a wheel `METADATA` reported an author of
 /// `Dynamic classifier Dynamic`. Line context only exists out here, which is why
 /// the filter lives at this stage rather than in the tagger or the grammar.
+///
+/// Narrowed to this format rather than to every `<Key>: author` line, which a
+/// scan of 25,290 real-world files argues against: of the three that carry such a
+/// line, none produced a false author, and one — a YAML `role: author` above
+/// `name: Spencer Alger` — names a real person the broader rule would have
+/// discarded. The keyword only reaches the next line when that line reads like a
+/// bare name, which lowercase YAML keys do not.
+///
+/// Python core metadata is narrowed because its specification settles the
+/// meaning rather than leaving it to the shape of the next line: `Dynamic:` and
+/// `Provides-Extra:` take field and extra names, never people.
 pub(in super::super) fn drop_metadata_field_listing_authors(
     prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,


### PR DESCRIPTION
## Summary

#1361 left one question open: should the underlying keyword be narrowed further? A line whose *value* happens to be `author` introduces the next line as a name — wrong for `Dynamic: author`, right for a bare `Author` heading.

Settled by measurement, against a real-world corpus rather than the fixtures. **The evidence argues against widening.**

- **25,290 files scanned**, 4,615 author detections. **None** was seeded by a `<Key>: author` line.
- Only **three** files in that corpus carry the shape at all, and they cut against a broader rule:
  - a YAML `role: author` directly above `name: Spencer Alger` — a **real person a blanket rule would have discarded**;
  - a Debian `Copyright: Authors` above `License: Public-Domain`, already excluded.
- The reason both are safe: the keyword only reaches the next line when that line reads like a bare name, which lowercase YAML keys do not. That is also why `Dynamic: classifier` — capitalised — did fire, and is exactly the case #1361 fixed.

So a general rule against `<Key>: author` would trade a real author for a case with zero observed occurrences.

## Scope and exclusions

- Doc comment only; no behaviour change.
- Python core metadata stays the one narrowed context because its *specification* settles the meaning rather than leaving it to the shape of the next line: `Dynamic:` and `Provides-Extra:` take field and extra names, never people.

## Issues

- Covers: the open question recorded in #1361.

## How to verify

```sh
provenant --copyright --json /tmp/a.json reference/scancode-toolkit/tests
rg -lIe '^\s*[A-Za-z][\w.-]*\s*:\s*[Aa]uthors?\s*$' reference/scancode-toolkit/tests   # 3 files
```

Then check whether any detected author starts on the line after one of those — none does. The two shapes are worth scanning directly, since they are the ones a broader rule would have changed.

## Follow-up work

- None. The question this records is answered; the measurement above is what would have to change to reopen it.