### PR TITLE
fix(copyright): inline an anchor's URL instead of leaving markup in the value

### DIFF
--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -175,6 +175,7 @@ fn render_raw_copyright_from_text(
     // Acme</small>`); the source-faithful projection otherwise carries the markup
     // into the value. Only edge tags are removed, so `©`, angle-bracket emails,
     // URLs, and `<year>` markers inside the notice are preserved.
+    let rendered = inline_anchor_hrefs(&rendered);
     let rendered = strip_edge_html_tags(&rendered);
     // Normalize the HTML copyright entity to `(c)` so an `&copy;`-encoded notice
     // does not survive verbatim and split into a near-duplicate value. `(c)` is
@@ -200,6 +201,110 @@ fn render_raw_copyright_from_text(
     } else {
         project_native_copyright_value(&rendered, fallback)
     }
+}
+
+/// Replace an anchor with the URL it points at, dropping anchors that carry none.
+///
+/// The URL in `<a href="URL">Name</a>` is part of the attribution, so a linked
+/// notice renders as the same `<marker> <url> <name>` shape the detector already
+/// produces for a single-line linked notice.
+fn inline_anchor_hrefs(text: &str) -> String {
+    // Quoted segments may hold a `>` (`<a title="a > b" href="...">`), so the
+    // attribute run alternates quoted values with unquoted non-`>` text rather
+    // than treating the first `>` as the tag end.
+    static ANCHOR_TAG_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"(?is)<\s*(?P<close>/)?\s*a\b(?P<attrs>(?:"[^"]*"|'[^']*'|[^>"'])*)>"#)
+            .expect("valid regex")
+    });
+    // Consuming each quoted value whole is what keeps a literal `href=` inside an
+    // earlier attribute (`<a title="see href=elsewhere" href="real">`) from being
+    // read as the anchor's own href.
+    static ATTR_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r#"(?is)(?P<name>[A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*(?:"(?P<dq>[^"]*)"|'(?P<sq>[^']*)'|(?P<bare>[^\s>]+))"#,
+        )
+        .expect("valid regex")
+    });
+    // Tidied only on values that carried an anchor, so every other native value
+    // stays byte-identical.
+    static SPACE_BEFORE_PUNCT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"[ \t]+(?P<p>[,.;:)\]])").expect("valid regex"));
+    static SPACE_AFTER_OPEN_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?P<b>[(\[])[ \t]+").expect("valid regex"));
+    static SPACE_RUN_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"[ \t]{2,}").expect("valid regex"));
+
+    if !ANCHOR_TAG_RE.is_match(text) {
+        return text.to_string();
+    }
+
+    let replaced = ANCHOR_TAG_RE.replace_all(text, |caps: &regex::Captures| {
+        if caps.name("close").is_some() {
+            return " ".to_string();
+        }
+        let attrs = caps.name("attrs").map(|m| m.as_str()).unwrap_or("");
+        ATTR_RE
+            .captures_iter(attrs)
+            .find(|attr| {
+                attr.name("name")
+                    .is_some_and(|n| n.as_str().eq_ignore_ascii_case("href"))
+            })
+            .and_then(|attr| {
+                attr.name("dq")
+                    .or_else(|| attr.name("sq"))
+                    .or_else(|| attr.name("bare"))
+            })
+            .map(|url| format!(" {} ", decode_html_entities(url.as_str())))
+            .unwrap_or_else(|| " ".to_string())
+    });
+
+    let collapsed = SPACE_RUN_RE.replace_all(&replaced, " ");
+    let tidied = SPACE_BEFORE_PUNCT_RE.replace_all(&collapsed, "$p");
+    SPACE_AFTER_OPEN_RE
+        .replace_all(&tidied, "$b")
+        .trim()
+        .to_string()
+}
+
+/// Decode the HTML entities an `href` can carry, so the emitted URL is the
+/// anchor's real target (`?a=1&amp;b=2` and `?a=1&#38;b=2` both address
+/// `?a=1&b=2`). One left-to-right pass, so a decoded `&` cannot combine with the
+/// following text into a second entity.
+fn decode_html_entities(value: &str) -> String {
+    static ENTITY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)&(?:#(?P<dec>[0-9]{1,7})|#x(?P<hex>[0-9a-f]{1,6})|(?P<name>amp|lt|gt|quot|apos));")
+            .expect("valid regex")
+    });
+
+    if !value.contains('&') {
+        return value.to_string();
+    }
+    ENTITY_RE
+        .replace_all(value, |caps: &regex::Captures| {
+            if let Some(name) = caps.name("name") {
+                return match name.as_str().to_ascii_lowercase().as_str() {
+                    "amp" => "&",
+                    "lt" => "<",
+                    "gt" => ">",
+                    "quot" => "\"",
+                    _ => "'",
+                }
+                .to_string();
+            }
+            let code = caps
+                .name("dec")
+                .and_then(|m| m.as_str().parse::<u32>().ok())
+                .or_else(|| {
+                    caps.name("hex")
+                        .and_then(|m| u32::from_str_radix(m.as_str(), 16).ok())
+                });
+            match code.and_then(char::from_u32) {
+                Some(ch) => ch.to_string(),
+                // An unassigned code point is left as written rather than guessed at.
+                None => caps[0].to_string(),
+            }
+        })
+        .into_owned()
 }
 
 /// Strip presentational HTML tags from a source-faithful copyright value, e.g.

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -3,7 +3,7 @@
 
 use super::{
     collapse_angle_bracket_padding, extract_comment_author_supplements,
-    extract_copyright_information, extract_patch_header_author_supplements,
+    extract_copyright_information, extract_patch_header_author_supplements, inline_anchor_hrefs,
     is_binary_garbage_party_value, is_binary_string_copyright_candidate,
     is_font_metadata_label_copyright, strip_common_comment_wrappers,
 };
