### PR TITLE
fix(finder): keep detected emails in their source case

### DIFF
--- a/docs/OUTPUT_FIELD_REFERENCE.md
+++ b/docs/OUTPUT_FIELD_REFERENCE.md
@@ -187,11 +187,11 @@ File-level copyright evidence record.
 
 File-level email evidence record.
 
-| JSON field   | Value shape | Key presence    | Meaning                                       |
-| ------------ | ----------- | --------------- | --------------------------------------------- |
-| `email`      | `string`    | Always emitted. | Extracted email address.                      |
-| `start_line` | `integer`   | Always emitted. | First line where the email evidence appeared. |
-| `end_line`   | `integer`   | Always emitted. | Last line where the email evidence appeared.  |
+| JSON field   | Value shape | Key presence    | Meaning                                                    |
+| ------------ | ----------- | --------------- | ---------------------------------------------------------- |
+| `email`      | `string`    | Always emitted. | Extracted email address, in the case the source file used. |
+| `start_line` | `integer`   | Always emitted. | First line where the email evidence appeared.              |
+| `end_line`   | `integer`   | Always emitted. | Last line where the email evidence appeared.               |
 
 ## `OutputHolder`
 

--- a/src/finder/emails.rs
+++ b/src/finder/emails.rs
@@ -45,16 +45,17 @@ pub fn find_emails(text: &str, config: &DetectionConfig) -> Vec<EmailDetection> 
                         continue;
                     }
                 }
-                let email = matched.as_str().to_lowercase();
-                if !is_good_email_domain(&email) {
+                // RFC 5321 makes the local part case-sensitive, so emit the source form.
+                let email = matched.as_str();
+                if !is_good_email_domain(email) {
                     continue;
                 }
-                if !classify_email(&email) {
+                if !classify_email(email) {
                     continue;
                 }
 
                 detections.push(EmailDetection {
-                    email,
+                    email: email.to_string(),
                     start_line: line_number,
                     end_line: line_number,
                 });
@@ -62,11 +63,12 @@ pub fn find_emails(text: &str, config: &DetectionConfig) -> Vec<EmailDetection> 
         }
     }
 
