### PR TITLE
docs(benchmarks): refresh the erlang/otp row at 6146f0df

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 254 of 254 recorded runs, with a **19.7× median speedup** and **19.7× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **37.2×** on 10k+ file targets.
+> Provenant is faster on 254 of 254 recorded runs, with a **19.7× median speedup** and **19.7× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **37.9×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -322,12 +322,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.88s`; ScanCode `51.28s`
 - Direct Hex package and dependency extraction (`1` vs `0` packages, `13` vs `0` dependencies): a `pkg:hex/plug` package from `mix.exs` carrying locked `plug_crypto`, `telemetry`, `ex_doc`, and sibling Hex pins from `mix.lock` that ScanCode leaves at zero, with Unicode-preserving `Loïc Hoguin` holder normalization
 
-##### [erlang/otp @ 264def5](https://github.com/erlang/otp/tree/264def545b8214ea7100bfede1a4629c676ff1c0) — **33.91× faster**
+##### [erlang/otp @ 6146f0d](https://github.com/erlang/otp/tree/6146f0df6794451472fac4735e694ec1f56b873e) — **38.99× faster**
 
-- Files: 11,749
-- Run context: 2026-06-19 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
-- Timing: Provenant `59.99s`; ScanCode `2034.56s`
-- Broader OTP package visibility (`51` vs `0` packages): one `pkg:hex/<app>` package per committed `lib/*/src/*.app.src` (`41`, with bounded `%PLACEHOLDER%` handling that keeps canonical manifests such as `diameter.app.src` scannable) alongside `10` `pkg:autotools` packages from per-application `configure.ac` build manifests, preserving the same non-stdlib runtime dependency inventory ScanCode finds
+- Files: 11,803
+- Run context: 2026-08-20 · macOS 26.6.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `51.90s`; ScanCode `2023.39s`
+- Broader OTP package and dependency visibility (`51` vs `0` packages, `16` vs `9` dependencies): one `pkg:hex/<app>` package per committed `lib/*/src/*.app.src` (`41`, with bounded `%PLACEHOLDER%` handling that keeps canonical manifests such as `diameter.app.src` scannable) alongside `10` `pkg:autotools` packages from per-application `configure.ac` build manifests and the `mix.lock` Hex pins ScanCode leaves unread, plus lower-noise detection across the doc and test tree, where ScanCode reads Erlang identifiers as licenses (`mpl-2.0` from `ModemDescriptor_mpl`, `boost-1.0` from the `bsl` bit-shift operator), a code comment as `proprietary-license`, Erlang variables as copyright holders (`(c), Ctxt, Ren, Env`), and an Erlang `.app` filename as `http://ftp.app/`, with more precise license composition on the vendored `ryu` sources — whose alternative grant reads `(apache-2.0 OR boost-1.0)` rather than a conjunction — third-party `vendor.info` notices recorded without the trailing JSON key ScanCode appends, and Unicode-preserving party names such as `Björn Gustavsson`, `Mickaël Rémond`, and `Claes Wikström`
 
 ##### [livebook-dev/livebook @ 77cbcd9](https://github.com/livebook-dev/livebook/tree/77cbcd98df133045f5a4adf7273e4cd077307714) — **17.14× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -740,9 +740,9 @@ ScanCode: 1396.87s</title></rect>
     <rect x="737.15" y="301.70" width="8" height="8" fill="#d97706" rx="1.5"><title>spring-projects/spring-boot @ 53827d4
 Files: 11643
 ScanCode: 997.84s</title></rect>
-    <rect x="737.77" y="268.04" width="8" height="8" fill="#d97706" rx="1.5"><title>erlang/otp @ 264def5
-Files: 11749
-ScanCode: 2034.56s</title></rect>
+    <rect x="738.09" y="268.30" width="8" height="8" fill="#d97706" rx="1.5"><title>erlang/otp @ 6146f0d
+Files: 11803
+ScanCode: 2023.39s</title></rect>
     <rect x="738.86" y="294.65" width="8" height="8" fill="#d97706" rx="1.5"><title>apache/airflow @ 47ce5f3
 Files: 11935
 ScanCode: 1158.57s</title></rect>
@@ -1504,9 +1504,9 @@ Provenant: 48.49s</title></circle>
     <circle cx="741.15" cy="452.64" r="4.5" fill="#2563eb"><title>spring-projects/spring-boot @ 53827d4
 Files: 11643
 Provenant: 44.52s</title></circle>
-    <circle cx="741.77" cy="438.55" r="4.5" fill="#2563eb"><title>erlang/otp @ 264def5
-Files: 11749
-Provenant: 59.99s</title></circle>
+    <circle cx="742.09" cy="445.39" r="4.5" fill="#2563eb"><title>erlang/otp @ 6146f0d
+Files: 11803
+Provenant: 51.90s</title></circle>
     <circle cx="742.86" cy="446.23" r="4.5" fill="#2563eb"><title>apache/airflow @ 47ce5f3
 Files: 11935
 Provenant: 50.99s</title></circle>


### PR DESCRIPTION
## Summary

- Records the verification checkpoint for `erlang/otp` at the snapshot from #1365, replacing the `264def5` row: **Provenant `51.90s` vs ScanCode `2023.39s` across 11,803 files (38.99×)**.
- The outcome bullet adds the dependency gap (`16` vs `9`) and the low-noise detection differences this compare run establishes — Erlang identifiers ScanCode reads as licenses (`mpl-2.0` from `ModemDescriptor_mpl`, `boost-1.0` from the `bsl` bit-shift operator), a code comment read as `proprietary-license`, Erlang variables read as copyright holders, an Erlang `.app` filename read as `http://ftp.app/`, the alternative grant on the vendored `ryu` sources reading `(apache-2.0 OR boost-1.0)` rather than a conjunction, `vendor.info` notices without the trailing JSON key ScanCode appends, and Unicode-preserving party names.
- Chart and the 10k+ median-gap figure (`37.2×` → `37.9×`) regenerated via `generate-benchmark-chart`.

## Issues

- Covers: the verification campaign behind #1365 — #1373, #1374, #1375, #1376, #1377 all landed before this run.

## Scope and exclusions

- Included: the one `erlang/otp` row plus the regenerated chart and summary figure.
- Explicit exclusions: the `(C)`-list-label false positive from #1365 is **not** claimed as an advantage. ScanCode reports nothing on `lib/inets/doc/archive/rfc1123.txt`, so that fix brought Provenant to parity rather than ahead, and per the doc's own rules a parity fix is not dressed up as an edge.

## How to verify

The recorded timing came from a clean idle-machine run:

```
cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- \
  --repo-url https://github.com/erlang/otp.git \
  --repo-ref 6146f0df6794451472fac4735e694ec1f56b873e --profile common
```

Two things are worth knowing about the timing. Wall-clock on this host swings ~25% run to run (three earlier runs of the same target read 53.69s, 57.61s, 67.67s), so the row is taken from a run with nothing else executing. And because that spread tracked the fix batches, I checked it with `perf-ab --base 9d77103c --head 4f134f54 --rounds 5`, which interleaves both sides: head median `54.92s` vs base median `62.28s`, i.e. the campaign left Provenant **11.8% faster**, not slower. That A/B number is not recorded here — `perf-ab` timings do not belong in this document.

The remaining ScanCode-favored queue for this target is 487 entries (down from 643), all triaged as Provenant advantages, the documented `rpm_specfile`-vs-`rpm_spefile` divergence, or cosmetic normalization (Provenant lowercases email addresses while finding more of them).

## Expected-output fixture changes

- Files changed: `docs/scan-duration-vs-files.svg` (generated).
- Why the new expected output is correct: regenerated by the owning command from the edited timing row; the only stat that moves is the 10k+ median gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)