@@ -1512,4 +1512,118 @@ fn test_strip_common_comment_wrappers_keeps_notice_punctuation_under_scaffolding
         "- Copyright 1999, Example Corp."
     );
     assert_eq!(strip_common_comment_wrappers("-->"), "");
+}
+
+#[test]
+fn test_inline_anchor_hrefs_keeps_the_url_and_drops_the_tag() {
+    // The W3C notice shape bundled in erlang/otp's xmerl test data.
+    assert_eq!(
+        inline_anchor_hrefs(
+            "Copyright 1994-2002 <a href=\"http://www.w3.org/\">World Wide Web Consortium</a>, (<a href=\"http://www.lcs.mit.edu/\">MIT</a>)"
+        ),
+        "Copyright 1994-2002 http://www.w3.org/ World Wide Web Consortium, (http://www.lcs.mit.edu/ MIT)"
+    );
+
+    // An anchor with no href leaves only its text behind.
+    assert_eq!(
+        inline_anchor_hrefs("Copyright 2024 <a name=\"x\">Example Corp.</a>"),
+        "Copyright 2024 Example Corp."
+    );
+
+    // A literal `href=` inside an earlier attribute is not the anchor's href.
+    assert_eq!(
+        inline_anchor_hrefs(
+            "Copyright 2024 <a title=\"see href=elsewhere.test\" href=\"http://real.test/\">Example Corp.</a>"
+        ),
+        "Copyright 2024 http://real.test/ Example Corp."
+    );
+
+    // An entity-encoded href addresses its decoded target.
+    assert_eq!(
+        inline_anchor_hrefs(
+            "Copyright 2024 <a href=\"http://x.test/?a=1&amp;b=2\">Example Corp.</a>"
+        ),
+        "Copyright 2024 http://x.test/?a=1&b=2 Example Corp."
+    );
+
+    // An unquoted href is still read.
+    assert_eq!(
+        inline_anchor_hrefs("Copyright 2024 <a href=http://x.test/ >Example Corp.</a>"),
+        "Copyright 2024 http://x.test/ Example Corp."
+    );
+
+    // A `>` inside a quoted attribute is not the end of the tag.
+    assert_eq!(
+        inline_anchor_hrefs(
+            "Copyright 2024 <a title=\"a > b\" href=\"http://x.test/\">Example Corp.</a>"
+        ),
+        "Copyright 2024 http://x.test/ Example Corp."
+    );
+
+    // Numeric entities decode too, decimal and hex alike.
+    for href in ["?a=1&#38;b=2", "?a=1&#x26;b=2", "?a=1&amp;b=2"] {
+        assert_eq!(
+            inline_anchor_hrefs(&format!(
+                "Copyright 2024 <a href=\"http://x.test/{href}\">Example Corp.</a>"
+            )),
+            "Copyright 2024 http://x.test/?a=1&b=2 Example Corp.",
+            "for {href:?}"
+        );
+    }
+
+    // A decoded `&` does not combine with the following text into a new entity.
+    assert_eq!(
+        inline_anchor_hrefs(
+            "Copyright 2024 <a href=\"http://x.test/?a=1&amp;lt;b\">Example Corp.</a>"
+        ),
+        "Copyright 2024 http://x.test/?a=1&lt;b Example Corp."
+    );
+
+    // A value with no anchor is returned untouched, angle-bracket emails included.
+    for value in [
+        "Copyright 2024 Example Corp.",
+        "Copyright 2024 Jane Doe <jane@example.com>",
+        "Copyright 2024 Example <small>Corp.</small>",
+    ] {
+        assert_eq!(inline_anchor_hrefs(value), value, "changed {value:?}");
+    }
+}
+
+#[test]
+fn test_extract_copyright_information_html_anchor_notice_carries_no_markup() {
+    let text = "<p>Copyright \u{a9} 1994-2002 <a href=\"http://www.w3.org/\">World Wide Web Consortium</a>,\n(<a href=\"http://www.lcs.mit.edu/\">Massachusetts Institute of Technology</a>). All Rights Reserved.</p>\n";
+    let mut builder = FileInfoBuilder::default();
+
+    extract_copyright_information(&mut builder, Path::new("notice.html"), text, 120.0, false);
+
+    let file = builder
+        .name("notice.html".to_string())
+        .base_name("notice".to_string())
+        .extension(".html".to_string())
+        .path("notice.html".to_string())
+        .file_type(FileType::File)
+        .size(text.len() as u64)
+        .build()
+        .expect("builder should produce file info");
+
+    assert!(!file.copyrights.is_empty(), "no copyrights");
+    for c in &file.copyrights {
+        assert!(
+            !c.copyright.contains("<a ") && !c.copyright.contains("</a>"),
+            "markup survived: {:?}",
+            c.copyright
+        );
+        assert!(
+            c.copyright.contains("http://www.w3.org/"),
+            "href dropped: {:?}",
+            c.copyright
+        );
+    }
+    assert!(
+        file.holders
+            .iter()
+            .any(|h| h.holder.contains("World Wide Web Consortium")),
+        "holders: {:?}",
+        file.holders
+    );
 }


