### PR TITLE
fix(copyright): drop holder warranty and liability disclaimer clauses

### DIFF
--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -954,3 +954,24 @@ fn test_bare_c_sign_notices_naming_a_holder_are_kept() {
         );
     }
 }
+
+#[test]
+fn test_holder_warranty_disclaimer_clauses_are_not_copyrights() {
+    // The all-caps W3C disclaimers, which name the holder as a verb's subject.
+    let content = "\
+<p>THIS SOFTWARE AND DOCUMENTATION IS PROVIDED \"AS IS,\" AND
+COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF
+MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE.</p>
+
+<p>COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT,
+SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE
+SOFTWARE OR DOCUMENTATION.</p>
+";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    assert!(
+        copyrights.is_empty(),
+        "unexpected copyrights: {copyrights:?}"
+    );
+    assert!(holders.is_empty(), "unexpected holders: {holders:?}");
+}

--- a/src/copyright/refiner/copyrights_junk_patterns.rs
+++ b/src/copyright/refiner/copyrights_junk_patterns.rs
@@ -317,6 +317,10 @@ pub(super) static COPYRIGHTS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new
         r"(?i)^\(Copyright notice\)",
         r"(?i)^COPYRIGHT HOLDER ALLOWS\b",
         r"(?i)^copyright holders?,? disclaims?\b",
+        // Warranty and liability disclaimers name the holder as a verb's subject
+        // rather than as a party, so the clause is not a notice.
+        r"(?i)^copyright (?:holders?|owners?)\s+makes?\s+no\b",
+        r"(?i)^copyright (?:holders?|owners?)\s+(?:will|shall|may|would|can|could)?\s*(?:not\s+)?be\s+liable\b",
         r"(?i)\bwe do not list the\b",
         r"(?i)\bno-warranty notice unaltered\b",
         r"(?i)\bprovides the program as\b",

--- a/src/copyright/refiner/holders_junk_patterns.rs
+++ b/src/copyright/refiner/holders_junk_patterns.rs
@@ -34,6 +34,8 @@ pub(super) static HOLDERS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(||
         r"(?i)^version\s*,\s*etc\b",
         r"(?i)^\(d\),\s*\d+(?:\.\d+)*\.?$",
         r"(?i)\bliable for\b",
+        // The verb phrase a warranty disclaimer leaves in the holder slot.
+        r"(?i)^makes?\s+no\s+(?:representations?|warrant(?:y|ies))\b",
         r"(?i)\bappear in all copies\b",
         r"(?i)\bdisclaimer of warranty\b",
         r"(?i)\bdisclaimer for the program\b",

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -3233,3 +3233,41 @@ fn test_changelog_copyright_year_update_is_junk_after_refine() {
         );
     }
 }
+
+#[test]
+fn test_junk_copyright_drops_holder_warranty_and_liability_disclaimers() {
+    // Warranty language names the holder as a verb's subject, not as a party.
+    for clause in [
+        "COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS",
+        "Copyright holders make no representations or warranties",
+        "COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR",
+        "Copyright holder shall not be liable for any damages",
+        "COPYRIGHT OWNER MAKES NO WARRANTY",
+        "Copyright owners be liable for any claim",
+    ] {
+        assert!(super::junk::is_junk_copyright(clause), "kept {clause:?}");
+    }
+
+    // The verb phrase the disclaimer leaves in the holder slot is junk too.
+    assert_eq!(refine_holder("MAKE NO REPRESENTATIONS"), None);
+    assert_eq!(refine_holder("makes no warranties"), None);
+}
+
+#[test]
+fn test_junk_copyright_keeps_notices_naming_the_holder_after_the_marker() {
+    // `copyright holders:` naming real parties must survive the disclaimer rule.
+    for notice in [
+        "Copyright 1994-2002 World Wide Web Consortium",
+        "Copyright (c) 2024 Example Corp.",
+        "Copyright holders: Alice Smith and Bob Jones",
+    ] {
+        assert!(
+            !super::junk::is_junk_copyright(notice),
+            "dropped {notice:?}"
+        );
+        assert!(
+            refine_copyright(notice).is_some(),
+            "refine dropped {notice:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- W3C, BSD, MIT, and Apache warranty language puts the copyright holder in the **subject slot of a verb** rather than naming a party, so the clause is a disclaimer, not a notice. The W3C copyright notices bundled in `erlang/otp`'s xmerl test data yielded `COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS` and `COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR` as copyrights on **10 files**, the first of them with `MAKE NO REPRESENTATIONS` as its holder.
- Adds the two clause shapes to the copyright junk patterns, alongside the `^copyright holders? disclaim` / `^COPYRIGHT HOLDER ALLOWS` entries that already cover the same family, plus the leftover verb phrase to the holder junk patterns.

## Issues

- Covers: surfaced while verifying `erlang/otp @ 6146f0df` as a benchmark target (`compare-outputs --profile common`).

## Scope and exclusions

- Included: `COPYRIGHTS_JUNK_PATTERNS` and `HOLDERS_JUNK_PATTERNS`.
- Explicit exclusions: both patterns are anchored on `copyright holder(s)`/`owner(s)` followed by a verb, so ordinary notices are untouched — including `Copyright holders: Alice Smith and Bob Jones`, which a broader `^copyright holders?` rule would have eaten. The real W3C notice sitting above the disclaimers in the same file still detects, with its full multi-institution holder.

## How to verify

```
curl -sLO https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e/lib/xmerl/test/xmerl_sax_std_SUITE_data/w3c-copyright-19980720.html
provenant scan --json-pp - --copyright w3c-copyright-19980720.html
```

Before: four copyrights, two of them the all-caps disclaimer clauses, plus a `MAKE NO REPRESENTATIONS` holder. After: the two real `Copyright © 1994-2002 … World Wide Web Consortium …` notices and their two holders only.

## Follow-up work

- Created or intentionally deferred: with this and #1374, the `erlang/otp` ScanCode-favored queue is fully triaged — everything remaining is a Provenant advantage, a documented divergence (`rpm_specfile` vs ScanCode's `rpm_spefile` typo), or cosmetic normalization. The refreshed `docs/BENCHMARKS.md` row lands last, after a re-run on merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)