### PR TITLE
fix(copyright): reject a bare `(c)` list label as a copyright sign

### DIFF
--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -896,3 +896,61 @@ fn test_changelog_update_copyright_year_bullet_not_detected() {
     );
     assert!(holders.is_empty(), "unexpected holders: {holders:?}");
 }
+
+#[test]
+fn test_alphabetic_list_label_is_not_a_copyright_sign() {
+    // `(C)` is also the third label of an alphabetic list, so RFC and other
+    // specification prose puts one at the head of an ordinary sentence
+    // (RFC 1123 §5.3.7, shipped in erlang/otp). A bare `(c)` notice names its
+    // holder right after the marker; enumerated prose puts a common noun there
+    // and only reaches a proper noun (`Internet`, `SMTP`) deeper into the
+    // sentence, which the span fallback used to accept as the holder anchor.
+    let content = "\
+         (A)  Blah
+         (B)  Bleh
+         (C)  From the Internet side, the gateway SHOULD accept all
+              valid address formats in SMTP commands and in RFC-822
+              headers, and all valid RFC-822 messages.  Although a
+              gateway must accept an RFC-822 explicit source route
+";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    assert!(
+        copyrights.is_empty(),
+        "unexpected copyrights: {copyrights:?}"
+    );
+    assert!(holders.is_empty(), "unexpected holders: {holders:?}");
+
+    // The list label alone — with no `(A)`/`(B)` siblings in view — is rejected
+    // on the same grounds, so a fragment or a lone clause is covered too.
+    let (copyrights, holders, _authors) =
+        detect_copyrights_from_text("(c)  From the Internet side, the gateway SHOULD accept all\n");
+    assert!(
+        copyrights.is_empty(),
+        "unexpected copyrights: {copyrights:?}"
+    );
+    assert!(holders.is_empty(), "unexpected holders: {holders:?}");
+}
+
+#[test]
+fn test_bare_c_sign_notices_naming_a_holder_are_kept() {
+    // The list-label rule must not touch a real bare `(c)` notice: the holder
+    // follows the marker directly, behind a year, or behind a leading
+    // determiner such as `The`/`by`.
+    for (text, expected) in [
+        (
+            "(c) Free Software Foundation, Inc.",
+            "Free Software Foundation, Inc.",
+        ),
+        ("(C) 2004 Acme Corporation", "Acme Corporation"),
+        ("(C) IBM Corp", "IBM Corp"),
+        ("(c) by John Doe <john@example.com>", "John Doe"),
+    ] {
+        let (copyrights, holders, _authors) = detect_copyrights_from_text(text);
+        assert!(!copyrights.is_empty(), "no copyright for {text:?}");
+        let vals: Vec<&String> = holders.iter().map(|h| &h.holder).collect();
+        assert!(
+            vals.iter().any(|h| h.as_str() == expected),
+            "expected holder {expected:?} in {vals:?} for {text:?}"
+        );
+    }
+}

