### PR TITLE
fix(copyright): strip `%`, `;`, `--`, and `!` comment markers from the native value

### DIFF
--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -554,8 +554,46 @@ fn normalize_html_copyright_entity(text: &str) -> std::borrow::Cow<'_, str> {
     COPYRIGHT_ENTITY_RE.replace_all(text, "(c)")
 }
 
+/// Strip one leading run of a single-character line-comment marker: `%`
+/// (Erlang, Matlab, TeX), `;` (Lisp, assembly, ini), `!` (Fortran), or `-` as
+/// the pair `--` (Ada, Haskell, Lua, SQL, VHDL).
+///
+/// Only the marker the line actually opens on is stripped, and only across its
+/// own repeated run (`%%`, `;;;`, `----`). That is what a wrapped notice needs —
+/// every continuation line repeats the marker, so an unstripped one survives
+/// into the middle of the value — while leaving punctuation that belongs to the
+/// notice alone: in `* -- nickg at modp dot com` the `*` is scaffolding but the
+/// `--` is the notice's own separator, so this pass declines the line and the
+/// caller's loop removes the `*` only.
+///
+/// A lone leading `-` is a bullet or a date range rather than a comment, and
+/// `-->` closes an XML comment, so both are left intact.
+fn strip_leading_comment_marker_run(line: &str) -> &str {
+    const RUN_MARKERS: [char; 4] = ['%', ';', '!', '-'];
+
+    let Some(marker) = line.chars().next().filter(|c| RUN_MARKERS.contains(c)) else {
+        return line;
+    };
+    let run = line.len() - line.trim_start_matches(marker).len();
+    if marker == '-' && (run < 2 || line[run..].starts_with('>')) {
+        return line;
+    }
+    line[run..].trim_start()
+}
+
+/// Strip the comment scaffolding off one raw source line so the native
+/// projection carries the notice text alone.
+///
+/// The stripped set covers the comment markers Provenant actually meets in
+/// scanned trees: the C/C++ and doc variants, block openers, XML, `*`
+/// continuations, and `#` handled by the loop below, plus the single-character
+/// markers handled once up front by [`strip_leading_comment_marker_run`].
+///
+/// Word-shaped markers (`REM`, `dnl`) and the VB `'` are deliberately absent: a
+/// notice can legitimately open on a quote or an all-caps acronym holder, so
+/// stripping those would eat notice text rather than scaffolding.
 fn strip_common_comment_wrappers(line: &str) -> String {
-    let mut trimmed = line.trim();
+    let mut trimmed = strip_leading_comment_marker_run(line.trim());
 
     loop {
         let next = trimmed

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -5,7 +5,7 @@ use super::{
     collapse_angle_bracket_padding, extract_comment_author_supplements,
     extract_copyright_information, extract_patch_header_author_supplements,
     is_binary_garbage_party_value, is_binary_string_copyright_candidate,
-    is_font_metadata_label_copyright,
+    is_font_metadata_label_copyright, strip_common_comment_wrappers,
 };
 use crate::copyright;
 use crate::models::{FileInfoBuilder, FileType};
@@ -1400,4 +1400,116 @@ fn test_extract_copyright_obfuscated_email_in_spaced_angle_brackets() {
     );
     assert_eq!(file.holders.len(), 1, "holders: {:?}", file.holders);
     assert_eq!(file.holders[0].holder, "Florian Loitsch");
+}
+
+#[test]
+fn test_extract_copyright_information_punctuation_comment_markers_stripped_from_native_value() {
+    // A notice wrapped across lines carries its comment marker on every line, so
+    // an unhandled marker survives in the middle of the native value as well as
+    // at its head. `%` (Erlang/Matlab/TeX), `;` (Lisp/assembly/ini), `--`
+    // (Ada/Haskell/Lua/SQL), and `!` (Fortran) each have to strip like `#`,
+    // `*`, and `//` already do. Repeated forms (`%%`, `;;`) come off too.
+    for (marker, file_name, extension) in [
+        ("%%", "fixture.hrl", ".hrl"),
+        ("%", "fixture.m", ".m"),
+        (";;", "fixture.el", ".el"),
+        (";", "fixture.ini", ".ini"),
+        ("--", "fixture.adb", ".adb"),
+    ] {
+        let text = format!(
+            "{marker} Portions created by Example are Copyright 1999, Example Utvecklings\n{marker} AB. All Rights Reserved.\n"
+        );
+        let mut builder = FileInfoBuilder::default();
+
+        extract_copyright_information(&mut builder, Path::new(file_name), &text, 120.0, false);
+
+        let file = builder
+            .name(file_name.to_string())
+            .base_name("fixture".to_string())
+            .extension(extension.to_string())
+            .path(file_name.to_string())
+            .file_type(FileType::File)
+            .size(text.len() as u64)
+            .build()
+            .expect("builder should produce file info");
+
+        assert_eq!(
+            file.copyrights.len(),
+            1,
+            "marker {marker:?} copyrights: {:?}",
+            file.copyrights
+        );
+        assert_eq!(
+            file.copyrights[0].copyright,
+            "Copyright 1999, Example Utvecklings AB. All Rights Reserved.",
+            "marker {marker:?}"
+        );
+    }
+}
+
+#[test]
+fn test_strip_common_comment_wrappers_leaves_word_shaped_markers_and_quotes() {
+    // `REM`, `dnl`, and the VB `'` stay: a notice can legitimately open on a
+    // quote or on an all-caps acronym holder, so stripping them would eat notice
+    // text rather than comment scaffolding.
+    for line in [
+        "REM Copyright 1999, Example Corp.",
+        "dnl Copyright 1999, Example Corp.",
+        "' Copyright 1999, Example Corp.",
+    ] {
+        assert_eq!(
+            strip_common_comment_wrappers(line),
+            line,
+            "unexpectedly stripped {line:?}"
+        );
+    }
+
+    // The punctuation markers do come off, including repeated forms.
+    for (line, expected) in [
+        (
+            "%% Copyright 1999, Example Corp.",
+            "Copyright 1999, Example Corp.",
+        ),
+        (
+            ";;; Copyright 1999, Example Corp.",
+            "Copyright 1999, Example Corp.",
+        ),
+        (
+            "-- Copyright 1999, Example Corp.",
+            "Copyright 1999, Example Corp.",
+        ),
+        (
+            "! Copyright 1999, Example Corp.",
+            "Copyright 1999, Example Corp.",
+        ),
+    ] {
+        assert_eq!(
+            strip_common_comment_wrappers(line),
+            expected,
+            "for {line:?}"
+        );
+    }
+}
+
+#[test]
+fn test_strip_common_comment_wrappers_keeps_notice_punctuation_under_scaffolding() {
+    // The single-character markers strip only as the run the line itself opens
+    // on. On a C continuation the `*` is scaffolding but the `--` underneath is
+    // the notice's own separator, so only the `*` comes off.
+    assert_eq!(
+        strip_common_comment_wrappers(" * -- nickg at modp dot com"),
+        "-- nickg at modp dot com"
+    );
+    assert_eq!(
+        strip_common_comment_wrappers(" # ; not a comment marker here"),
+        "; not a comment marker here"
+    );
+
+    // A lone leading `-` is a bullet or a date range, and `-->` closes an XML
+    // comment; neither is comment scaffolding this pass should eat.
+    assert_eq!(
+        strip_common_comment_wrappers("- Copyright 1999, Example Corp."),
+        "- Copyright 1999, Example Corp."
+    );
+    assert_eq!(strip_common_comment_wrappers("-->"), "");
 }


### PR DESCRIPTION
## Summary

- A notice wrapped across lines carries its comment marker on every line, so an unhandled marker survives in the **middle** of the source-faithful native value as well as at its head. Erlang headers throughout `erlang/otp` report `%% Portions created by Ericsson are Copyright 1999, Ericsson Utvecklings %% AB. All Rights Reserved.''` on **149 files**, where the same text behind `#` or `*` projects cleanly and `--compat-mode scancode` renders it correctly.
- `strip_common_comment_wrappers` already handled the C-family markers, `<!--`, `*`, and `#`. This adds the remaining punctuation line-comment markers Provenant meets in scanned trees: `%` (Erlang, Matlab, TeX), `;` (Lisp, assembly, ini), `--` (Ada, Haskell, Lua, SQL, VHDL), and `!` (Fortran).
- These strip in a single leading pass over the run the line itself opens on (`strip_leading_comment_marker_run`) rather than joining the loop, so punctuation belonging to the notice is left alone: in `* -- nickg at modp dot com` the `*` is scaffolding but the `--` is the notice's own separator. A lone leading `-` (bullet, date range) and `-->` (XML comment close) stay intact.

## Issues

- Covers: surfaced while verifying `erlang/otp @ 6146f0df` as a benchmark target (`compare-outputs --profile common`), where this was the single largest ScanCode-favored copyright delta.

## Scope and exclusions

- Included: `strip_common_comment_wrappers`, which feeds both the native copyright projection and the raw-span source-code shape check.
- Explicit exclusions: word-shaped markers (`REM`, `dnl`) and the VB `'` are deliberately left in place — a notice can legitimately open on a quote or an all-caps acronym holder, so stripping those would eat notice text rather than comment scaffolding. A regression test pins that boundary.

## How to verify

```
printf '%%%% Portions created by Example are Copyright 1999, Example Utvecklings\n%%%% AB. All Rights Reserved.\n' > f.hrl
provenant scan --json-pp - --copyright f.hrl
```

`copyright` reads `Copyright 1999, Example Utvecklings AB. All Rights Reserved.` with no `%%` anywhere in the value. Swapping the marker for `%`, `;`, `;;`, `--`, or `!` gives the same result; swapping it for `REM`, `dnl`, or `'` leaves the line untouched. Worth also poking a C continuation whose text carries its own `--` separator (`* -- nickg at modp dot com`) to confirm only the `*` comes off, and the real target file `lib/dialyzer/test/options1_SUITE_data/my_include/erl_compile.hrl` in `erlang/otp`, which now yields `Copyright 1999, Ericsson Utvecklings AB.`.

## Follow-up work

- Created or intentionally deferred: the `erlang/otp` verification campaign continues — a `MAKE NO REPRESENTATIONS` holder false positive on W3C copyright HTML (10 paths), plus the `license_clues` / `license_detections` tail. The refreshed `docs/BENCHMARKS.md` row lands last, after the queue is clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)