### PR TITLE
fix(copyright): keep a wrapped notice whole up to "all rights reserved"

### DIFF
--- a/src/copyright/detector/tests_multiline_repairs.rs
+++ b/src/copyright/detector/tests_multiline_repairs.rs
@@ -585,3 +585,33 @@ fn test_et_al_trailing_period_is_source_faithful() {
         "bare marker must stay bare (no period force-added): {bare:?}"
     );
 }
+
+// The IETF RFC boilerplate wraps a long holder phrase across two lines and ends
+// in "All rights reserved.". The statement must come back as one detection
+// spanning both lines, not truncated at the line break (and not as a truncated
+// prefix alongside a longer one).
+#[test]
+fn test_multiline_wrapped_holder_phrase_before_all_rights_reserved() {
+    let input = "   Copyright (c) 2015 IETF Trust and the persons identified as the\n   document authors.  All rights reserved.\n";
+    let (copyrights, holders, _a) = detect_copyrights_from_text(input);
+    assert_eq!(
+        copyrights
+            .iter()
+            .map(|c| (c.copyright.as_str(), c.start_line.get(), c.end_line.get()))
+            .collect::<Vec<_>>(),
+        vec![(
+            "Copyright (c) 2015 IETF Trust and the persons identified as the document authors",
+            1,
+            2
+        )],
+        "wrapped statement must be one full-span detection: {copyrights:?}"
+    );
+    assert_eq!(
+        holders
+            .iter()
+            .map(|h| h.holder.as_str())
+            .collect::<Vec<_>>(),
+        vec!["IETF Trust and the persons identified as the document authors"],
+        "holder must carry the whole wrapped phrase: {holders:?}"
+    );
+}

--- a/src/copyright/grammar/rules.rs
+++ b/src/copyright/grammar/rules.rs
@@ -5450,71 +5450,14 @@ pub(crate) static GRAMMAR_RULES: &[GrammarRule] = &[
             Label(AllRightReserved),
         ],
     },