### PR DESCRIPTION
## Summary

- A linked notice renders as `<a href="URL">Name</a>`, and the URL is part of the attribution. The native projection stripped a fixed list of formatting tags (`small`, `span`, `p`, …) but not anchors, so the W3C notices bundled in `erlang/otp`'s xmerl test data came back with markup on **10 files**, in both the default and `--compat-mode scancode` renderings:

  ```
  Copyright © 1994-2002 <a href="http://www.w3.org/">World Wide Web Consortium</a>, (<a href="http://www.lcs.mit.edu/">Massachusetts Institute of Technology</a>, …
  ```

- Now replaces an anchor with the URL it points at, and drops an anchor carrying no URL — the same `<marker> <url> <name>` shape the detector already produces for a *single-line* linked notice (`maybe_expand_copyrighted_by_href_urls`, pinned by `test_json_description_keeps_explicit_anchor_attribution`). That normalization is deliberately gated to short non-HTML inputs, which is why full HTML documents kept their markup.

  ```
  Copyright © 1994-2002 http://www.w3.org/ World Wide Web Consortium, (http://www.lcs.mit.edu/ Massachusetts Institute of Technology, …
  ```

## Issues

- Covers: surfaced while verifying `erlang/otp @ 6146f0df` as a benchmark target (`compare-outputs --profile common`) — the last remaining ScanCode-favored delta on that target. ScanCode's string for this notice is also markup-free but truncates at the first holder; Provenant keeps the full institution list and the `©` glyph.

## Scope and exclusions

- Included: `render_raw_copyright_from_text`, via a new `inline_anchor_hrefs` step ahead of the existing tag strip.
- Explicit exclusions: punctuation spacing is tidied **only** on lines that actually carried an anchor, so every other native value stays byte-identical — no golden churn (copyright, license, parser, assembly, integration, post-processing suites all pass unchanged). Angle-bracket emails (`<jane@example.com>`) and `<year>` markers are untouched because the anchor patterns require an `a` tag.

## How to verify

```
curl -sLO https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e/lib/xmerl/test/xmerl_sax_std_SUITE_data/w3c-copyright-19980720.html
provenant scan --json-pp - --copyright w3c-copyright-19980720.html
```

No `<a ` or `</a>` anywhere in the `copyright` values, with `http://www.w3.org/` and the sibling institution URLs still present. Holders are unchanged. Worth also confirming a non-HTML notice and an angle-bracket email notice render exactly as before.

## Follow-up work

- Created or intentionally deferred: none — this closes the `erlang/otp` ScanCode-favored queue. The refreshed `docs/BENCHMARKS.md` row lands next, after a re-run on merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)