### PR TITLE
fix(copyright): keep an SPDX `copyrightText` field beside a JSON description

### DIFF
--- a/src/copyright/detector/postprocess_transforms/metadata_repairs.rs
+++ b/src/copyright/detector/postprocess_transforms/metadata_repairs.rs
@@ -13,8 +13,9 @@ pub fn drop_json_description_metadata_copyrights_and_holders(
     copyrights: &mut Vec<CopyrightDetection>,
     holders: &mut Vec<HolderDetection>,
 ) {
+    // A window that declares a copyright field is attributing, not describing.
     static JSON_COPYRIGHT_KEY_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r#"(?i)"copyrights?"\s*:"#).unwrap());
+        LazyLock::new(|| Regex::new(r#"(?i)"copyrights?(?:_?text|_?notice)?"\s*:"#).unwrap());
 
     let mut retained_spans: HashSet<(usize, usize)> = HashSet::new();
     copyrights.retain(|copyright| {

--- a/src/copyright/detector/tests_structured_metadata.rs
+++ b/src/copyright/detector/tests_structured_metadata.rs
@@ -591,3 +591,52 @@ fn test_the_copyright_deadline_is_honoured_end_to_end() {
     );
     assert!(expired.is_empty(), "got {expired:?}");
 }
+
+#[test]
+fn test_json_description_keeps_spdx_copyright_text_field() {
+    // erlang/otp's `vendor.info` shape: a vendored component's own notice sits
+    // beside the description and download URL that would otherwise drop it.
+    let input = concat!(
+        "[\n",
+        "  {\n",
+        "    \"ID\": \"erts-ryu\",\n",
+        "    \"description\": \"ryu library\",\n",
+        "    \"copyrightText\": \"Copyright 2018 Ulf Adams\",\n",
+        "    \"downloadLocation\": \"https://github.com/ulfjack/ryu\",\n",
+        "    \"homepage\": \"https://github.com/ulfjack/ryu\"\n",
+        "  }\n",
+        "]\n"
+    );
+    let (c, h, _a) = detect_copyrights_from_text(input);
+    assert!(
+        c.iter()
+            .any(|cr| cr.copyright == "Copyright 2018 Ulf Adams"),
+        "copyrights: {c:?}"
+    );
+    assert!(
+        h.iter().any(|hr| hr.holder == "Ulf Adams"),
+        "holders: {h:?}"
+    );
+
+    let input = concat!(
+        "{\n",
+        "  \"description\": \"a library\",\n",
+        "  \"copyright_notice\": \"Copyright 2018 Ulf Adams\"\n",
+        "}\n"
+    );
+    let (c, _h, _a) = detect_copyrights_from_text(input);
+    assert!(
+        c.iter()
+            .any(|cr| cr.copyright == "Copyright 2018 Ulf Adams"),
+        "copyrights: {c:?}"
+    );
+}
+
+#[test]
+fn test_json_description_prose_without_a_copyright_field_still_drops() {
+    // No copyright field declared, so the prose-value drop still applies.
+    let input = r#"{"description": "Software Package Data Exchange (SPDX) is a set of standards for communicating the components, licenses, and copyrights associated with software.", "sponsor": {"@type": "Organization", "name": "FOSSology"}}"#;
+    let (c, h, _a) = detect_copyrights_from_text(input);
+    assert!(c.is_empty(), "copyrights: {c:?}");
+    assert!(h.is_empty(), "holders: {h:?}");
+}


### PR DESCRIPTION
## Summary

- The JSON-description drop (`drop_json_description_metadata_copyrights_and_holders`) exists to kill copyrights swept out of prose fields, and it lets a window through when that window declares a real copyright field. Its key pattern spelled that as `"copyrights?"` — which never matches SPDX's own field name, `copyrightText`.
- Every `vendor.info` in `erlang/otp` records the vendored component's notice that way, beside a `description` and a `downloadLocation`. So the third-party attribution for **ryu, zlib, zstd, asmjit, jQuery, wxWidgets, autoconf, and the Unicode data files** was dropped across **11 files**.
- Broadens the key pattern to the SPDX `copyrightText` spelling and the `copyright_notice` variant.

Minimal repro — the `description` line is what suppresses it:

```json
[ { "description": "ryu library", "copyrightText": "Copyright 2018 Ulf Adams" } ]
```

## Issues

- Covers: surfaced while verifying `erlang/otp @ 6146f0df` as a benchmark target (`compare-outputs --profile common`).

## Scope and exclusions

- Included: the escape-hatch key pattern only.
- Explicit exclusions: the drop itself is untouched. A `description` window whose only copyright-ish word is prose *inside the value*, with no copyright field declared, still drops — pinned by a new test using the SPDX-prose case. The existing `test_json_description_keeps_explicit_anchor_attribution` and `test_json_description_metadata_*` cases are unchanged.

## How to verify

```
curl -sLO https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e/erts/emulator/ryu/vendor.info
provenant scan --json-pp - --copyright vendor.info
```

Four copyrights instead of one: the Ericsson header notice plus `Copyright 2018 Ulf Adams` (×2) and `Copyright (c) Microsoft Corporation`, with `Ulf Adams` and `Microsoft Corporation` as holders. ScanCode finds these too but appends the following JSON key to the value (`Copyright 2018 Ulf Adams downloadLocation' https://github.com/ulfjack/ryu`), so Provenant's values are also the cleaner ones.

## Follow-up work

- Created or intentionally deferred: this is the last defect from the `erlang/otp` queue. The refreshed `docs/BENCHMARKS.md` row lands next, after a re-run on merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)