### PR TITLE
fix(copyright): report an xml copyright block once, over its real span

### DIFF
--- a/src/copyright/detector/pattern_extract/extraction/content.rs
+++ b/src/copyright/detector/pattern_extract/extraction/content.rs
@@ -692,7 +692,13 @@ pub fn extract_xml_copyright_tag_c_lines(
         }
 
         let mut bodies: Vec<String> = Vec::new();
-        for raw_line in inner.lines() {
+        // The combined statement spans every line that contributes a segment, so
+        // track the last one instead of collapsing the span onto the tag line.
+        let mut last_line = ln;
+        let mut offset = cap.name("body").map(|m| m.start()).unwrap_or(0);
+        for raw_line in inner.split_inclusive('\n') {
+            let line_start = offset;
+            offset += raw_line.len();
             let prepared = crate::copyright::prepare::prepare_text_line(raw_line);
             let line = prepared.trim();
             if line.is_empty() {
@@ -718,6 +724,7 @@ pub fn extract_xml_copyright_tag_c_lines(
             if body.is_empty() {
                 continue;
             }
+            last_line = last_line.max(line_number_index.line_number_at_offset(line_start));
             bodies.push(body);
         }
 
@@ -731,10 +738,18 @@ pub fn extract_xml_copyright_tag_c_lines(
             .collect::<Vec<_>>()
             .join(" ");
         if let Some(cr) = refine_copyright(&combined) {
+            // The grammar path reads the `<copyright>` opener as a bare marker and
+            // reports this same statement with that tag word glued to the front.
+            // The tag name is not part of the notice, so the combined value
+            // supersedes it — mirroring the per-line holder cleanup below.
+            let tag_prefixed = format!("copyright {cr}");
+            copyrights.retain(|c| {
+                !(c.start_line == ln && c.copyright.eq_ignore_ascii_case(&tag_prefixed))
+            });
             copyrights.push(CopyrightDetection {
                 copyright: cr,
                 start_line: ln,
-                end_line: ln,
+                end_line: last_line,
             });
         }
 
@@ -743,7 +758,7 @@ pub fn extract_xml_copyright_tag_c_lines(
             holders.push(HolderDetection {
                 holder: h,
                 start_line: ln,
-                end_line: ln,
+                end_line: last_line,
             });
         }
 

--- a/src/copyright/detector/tests_multiline_repairs.rs
+++ b/src/copyright/detector/tests_multiline_repairs.rs
@@ -615,3 +615,61 @@ fn test_multiline_wrapped_holder_phrase_before_all_rights_reserved() {
         "holder must carry the whole wrapped phrase: {holders:?}"
     );
 }
+
+// A `<copyright>` element whose body carries one `(c)` segment per line is
+// reported once, spanning the lines it actually covers. The grammar path reads
+// the tag opener as a bare `copyright` marker and would otherwise report the
+// same statement a second time with that tag word glued on.
+#[test]
+fn test_xml_copyright_tag_block_reports_one_statement_over_its_real_span() {
+    let input = "<copyright>(c) Distributed via COMTEX News. \n                   (c) YYYY A&G Information Services, all rights reserved.\n        </copyright>\n";
+    let (copyrights, holders, _a) = detect_copyrights_from_text(input);
+    assert_eq!(
+        copyrights
+            .iter()
+            .map(|c| (c.copyright.as_str(), c.start_line.get(), c.end_line.get()))
+            .collect::<Vec<_>>(),
+        vec![(
+            "(c) Distributed via COMTEX News. (c) YYYY A&G Information Services",
+            1,
+            2
+        )],
+        "one statement, no tag-word duplicate, span covers both segments: {copyrights:?}"
+    );
+    assert_eq!(
+        holders
+            .iter()
+            .map(|h| (h.holder.as_str(), h.start_line.get(), h.end_line.get()))
+            .collect::<Vec<_>>(),
+        vec![(
+            "Distributed via COMTEX News. YYYY A&G Information Services",
+            1,
+            2
+        )],
+        "holder carries the same span as its statement: {holders:?}"
+    );
+}
+
+// The tag word is still needed as a marker when it is the only thing that makes
+// the notice detectable, so the cleanup above must not strip it there.
+#[test]
+fn test_xml_copyright_tag_word_still_marks_a_single_line_notice() {
+    let (copyrights, holders, _a) =
+        detect_copyrights_from_text("<Copyright>MaxRev \u{a9} 2026</Copyright>\n");
+    assert_eq!(
+        copyrights
+            .iter()
+            .map(|c| c.copyright.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Copyright MaxRev (c) 2026"],
+        "single-segment block keeps the tag-derived marker: {copyrights:?}"
+    );
+    assert_eq!(
+        holders
+            .iter()
+            .map(|h| h.holder.as_str())
+            .collect::<Vec<_>>(),
+        vec!["MaxRev"],
+        "holder unaffected: {holders:?}"
+    );
+}

--- a/testdata/copyright-golden/copyrights/misco2/distributed_8.txt.yml
+++ b/testdata/copyright-golden/copyrights/misco2/distributed_8.txt.yml
@@ -4,7 +4,6 @@ what:
   - holders_summary
 copyrights:
   - (c) Distributed via COMTEX News. (c) YYYY A&G Information Services
-  - copyright (c) Distributed via COMTEX News. (c) YYYY A&G Information Services
 holders:
   - Distributed via COMTEX News. YYYY A&G Information Services
 holders_summary:


### PR DESCRIPTION
## Summary

- A `<copyright>` element whose body carries one `(c)` segment per line was reported **twice**: once as the combined statement, once as the same statement with a `copyright` word glued to the front. The prefix comes from the XML tag name, not from the notice text.
- `extract_xml_copyright_tag_c_lines` already drops the per-line **holders** it supersedes; it just never dropped the superseded **copyright**. The neighbouring extractor a few lines up does exactly that cleanup, so this brings the two into line.
- The combined detection also collapsed its span onto the tag line (`1–1` for a statement covering lines 1–2). Since the fix removes the prefixed entry that happened to carry the right span, the surviving entry has to carry it instead: `end_line` is now the last line that contributes a segment, for the statement and its holder.

## Issues

- Closes: #1370

## Scope and exclusions

- Included: the superseded-copyright cleanup and the span fix, both inside `extract_xml_copyright_tag_c_lines`.
- Explicit exclusions: the tag-derived marker itself stays. For a single-segment block such as `<Copyright>MaxRev © 2026</Copyright>` the tag word is the only thing that makes the notice detectable at all — that path is untouched and now has a test pinning it, so a later cleanup cannot quietly take the marker away.

## How to verify

```bash
provenant scan --json-pp - --copyright --compat-mode scancode \
  testdata/copyright-golden/copyrights/misco2/distributed_8.txt
```

One `copyrights` entry, `(c) Distributed via COMTEX News. (c) YYYY A&G Information Services`, spanning lines 1–2 — matching upstream's expectation for that fixture.

Worth poking beyond CI: other `<copyright>`-wrapped notices, particularly a block whose segments are separated by blank or non-`(c)` lines, where the last contributing line and the block's closing tag are far apart.

## Intentional differences from Python

- None new. This removes a Provenant-only extra entry, so the fixture now matches the upstream expectation exactly.

## Expected-output fixture changes

- Files changed: `testdata/copyright-golden/copyrights/misco2/distributed_8.txt.yml`
- Why the new expected output is correct: it drops the tag-prefixed duplicate and nothing else. The file is now byte-identical to `reference/scancode-toolkit/tests/cluecode/data/copyrights/misco2/distributed_8.txt.yml` — it was synced from the Python reference rather than from Provenant actuals, and `--list-mismatches` reports no remaining divergence for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
