### PR TITLE
test(copyright): pin the two properties that keep flattened `+` rules safe

### DIFF
--- a/src/copyright/parser_test.rs
+++ b/src/copyright/parser_test.rs
@@ -156,3 +156,174 @@ fn test_match_pattern_repetition_is_bounded() {
     // input cannot collapse into one enormous statement.
     assert_eq!(match_pattern(&pattern, &nodes), None);
 }
+
+/// Reduce a synthesized node sequence the way [`parse`] does, so a rule that
+/// consumes tree labels can be exercised without authoring text that happens to
+/// lex into them.
+#[cfg(test)]
+fn reduce_nodes(mut nodes: Vec<ParseNode>) -> Vec<ParseNode> {
+    use crate::copyright::grammar::GRAMMAR_RULES;
+    for _ in 0..50 {
+        let mut changed = false;
+        for rule in GRAMMAR_RULES.iter() {
+            if let Some(next) = try_apply_rule(rule, &nodes) {
+                nodes = next;
+                changed = true;
+                break;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    nodes
+}
+
+#[cfg(test)]
+fn empty_tree(label: TreeLabel) -> ParseNode {
+    ParseNode::Tree {
+        label,
+        children: vec![],
+    }
+}
+
+// Reduce with an explicit rule set, so a property can be attributed to the rule
+// under test instead of to whichever table rule happens to cover the same shape.
+#[cfg(test)]
+fn reduce_with(rules: &[GrammarRule], mut nodes: Vec<ParseNode>) -> Vec<ParseNode> {
+    for _ in 0..50 {
+        let mut changed = false;
+        for rule in rules {
+            if let Some(next) = try_apply_rule(rule, &nodes) {
+                nodes = next;
+                changed = true;
+                break;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    nodes
+}
+
+// Most rules ported from an upstream `<X|Y>+` element were written out at a fixed
+// width instead. That is only safe because a rule whose own label is also its
+// first element re-applies on the next pass of the fixpoint loop: the run grows
+// one element per pass, so the fixed width is not a ceiling. Exercise the rule
+// alone — against the whole table another rule covering the same shape would keep
+// this green after the recursion broke.
+#[test]
+fn test_fixpoint_loop_grows_a_left_recursive_rule_past_its_fixed_width() {
+    let rule = GrammarRule {
+        label: TreeLabel::Copyright,
+        pattern: &[
+            TagMatcher::Label(TreeLabel::Copyright),
+            TagMatcher::Label(TreeLabel::Name),
+        ],
+    };
+    for count in 1..=8 {
+        let mut nodes = vec![empty_tree(TreeLabel::Copyright)];
+        nodes.extend((0..count).map(|_| empty_tree(TreeLabel::Name)));
+        let reduced = reduce_with(std::slice::from_ref(&rule), nodes);
+        assert_eq!(
+            (reduced.len(), reduced.first().and_then(|n| n.label())),
+            (1, Some(TreeLabel::Copyright)),
+            "one width-2 left-recursive rule must absorb {count} names by iterating"
+        );
+    }
+}
+
+// The counterpart, and the reason #1364 existed: iteration cannot grow a rule
+// whose repetition is followed by an anchor, because each pass needs the anchor
+// adjacent to the run. Such a rule caps at its written width no matter how many
+// passes run, which is why these have to be expressed with the repeating matcher.
+#[test]
+fn test_fixpoint_loop_cannot_grow_an_anchored_rule_past_its_fixed_width() {
+    let anchored = GrammarRule {
+        label: TreeLabel::Copyright,
+        pattern: &[
+            TagMatcher::Label(TreeLabel::Copyright),
+            TagMatcher::Tag(PosTag::Nn),
+            TagMatcher::Label(TreeLabel::AllRightReserved),
+        ],
+    };
+    let repeating = GrammarRule {
+        label: TreeLabel::Copyright,
+        pattern: &[
+            TagMatcher::Label(TreeLabel::Copyright),
+            TagMatcher::OneOrMoreTagOrLabel(&[PosTag::Nn], &[]),
+            TagMatcher::Label(TreeLabel::AllRightReserved),
+        ],
+    };
+    let sequence = |middles: usize| {
+        let mut nodes = vec![empty_tree(TreeLabel::Copyright)];
+        nodes.extend(
+            (0..middles)
+                .map(|_| make_token("word", PosTag::Nn, 1))
+                .map(ParseNode::Leaf),
+        );
+        nodes.push(empty_tree(TreeLabel::AllRightReserved));
+        nodes
+    };
+
+    assert_eq!(
+        reduce_with(std::slice::from_ref(&anchored), sequence(1)).len(),
+        1,
+        "the anchored rule still matches at its written width"
+    );
+    for middles in 2..=6 {
+        assert!(
+            reduce_with(std::slice::from_ref(&anchored), sequence(middles)).len() > 1,
+            "iteration must not rescue an anchored rule at {middles} middles"
+        );
+        assert_eq!(
+            reduce_with(std::slice::from_ref(&repeating), sequence(middles)).len(),
+            1,
+            "the repeating matcher must cover {middles} middles"
+        );
+    }
+}
+
+// The behavioural guarantee the two properties above add up to: whatever the
+// table looks like, a copyright followed by a run longer than any single rule's
+// written width still comes back as one node. This holds through whichever rule
+// happens to cover it, so it survives a rule being rewritten and fails only if
+// the coverage disappears altogether.
+#[test]
+fn test_grammar_absorbs_a_name_run_longer_than_any_single_rule() {
+    for count in 1..=8 {
+        let mut nodes = vec![empty_tree(TreeLabel::Copyright)];
+        nodes.extend((0..count).map(|_| empty_tree(TreeLabel::Name)));
+        let reduced = reduce_nodes(nodes);
+        assert_eq!(
+            (reduced.len(), reduced.first().and_then(|n| n.label())),
+            (1, Some(TreeLabel::Copyright)),
+            "a copyright followed by {count} names must reduce to one node, got: {reduced:?}"
+        );
+    }
+}
+
+// The rules anchored on `ALLRIGHTRESERVED` are written out at two middle elements
+// each and, per the test above, iteration cannot grow them. Longer runs reach the
+// anchor only through the `#99999` catch-all, whose alternative set is a superset
+// of theirs and whose repetition is unbounded. Narrowing that set would resurrect
+// the truncation for the whole family at once.
+#[test]
+fn test_all_rights_reserved_anchor_is_reachable_past_the_fixed_width() {
+    for middles in 1..=10 {
+        let mut nodes = vec![empty_tree(TreeLabel::Copyright)];
+        nodes.extend(
+            (0..middles)
+                .map(|_| make_token("word", PosTag::Nn, 1))
+                .map(ParseNode::Leaf),
+        );
+        nodes.push(empty_tree(TreeLabel::AllRightReserved));
+        let reduced = reduce_nodes(nodes);
+        assert_eq!(
+            (reduced.len(), reduced.first().and_then(|n| n.label())),
+            (1, Some(TreeLabel::Copyright)),
+            "{middles} middle elements before the anchor must still reduce to one node, got: {reduced:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- #1369 proposed converting ~46 rules that were ported from an upstream `<X|Y>+` element by writing them out at a fixed width, on the theory that each carries the same silent ceiling that caused #1364. **The investigation does not support that** — no shape I could construct truncates. This PR lands the part that is worth keeping: an executable guard on the two properties that make those rules safe, since both are load-bearing and neither was covered.
- Recommend closing #1369 rather than doing the conversion. The reasoning and evidence are below and posted on the issue.

## Why the conversion is not warranted

**Property 1 — left recursion plus the fixpoint loop.** A rule whose own label is also its first element (`COPYRIGHT: {<COPYRIGHT> <NAME|NAME-YEAR>+}`, ported at widths 1 and 2) re-applies on the next pass of the parser's fixpoint loop. The run grows one element per pass, so the fixed width is not a ceiling. Verified: a `Copyright` node followed by 1–8 `Name` nodes reduces to a single node every time, even though the widest ported rule takes two.

**Property 2 — the `#99999` superset.** The rules anchored on `ALLRIGHTRESERVED` (`#2862` and friends) are each written out at two middle elements, and an anchored rule genuinely cannot grow by iteration — the anchor has to sit adjacent, which is exactly why #1364 broke. They are covered anyway because the `#99999` catch-all's alternative set is a superset of theirs and its repetition became unbounded in #1367. Verified: 1–10 middle elements before the anchor all reduce to a single node.

So #1367 did not fix one rule; it fixed the whole anchored family through the last-resort superset.

**Empirical check.** Realistic notices across the flagged families — long company lists after a copyright, `<NNP|CAPS>+ <COMP|COMPANY>+` runs, `<NN|NNP|CAPS>+ <CC> <OTH>`, `ANDCO` and-lists, `<NNP|PN>+ <NNP>+` personal-name runs, `COMPANY: {<NAME…>+ <OF> … }`, and `AUTHOR` lists of four to six parties — all return the complete statement, holder, and author. The one probe that first looked like a miss was my own harness not printing the `authors` array.

## Scope and exclusions

- Included: three parser-level tests, plus the small `reduce_nodes`/`reduce_with`/`empty_tree` helpers they need to exercise rules that consume tree labels without authoring text that happens to lex into them.
  - `test_fixpoint_loop_grows_a_left_recursive_rule_past_its_fixed_width` and `test_fixpoint_loop_cannot_grow_an_anchored_rule_past_its_fixed_width` assert the two directions against a **single locally-built rule**, so each result is attributable to the rule under test rather than to whichever table rule covers the same shape. Mutation-checked: breaking the recursion (changing that rule's label) fails the first one.
  - `test_grammar_absorbs_a_name_run_longer_than_any_single_rule` keeps the weaker behavioural guarantee over the real table — it holds through whichever rule covers the shape and fails only if coverage disappears entirely.
- Explicit exclusions: no rule-table change. Converting `#2862` and its siblings to the repeating matcher is a no-op today — it changes which rule fires, not the output — so it is churn against a 1882-fixture corpus for no user-visible gain. The residual fragility (that family depending on `#99999`) is what the second test now pins.

## Issues

- Covers: #1369

## How to verify

CI covers this fully — the tests are the deliverable. To see the properties bite: change the locally-built rule's label in `test_fixpoint_loop_grows_a_left_recursive_rule_past_its_fixed_width` (breaks the recursion → fails), or narrow `#99999`'s alternative list (→ `test_all_rights_reserved_anchor_is_reachable_past_the_fixed_width` fails).

## Expected-output fixture changes

- None. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