+    // Address identity ignores case even though the emitted value keeps it.
     let mut detections = if config.unique {
         let mut seen = std::collections::HashSet::<String>::new();
         detections
             .into_iter()
-            .filter(|d| seen.insert(d.email.clone()))
+            .filter(|d| seen.insert(d.email.to_lowercase()))
             .collect::<Vec<_>>()
     } else {
         detections
@@ -74,7 +76,7 @@ pub fn find_emails(text: &str, config: &DetectionConfig) -> Vec<EmailDetection> 
 
     if config.max_emails > 0 && detections.len() > config.max_emails {
         let mut seen = std::collections::HashSet::<String>::new();
-        detections.retain(|d| seen.insert(d.email.clone()));
+        detections.retain(|d| seen.insert(d.email.to_lowercase()));
         detections.truncate(config.max_emails);
     }
 
@@ -90,6 +92,55 @@ mod tests {
             .into_iter()
             .map(|d| d.email)
             .collect()
+    }
+
+    #[test]
+    fn test_find_emails_preserves_source_case() {
+        assert_eq!(
+            emails("mailto Richard.M.Bartel@ccMail.Census.GOV now"),
+            vec!["Richard.M.Bartel@ccMail.Census.GOV"]
+        );
+        assert_eq!(
+            emails("send to Paul.Green@stratus.com"),
+            vec!["Paul.Green@stratus.com"]
+        );
+    }
+
+    #[test]
+    fn test_find_emails_dedupes_case_variants_of_one_address() {
+        let config = DetectionConfig {
+            unique: true,
+            ..DetectionConfig::default()
+        };
+        let detections = find_emails(
+            "Paul.Green@stratus.com\npaul.green@stratus.com\nPAUL.GREEN@STRATUS.COM\n",
+            &config,
+        );
+        // First occurrence wins, so the emitted value stays the one the source shows first.
+        assert_eq!(
+            detections
+                .iter()
+                .map(|d| d.email.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Paul.Green@stratus.com"]
+        );
+    }
+
+    #[test]
+    fn test_find_emails_caps_on_case_insensitive_uniqueness() {
+        let config = DetectionConfig {
+            max_emails: 2,
+            max_urls: 0,
+            unique: false,
+        };
+        let detections = find_emails("a@corp.com\nA@Corp.com\nb@corp.com\nc@corp.com\n", &config);
+        assert_eq!(
+            detections
+                .iter()
+                .map(|d| d.email.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a@corp.com", "b@corp.com"]
+        );
     }
 
     #[test]

--- a/src/output_schema/metadata/file_evidence.rs
+++ b/src/output_schema/metadata/file_evidence.rs
@@ -59,7 +59,7 @@ pub(super) const EMAIL_FIELDS: &[OutputFieldDoc] = &[
         rust_field: "email",
         value_shape: "string",
         presence: "Always emitted.",
-        meaning: "Extracted email address.",
+        meaning: "Extracted email address, in the case the source file used.",
     },
     OutputFieldDoc {
         json_name: "start_line",

--- a/src/scanner/process/binary_text.rs
+++ b/src/scanner/process/binary_text.rs
@@ -132,7 +132,7 @@ pub(super) fn extract_named_author_from_binary_line(line: &str) -> Option<String
     }
 
     let lower_line = line.to_ascii_lowercase();
-    let email_start = lower_line.find(email)?;
+    let email_start = lower_line.find(&email.to_ascii_lowercase())?;
     let raw_prefix = &line[..email_start];
     let has_author_marker = contains_binary_author_marker(raw_prefix);
     let prefix = take_suffix_after_last_author_marker(raw_prefix)?;
@@ -324,7 +324,10 @@ fn has_strong_binary_host_shape(host: &str) -> bool {
         return false;
     }
 
-    let relevant = if matches!(labels.first(), Some(&"www" | &"ftp")) {
+    let relevant = if labels
+        .first()
+        .is_some_and(|label| label.eq_ignore_ascii_case("www") || label.eq_ignore_ascii_case("ftp"))
+    {
         &labels[1..]
     } else {
         &labels[..]

--- a/src/scanner/process/contacts.rs
+++ b/src/scanner/process/contacts.rs
@@ -57,7 +57,8 @@ pub(super) fn extract_email_url_information(
                         d.start_line,
                     )
             })
-            .filter(|d| seen_email_spans.insert((d.email.clone(), d.start_line, d.end_line)))
+            // Address identity ignores case even though the emitted value keeps it.
+            .filter(|d| seen_email_spans.insert((d.email.to_lowercase(), d.start_line, d.end_line)))
             .map(|d| OutputEmail {
                 email: d.email,
                 start_line: d.start_line,

--- a/src/scanner/process/contacts_test.rs
+++ b/src/scanner/process/contacts_test.rs
@@ -197,7 +197,7 @@ fn test_extract_email_url_information_keeps_gettext_mo_contacts() {
         .expect("builder should produce file info");
 
     assert_eq!(file.emails.len(), 2, "emails: {:?}", file.emails);
-    assert_eq!(file.emails[0].email, "ll@li.org");
+    assert_eq!(file.emails[0].email, "LL@li.org");
     assert_eq!(file.emails[1].email, "cs@sweetgood.de");
 }
 
@@ -292,7 +292,7 @@ fn test_extract_email_url_information_keeps_short_uppercase_font_metadata_email(
         .expect("builder should produce file info");
 
     assert_eq!(file.emails.len(), 1, "emails: {:?}", file.emails);
-    assert_eq!(file.emails[0].email, "a@0.cc");
+    assert_eq!(file.emails[0].email, "A@0.CC");
     assert_eq!(file.urls.len(), 1, "urls: {:?}", file.urls);
     assert_eq!(
         file.urls[0].url,
@@ -351,4 +351,62 @@ fn test_extract_email_url_information_prefers_unique_text_emails_before_cap() {
     assert!(emails.contains(&"dev-subscribe@parquet.apache.org"));
     assert!(emails.contains(&"jaxrs-dev@eclipse.org"));
     assert!(!emails.contains(&"mvel2@2.5.2.final"));
+}
+
+#[test]
+fn test_extract_email_url_information_preserves_source_case_and_dedupes_variants() {
+    let mut builder = FileInfoBuilder::default();
+    let options = TextDetectionOptions {
+        collect_info: false,
+        detect_packages: false,
+        detect_application_packages: false,
+        detect_system_packages: false,
+        detect_packages_in_compiled: false,
+        detect_copyrights: false,
+        detect_generated: false,
+        detect_emails: true,
+        detect_urls: false,
+        max_emails: 50,
+        max_urls: 50,
+        timeout_seconds: 120.0,
+    };
+
+    let text = concat!(
+        "mail Richard.M.Bartel@ccMail.Census.GOV and Paul.Green@stratus.com paul.green@stratus.com\n",
+        "again Paul.Green@stratus.com\n",
+    );
+
+    extract_email_url_information(
+        &mut builder,
+        Path::new("config.guess"),
+        text,
+        &options,
+        false,
+    );
+
+    let file = builder
+        .name("config.guess".to_string())
+        .base_name("config".to_string())
+        .extension(".guess".to_string())
+        .path("config.guess".to_string())
+        .file_type(FileType::File)
+        .size(1)
+        .build()
+        .expect("builder should produce file info");
+
+    let emails: Vec<(&str, usize)> = file
+        .emails
+        .iter()
+        .map(|email| (email.email.as_str(), email.start_line.get()))
+        .collect();
+    assert_eq!(
+        emails,
+        vec![
+            ("Richard.M.Bartel@ccMail.Census.GOV", 1),
+            ("Paul.Green@stratus.com", 1),
+            ("Paul.Green@stratus.com", 2),
+        ],
+        "emails: {:?}",
+        file.emails
+    );
 }


### PR DESCRIPTION
## Summary

- Email detection lowercased the entire regex match, so `Paul.Green@stratus.com` was emitted as `paul.green@stratus.com` and `Richard.M.Bartel@ccMail.Census.GOV` as `richard.m.bartel@ccmail.census.gov`. RFC 5321 §2.4 makes the **local part** case-sensitive — only the domain is case-insensitive — so folding the whole address discards information the source file carried, and for an attribution field the source form is what a reader wants to see.
- `find_emails` now emits the matched source text. The junk/domain filters (`is_good_email_domain`, `classify_email`) already lowercase internally, so they behave identically on the unfolded value.
- Deduplication still treats one address as one address: the `unique` filter, the `max_emails` cap, and the per-span dedup in `extract_email_url_information` now fold case explicitly for their keys while the emitted value keeps the source form. First occurrence wins, so the value shown is the first form the file uses.
- Two binary-string helpers compared against an assumed-lowercase email; both now compare case-insensitively so the binary/font contact path keeps its previous behavior:
  - `extract_named_author_from_binary_line` located the email inside a lowercased line (`lower_line.find(email)`), which would have stopped finding mixed-case addresses.
  - `has_strong_binary_host_shape` matched the `www`/`ftp` leading label with an exact `==`.
- The lowercasing was never a documented or tested contract: it arrived in the original `feat(finder): implement email/url detection and scanner integration` commit with no comment, no doc statement, and no test asserting the folded form as intent. The only two tests that pinned lowercase values (`LL@li.org`, `A@0.CC`) assert *survival* of the detection; the lowercase spelling in them was incidental, and both inputs are uppercase in the source string, so their expectations now read back the source form.

## Issues

- Covers: lossy lowercasing of detected email addresses.

## Scope and exclusions

- Included: `src/finder/emails.rs` emission and dedup keys, the per-span dedup in `src/scanner/process/contacts.rs`, two case-insensitivity fixes in `src/scanner/process/binary_text.rs`, and the `OutputEmail.email` field meaning in the generated output-field reference.
- Explicit exclusions: URL normalization is untouched — URL hosts are genuinely case-insensitive and the `url` crate already normalizes them. Copyright/holder/author values are also untouched: they were already source-faithful (`Copyright 2024 Jane Doe <Jane.Doe@Acme.COM>` renders as written), so this change makes the `emails` entry agree with the copyright value instead of contradicting it.

## How to verify

Scan `erts/autoconf/config.guess` from `erlang/otp @ 6146f0df` and inspect `files[0].emails`:

```
curl -sLO https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e/erts/autoconf/config.guess
provenant scan --json-pp - --email config.guess | jq '.files[0].emails[].email'
```

`Richard.M.Bartel@ccMail.Census.GOV` (line 1375) and `Paul.Green@stratus.com` (lines 1388, 1392) now come back as written. The finding count is unchanged at 10, so nothing was split or merged by the switch.

Worth poking at: a file that writes the same address twice with different casing on one line — it should still yield a single finding for that span, spelled the way the source spells it first.

## Intentional differences from Python

- None. ScanCode also preserves the source case here; this removes a Provenant-only divergence. Note that `testdata/summarycode-golden/tallies/full_tallies/tallies_by_facet.expected.json` already carries mixed-case emails (`ssteinerX@gmail.com`, `Dev@SLaks.net`) because it is a reshaped-JSON fixture rather than a native scan — independent evidence that the source case is the expected shape.

## Follow-up work

- Created or intentionally deferred: none.

## Expected-output fixture changes

- Files changed: none. `docs/OUTPUT_FIELD_REFERENCE.md` moved, but only as the regenerated form of the `OutputEmail.email` field meaning ("Extracted email address, in the case the source file used."); it is produced by `generate-output-field-reference`, not hand-edited.
- Why the new expected output is correct: no golden expectation shifted. `finder_golden` (the email/URL fixtures), `copyright_golden`, `scanner_integration`, `post_processing_golden`, `license_detection_golden`, and `output_format_golden` all pass unchanged, because every email in those fixtures is already lowercase in its source file. The only expectation edits are the two in-tree unit assertions described above, in `src/scanner/process/contacts_test.rs`, whose inputs are uppercase in the source (`translator LL@li.org`, `xx/A@0.CC`) and which now read back that source form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