--- a/src/copyright/detector/tree_walk/copyright/spans.rs
+++ b/src/copyright/detector/tree_walk/copyright/spans.rs
@@ -28,25 +28,85 @@ use crate::copyright::types::{
 /// fallback from manufacturing copyrights out of ordinary prose that merely
 /// mentions the word "copyright".
 fn span_has_strong_holder_or_year(span: &[&Token]) -> bool {
-    span.iter().any(|t| {
-        // The copyright marker itself is never the holder; excluding it stops an
-        // all-uppercase `COPYRIGHT` token from validating its own span.
-        t.tag != PosTag::Copy
-            && (detector::token_utils::is_year_like_token(t)
-                || matches!(
-                    t.tag,
-                    PosTag::Nnp
-                        | PosTag::Pn
-                        | PosTag::Caps
-                        | PosTag::MixedCap
-                        | PosTag::Comp
-                        | PosTag::Uni
-                        | PosTag::Email
-                        | PosTag::Url
-                        | PosTag::Url2
-                )
-                || is_acronym_like(&t.value))
-    })
+    span.iter().any(|t| is_strong_holder_or_year_token(t))
+}
+
+/// Whether one token can anchor a copyright span: a year, a proper noun /
+/// company / university token, an email or URL, or an organization acronym.
+fn is_strong_holder_or_year_token(t: &Token) -> bool {
+    // The copyright marker itself is never the holder; excluding it stops an
+    // all-uppercase `COPYRIGHT` token from validating its own span.
+    t.tag != PosTag::Copy
+        && (detector::token_utils::is_year_like_token(t)
+            || matches!(
+                t.tag,
+                PosTag::Nnp
+                    | PosTag::Pn
+                    | PosTag::Caps
+                    | PosTag::MixedCap
+                    | PosTag::Comp
+                    | PosTag::Uni
+                    | PosTag::Email
+                    | PosTag::Url
+                    | PosTag::Url2
+            )
+            || is_acronym_like(&t.value))
+}
+
+/// Whether the token is a bare `(c)` copyright sign, the only copyright marker
+/// that is also an ordinary alphabetic list label.
+fn is_bare_c_sign(token: &Token) -> bool {
+    token.tag == PosTag::Copy
+        && token
+            .value
+            .trim_end_matches(',')
+            .eq_ignore_ascii_case("(c)")
+}
+
+/// Whether a span led by a bare `(c)` sign names its holder right after the
+/// marker.
+///
+/// `(c)` doubles as an alphabetic list label — `(a) … (b) … (c) …` — so a `(c)`
+/// heading a prose sentence is routinely a list item rather than a notice. A
+/// real bare-`(c)` notice names its holder immediately (`(c) Free Software
+/// Foundation, Inc.`, `(c) The Regents of the University of California`), which
+/// is what the `<COPY> <NAME>` grammar production the span fallback stands in
+/// for requires. Enumerated prose instead puts a common noun there and only
+/// reaches a proper noun deeper into the sentence (`(c) From the Internet side,
+/// the gateway SHOULD accept all valid address formats in SMTP commands …`),
+/// which the span-wide [`span_has_strong_holder_or_year`] check cannot tell
+/// apart. Only a leading determiner may sit between the marker and the holder.
+///
+/// A span carrying a year is exempt: the year already proves the marker is a
+/// copyright sign, and a list label never carries one.
+fn bare_c_span_names_holder_up_front(span: &[&Token]) -> bool {
+    const LEADING_DETERMINERS: &[&str] = &["the", "a", "an", "by"];
+
+    if span
+        .iter()
+        .any(|t| detector::token_utils::is_year_like_token(t))
+    {
+        return true;
+    }
+
+    span.iter()
+        .skip(1)
+        .find(|t| {
+            let word = t
+                .value
+                .trim_matches(|c: char| !c.is_alphanumeric())
+                .to_ascii_lowercase();
+            !LEADING_DETERMINERS.contains(&word.as_str())
+        })
+        .is_some_and(|t| is_strong_holder_or_year_token(t))
+}
+
+/// Whether a fallback span carries a usable holder anchor. `leads_with_bare_c`
+/// tightens the check to an up-front holder when the span opens on a bare `(c)`
+/// sign; see [`bare_c_span_names_holder_up_front`].
+fn span_has_holder_anchor(span: &[&Token], leads_with_bare_c: bool) -> bool {
+    span_has_strong_holder_or_year(span)
+        && (!leads_with_bare_c || bare_c_span_names_holder_up_front(span))
 }
 
 /// A compound organization acronym (`INRIA-ENPC`, `AT&T`, `K3D`) that the POS
@@ -248,11 +308,12 @@ pub fn extract_from_spans(
 
             let span = &all_leaves[start..i];
             if span.len() > 1 {
+                let leads_with_bare_c = start == copy_idx && is_bare_c_sign(token);
                 let allow_single_word_contributors = span
                     .iter()
                     .any(|t| detector::token_utils::is_year_like_token(t));
                 let filtered = detector::token_utils::strip_all_rights_reserved_slice(span);
-                if span_has_strong_holder_or_year(&filtered)
+                if span_has_holder_anchor(&filtered, leads_with_bare_c)
                     && let Some(det) = detector::token_utils::build_copyright_from_tokens(&filtered)
                 {
                     copyrights.push(det);
@@ -262,7 +323,7 @@ pub fn extract_from_spans(
                     continue;
                 }
 
-                if !skip_holder_from_span && span_has_strong_holder_or_year(&filtered) {
+                if !skip_holder_from_span && span_has_holder_anchor(&filtered, leads_with_bare_c) {
                     let holder_span = filtered.as_slice();
                     let holder_tokens: Vec<&Token> = holder_span
                         .iter()
@@ -501,8 +562,9 @@ pub fn extract_copyrights_from_spans(
                     .iter()
                     .any(|t| detector::token_utils::is_year_like_token(t));
 
+                let leads_with_bare_c = start == copy_idx && is_bare_c_sign(token);
                 let filtered = detector::token_utils::strip_all_rights_reserved_slice(span);
-                if span_has_strong_holder_or_year(&filtered)
+                if span_has_holder_anchor(&filtered, leads_with_bare_c)
                     && let Some(det) = detector::token_utils::build_copyright_from_tokens(&filtered)
                 {
                     copyrights.push(det);
@@ -512,7 +574,7 @@ pub fn extract_copyrights_from_spans(
                     continue;
                 }
 
-                if !skip_holder_from_span && span_has_strong_holder_or_year(&filtered) {
+                if !skip_holder_from_span && span_has_holder_anchor(&filtered, leads_with_bare_c) {
                     let holder_span = filtered.as_slice();
                     let holder_tokens: Vec<&Token> = holder_span
                         .iter()


### PR DESCRIPTION
## Summary

- `(C)` is also the third label of an alphabetic list, so specification prose puts one at the head of an ordinary sentence. RFC 1123 §5.3.7 — shipped in `erlang/otp` as `lib/inets/doc/archive/rfc1123.txt` — reads `(C)  From the Internet side, the gateway SHOULD accept all valid address formats in SMTP commands ...`, and the whole sentence came back as a copyright, with `the Internet side, the gateway SHOULD accept ...` as its holder.
- The `<COPY> <NAME>` grammar production that the flat-span fallback stands in for names the holder *right after* the marker. The fallback instead accepted any proper noun anywhere in the span, so `Internet` and `SMTP` deeper into the sentence validated it.
- A span that opens on a bare `(c)` now has to name its holder up front — behind a leading determiner (`The`, `by`, `a`, `an`) at most. Spans carrying a year stay exempt: a year already proves the marker is a copyright sign, and a list label never has one.

## Issues

- Closes: #1365

## Scope and exclusions

- Included: the bare `(c)`/`(C)` marker in the two flat-span fallbacks (`extract_from_spans`, `extract_copyrights_from_spans`), for both the copyright and the holder it yields.
- Explicit exclusions: the unambiguous markers (`Copyright`, `©`, `Copr.`) keep the span-wide anchor rule — none of them doubles as a list label. A `(C)` list item whose text genuinely *starts* with a proper noun is still indistinguishable from a notice and is out of reach of this rule.

## How to verify

```
printf '         (A)  Blah\n         (B)  Bleh\n         (C)  From the Internet side, the gateway SHOULD accept all\n              valid address formats in SMTP commands and in RFC-822\n              headers, and all valid RFC-822 messages.  Although a\n' > rfc.txt
provenant scan --json-pp - --copyright --compat-mode scancode rfc.txt
```

`copyrights` and `holders` are now empty. The issue's real target is worth a pass too — `curl -sL https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e/lib/inets/doc/archive/rfc1123.txt` scanned with the same flags reports nothing, where it previously reported the one bogus notice. Beyond that, the new unit tests plus the copyright/license/parser golden suites are the source of truth and CI runs them.

## Follow-up work

- Created or intentionally deferred: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