-    // #99999 catch-all (broad matcher, expanded to 1-3 middle elements)
+    // #99999 catch-all: the upstream middle element is `+`, so a notice of any
+    // length between the copyright marker and "all rights reserved" is one
+    // statement.
     GrammarRule {
         label: Copyright,
         pattern: &[
             AnyTagOrLabel(&[Copy], &[Copyright, Copyright2, NameCopy]),
-            AnyTagOrLabel(
-                &[
-                    Copy, Nnp, AuthDot, Caps, Cd, Cds, Pn, Comp, Uni, Cc, Of, In, By, Oth, Van,
-                    Email, MixedCap, Nn,
-                ],
-                &[
-                    YrRange, Name, NameEmail, NameYear, NameCopy, NameCaps, Company,
-                ],
-            ),
-            Label(AllRightReserved),
-        ],
-    },
-    GrammarRule {
-        label: Copyright,
-        pattern: &[
-            AnyTagOrLabel(&[Copy], &[Copyright, Copyright2, NameCopy]),
-            AnyTagOrLabel(
-                &[
-                    Copy, Nnp, AuthDot, Caps, Cd, Cds, Pn, Comp, Uni, Cc, Of, In, By, Oth, Van,
-                    Email, MixedCap, Nn,
-                ],
-                &[
-                    YrRange, Name, NameEmail, NameYear, NameCopy, NameCaps, Company,
-                ],
-            ),
-            AnyTagOrLabel(
-                &[
-                    Copy, Nnp, AuthDot, Caps, Cd, Cds, Pn, Comp, Uni, Cc, Of, In, By, Oth, Van,
-                    Email, MixedCap, Nn,
-                ],
-                &[
-                    YrRange, Name, NameEmail, NameYear, NameCopy, NameCaps, Company,
-                ],
-            ),
-            Label(AllRightReserved),
-        ],
-    },
-    GrammarRule {
-        label: Copyright,
-        pattern: &[
-            AnyTagOrLabel(&[Copy], &[Copyright, Copyright2, NameCopy]),
-            AnyTagOrLabel(
-                &[
-                    Copy, Nnp, AuthDot, Caps, Cd, Cds, Pn, Comp, Uni, Cc, Of, In, By, Oth, Van,
-                    Email, MixedCap, Nn,
-                ],
-                &[
-                    YrRange, Name, NameEmail, NameYear, NameCopy, NameCaps, Company,
-                ],
-            ),
-            AnyTagOrLabel(
-                &[
-                    Copy, Nnp, AuthDot, Caps, Cd, Cds, Pn, Comp, Uni, Cc, Of, In, By, Oth, Van,
-                    Email, MixedCap, Nn,
-                ],
-                &[
-                    YrRange, Name, NameEmail, NameYear, NameCopy, NameCaps, Company,
-                ],
-            ),
-            AnyTagOrLabel(
+            OneOrMoreTagOrLabel(
                 &[
                     Copy, Nnp, AuthDot, Caps, Cd, Cds, Pn, Comp, Uni, Cc, Of, In, By, Oth, Van,
                     Email, MixedCap, Nn,

--- a/src/copyright/grammar/types.rs
+++ b/src/copyright/grammar/types.rs
@@ -25,6 +25,10 @@ pub(crate) enum TagMatcher {
     AnyLabel(&'static [TreeLabel]),
     /// Match any of several tags OR labels.
     AnyTagOrLabel(&'static [PosTag], &'static [TreeLabel]),
+    /// Match one or more consecutive nodes, each matching any of the tags or
+    /// labels. Ports the `+` repetition of the upstream Python grammar; the
+    /// following matcher acts as the anchor that ends the run.
+    OneOrMoreTagOrLabel(&'static [PosTag], &'static [TreeLabel]),
 }
 
 /// A grammar rule: matches a pattern and produces a tree node with the given label.

--- a/src/copyright/parser.rs
+++ b/src/copyright/parser.rs
@@ -10,8 +10,19 @@
 use std::time::Instant;
 
 use super::grammar::{GRAMMAR_RULES, GrammarRule, TagMatcher};
-use super::types::{ParseNode, Token};
+use super::types::{ParseNode, PosTag, Token, TreeLabel};
 use crate::models::LineNumber;
+
+/// Upper bound on how many nodes a single repeating matcher may consume.
+///
+/// A bound is needed because a rule anchored on a trailing marker will happily
+/// span whatever sits in front of it: degenerate input (minified data that lexes
+/// into thousands of `NN` tokens before an incidental "all rights reserved")
+/// would otherwise collapse into one multi-kilobyte statement. The cap keeps
+/// such a merge to roughly a kilobyte, and no fixture in the golden corpus needs
+/// more than a quarter of it, so real notices are unaffected. A run longer than
+/// this leaves the anchor out of reach and the rule simply does not fire.
+const MAX_REPETITION: usize = 256;
 
 fn first_line(node: &ParseNode) -> Option<LineNumber> {
     match node {
@@ -75,26 +86,28 @@ pub fn parse_with_deadline(tokens: Vec<Token>, deadline: Option<Instant>) -> Vec
 /// Try to apply a single grammar rule to the node sequence.
 /// Returns `Some(new_nodes)` if the rule matched somewhere, `None` otherwise.
 fn try_apply_rule(rule: &GrammarRule, nodes: &[ParseNode]) -> Option<Vec<ParseNode>> {
-    let pattern_len = rule.pattern.len();
-    if pattern_len == 0 || nodes.len() < pattern_len {
+    // Every matcher consumes at least one node, so the pattern length is a
+    // lower bound on the span a match can cover.
+    let min_len = rule.pattern.len();
+    if min_len == 0 || nodes.len() < min_len {
         return None;
     }
 
     // Scan for the first position where the pattern matches.
-    for start in 0..=(nodes.len() - pattern_len) {
-        if matches_at(rule, nodes, start) {
+    for start in 0..=(nodes.len() - min_len) {
+        if let Some(matched_len) = matches_at(rule, nodes, start) {
             // Build the replacement tree node.
-            let matched: Vec<ParseNode> = nodes[start..start + pattern_len].to_vec();
+            let matched: Vec<ParseNode> = nodes[start..start + matched_len].to_vec();
             let tree_node = ParseNode::Tree {
                 label: rule.label,
                 children: matched,
             };
 
             // Construct new node sequence: before + tree_node + after.
-            let mut new_nodes = Vec::with_capacity(nodes.len() - pattern_len + 1);
+            let mut new_nodes = Vec::with_capacity(nodes.len() - matched_len + 1);
             new_nodes.extend_from_slice(&nodes[..start]);
             new_nodes.push(tree_node);
-            new_nodes.extend_from_slice(&nodes[start + pattern_len..]);
+            new_nodes.extend_from_slice(&nodes[start + matched_len..]);
 
             return Some(new_nodes);
         }
@@ -104,7 +117,11 @@ fn try_apply_rule(rule: &GrammarRule, nodes: &[ParseNode]) -> Option<Vec<ParseNo
 }
 
 /// Check if a rule's pattern matches the node sequence at position `start`.
-fn matches_at(rule: &GrammarRule, nodes: &[ParseNode], start: usize) -> bool {
+///
+/// Returns the number of nodes consumed by the match. Fixed matchers consume one
+/// node each, so that is the pattern length unless the rule uses a repeating
+/// matcher.
+fn matches_at(rule: &GrammarRule, nodes: &[ParseNode], start: usize) -> Option<usize> {
     if rule.label == crate::copyright::types::TreeLabel::NameCopy
         && rule.pattern.len() == 2
         && matches!(
@@ -117,7 +134,7 @@ fn matches_at(rule: &GrammarRule, nodes: &[ParseNode], start: usize) -> bool {
         )
         && last_line(&nodes[start]) != first_line(&nodes[start + 1])
     {
-        return false;
+        return None;
     }
 
     if rule.label == crate::copyright::types::TreeLabel::Copyright2
@@ -134,7 +151,7 @@ fn matches_at(rule: &GrammarRule, nodes: &[ParseNode], start: usize) -> bool {
         && labels.contains(&crate::copyright::types::TreeLabel::Company)
         && last_line(&nodes[start]) != first_line(&nodes[start + 1])
     {
-        return false;
+        return None;
     }
 
     if rule.label == crate::copyright::types::TreeLabel::Copyright
@@ -149,15 +166,42 @@ fn matches_at(rule: &GrammarRule, nodes: &[ParseNode], start: usize) -> bool {
         )
         && last_line(&nodes[start]) != first_line(&nodes[start + 1])
     {
-        return false;
+        return None;
     }
 
-    for (i, matcher) in rule.pattern.iter().enumerate() {
-        if !matcher_matches(matcher, &nodes[start + i]) {
-            return false;
+    match_pattern(rule.pattern, &nodes[start..])
+}
+
+/// Match `pattern` against the front of `nodes`, returning the consumed length.
+///
+/// Repeating matchers are matched greedily and then backtracked so the anchor
+/// that follows them still gets a chance to match.
+fn match_pattern(pattern: &[TagMatcher], nodes: &[ParseNode]) -> Option<usize> {
+    let Some((matcher, rest)) = pattern.split_first() else {
+        return Some(0);
+    };
+
+    if let TagMatcher::OneOrMoreTagOrLabel(tags, labels) = matcher {
+        let repeat_limit = nodes
+            .iter()
+            .take(MAX_REPETITION)
+            .take_while(|node| tag_or_label_matches(node, tags, labels))
+            .count();
+        // Longest run first so the repetition stays greedy, as in the upstream
+        // Python grammar.
+        for taken in (1..=repeat_limit).rev() {
+            if let Some(len) = match_pattern(rest, &nodes[taken..]) {
+                return Some(taken + len);
+            }
         }
+        return None;
     }
-    true
+
+    let node = nodes.first()?;
+    if !matcher_matches(matcher, node) {
+        return None;
+    }
+    match_pattern(rest, &nodes[1..]).map(|len| len + 1)
 }
 
 /// Check if a single `TagMatcher` matches a single `ParseNode`.
@@ -183,20 +227,25 @@ fn matcher_matches(matcher: &TagMatcher, node: &ParseNode) -> bool {
             }
         }
 
-        TagMatcher::AnyTagOrLabel(tags, labels) => {
-            if let Some(node_tag) = node.tag()
-                && tags.contains(&node_tag)
-            {
-                return true;
-            }
-            if let Some(node_label) = node.label()
-                && labels.contains(&node_label)
-            {
-                return true;
-            }
-            false
+        TagMatcher::AnyTagOrLabel(tags, labels) | TagMatcher::OneOrMoreTagOrLabel(tags, labels) => {
+            tag_or_label_matches(node, tags, labels)
         }
     }
+}
+
+/// Whether a node carries any of the given POS tags or tree labels.
+fn tag_or_label_matches(node: &ParseNode, tags: &[PosTag], labels: &[TreeLabel]) -> bool {
+    if let Some(node_tag) = node.tag()
+        && tags.contains(&node_tag)
+    {
+        return true;
+    }
+    if let Some(node_label) = node.label()
+        && labels.contains(&node_label)
+    {
+        return true;
+    }
+    false
 }
 
 #[cfg(test)]

--- a/src/copyright/parser_test.rs
+++ b/src/copyright/parser_test.rs
@@ -108,3 +108,51 @@ fn test_matcher_any_tag() {
         &node
     ));
 }
+
+#[test]
+fn test_match_pattern_repetition_is_greedy_and_backtracks_to_anchor() {
+    let pattern = [
+        TagMatcher::Tag(PosTag::Copy),
+        TagMatcher::OneOrMoreTagOrLabel(&[PosTag::Nn], &[]),
+        TagMatcher::Tag(PosTag::Reserved),
+    ];
+    let nodes: Vec<ParseNode> = [
+        make_token("Copyright", PosTag::Copy, 1),
+        make_token("a", PosTag::Nn, 1),
+        make_token("b", PosTag::Nn, 1),
+        make_token("c", PosTag::Nn, 1),
+        make_token("reserved.", PosTag::Reserved, 2),
+        make_token("tail", PosTag::Nn, 2),
+    ]
+    .into_iter()
+    .map(ParseNode::Leaf)
+    .collect();
+
+    // Greedy over the three NN tokens, then backtracked so the anchor matches;
+    // the trailing token stays outside the match.
+    assert_eq!(match_pattern(&pattern, &nodes), Some(5));
+
+    // Repetition needs at least one node.
+    assert_eq!(match_pattern(&pattern, &nodes[..1]), None);
+    assert_eq!(
+        match_pattern(&pattern, &[nodes[0].clone(), nodes[4].clone()]),
+        None
+    );
+}
+
+#[test]
+fn test_match_pattern_repetition_is_bounded() {
+    let pattern = [
+        TagMatcher::Tag(PosTag::Copy),
+        TagMatcher::OneOrMoreTagOrLabel(&[PosTag::Nn], &[]),
+        TagMatcher::Tag(PosTag::Reserved),
+    ];
+    let mut tokens = vec![make_token("Copyright", PosTag::Copy, 1)];
+    tokens.extend((0..MAX_REPETITION + 1).map(|_| make_token("word", PosTag::Nn, 1)));
+    tokens.push(make_token("reserved.", PosTag::Reserved, 1));
+    let nodes: Vec<ParseNode> = tokens.into_iter().map(ParseNode::Leaf).collect();
+
+    // A run longer than the cap leaves the anchor out of reach, so degenerate
+    // input cannot collapse into one enormous statement.
+    assert_eq!(match_pattern(&pattern, &nodes), None);
+}

--- a/testdata/copyright-golden/all-rights-reserved/wrapped_holder_phrase_before_all_rights_reserved.txt
+++ b/testdata/copyright-golden/all-rights-reserved/wrapped_holder_phrase_before_all_rights_reserved.txt
@@ -1,0 +1,4 @@
+Copyright Notice
+
+   Copyright (c) 2015 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.

--- a/testdata/copyright-golden/all-rights-reserved/wrapped_holder_phrase_before_all_rights_reserved.txt.yml
+++ b/testdata/copyright-golden/all-rights-reserved/wrapped_holder_phrase_before_all_rights_reserved.txt.yml
@@ -1,0 +1,8 @@
+what:
+  - copyrights
+  - holders
+  - authors
+copyrights:
+  - Copyright (c) 2015 IETF Trust and the persons identified as the document authors
+holders:
+  - IETF Trust and the persons identified as the document authors

--- a/testdata/copyright-golden/copyrights/misco2/distributed_8.txt.yml
+++ b/testdata/copyright-golden/copyrights/misco2/distributed_8.txt.yml
@@ -4,7 +4,7 @@ what:
   - holders_summary
 copyrights:
   - (c) Distributed via COMTEX News. (c) YYYY A&G Information Services
-  - copyright (c) Distributed via COMTEX News
+  - copyright (c) Distributed via COMTEX News. (c) YYYY A&G Information Services
 holders:
   - Distributed via COMTEX News. YYYY A&G Information Services
 holders_summary:

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/include/linux/pnfs_osd_xdr.h.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/include/linux/pnfs_osd_xdr.h.yml
@@ -3,9 +3,6 @@ what:
   - holders
   - authors
 copyrights:
-  - Copyright (c) 2007 Panasas Inc.
   - Copyright (c) 2007 Panasas Inc. year of first publication
 holders:
-  - Panasas Inc.
   - Panasas Inc. year of first publication
-authors: []


### PR DESCRIPTION
## Summary

- A copyright notice whose holder phrase wraps across lines was cut at the line break, and a shorter prefix of the same statement was emitted as a second detection. The reported case is the IETF RFC boilerplate in `erlang/otp`, which came back as `Copyright (c) 2015 IETF Trust` **and** `Copyright (c) 2015 IETF Trust and the persons identified as the` instead of one statement ending in `document authors`.
- Root cause: the last-resort `#99999` grammar rule was ported with the upstream `+` repetition flattened into one, two, or three fixed middle elements. Eight middle tokens exceed that, so the rule never fired; the tree kept only the leading `Copyright (c) <year> <name>` node and the wrapped words stayed loose leaves, leaving the span-based fallbacks to emit line-truncated fragments.
- The grammar matcher now has a real one-or-more element (`OneOrMoreTagOrLabel`), matched greedily and backtracked to its following anchor, and `#99999` is expressed with it instead of three hand-expanded copies.

## Issues

- Closes: #1364

## Scope and exclusions

- Included: grammar matcher repetition support, the `#99999` rule, a golden fixture for the wrapped-notice shape, and detector/parser regression tests.
- Explicit exclusions: `distributed_8.txt` still emits the same statement twice — once with the `copyright` word that Provenant derives from the surrounding `<copyright>` markup, once without. That duplicate pair predates this change and is a separate rendering question, so it is left alone.

## How to verify

```bash
curl -sfLO https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e/lib/diameter/doc/standard/rfc7683.txt
cargo run --release -- scan --json-pp - --license --copyright --compat-mode scancode rfc7683.txt
```

Expect a single detection, `Copyright (c) 2015 IETF Trust and the persons identified as the document authors`, spanning lines 41–42 — the value the issue asks for.

Worth poking beyond CI: other notices where a party list or holder phrase wraps before `All rights reserved.`, since the repetition is now unbounded (capped at 256 nodes) where it used to stop at three. Multi-line notices *without* an `all rights reserved` terminator are unaffected — the rule is anchored on it.

## Intentional differences from Python

- None new. The change moves toward upstream: the rule now has the upstream `+` semantics rather than a truncated approximation of it.

## Expected-output fixture changes

- Files changed:
  - `testdata/copyright-golden/copyrights/misco4/linux-copyrights/include/linux/pnfs_osd_xdr.h.yml`
  - `testdata/copyright-golden/copyrights/misco2/distributed_8.txt.yml`
  - new: `testdata/copyright-golden/all-rights-reserved/wrapped_holder_phrase_before_all_rights_reserved.txt{,.yml}`
- Why the new expected output is correct: both updated fixtures lose exactly one duplicate truncated prefix — the same defect as the issue. `pnfs_osd_xdr.h` now matches the upstream ScanCode expectation byte for byte (synced from the Python reference, not from actuals). `distributed_8.txt` keeps its two entries but both now carry the whole statement rather than one being a cut-short copy of the other. The new fixture pins the reported wrapped-notice shape in the Provenant-owned `all-rights-reserved` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
