### PR TITLE
fix(copyright): drop values that are source code or a notice template

### DIFF
--- a/src/copyright/detector/pattern_extract/extraction/content.rs
+++ b/src/copyright/detector/pattern_extract/extraction/content.rs
@@ -58,7 +58,8 @@ pub fn extract_spdx_filecopyrighttext_c_without_year(
         }
 
         let raw = format!("Copyright (c) {tail}");
-        if let Some(refined) = refine_copyright(&raw) {
+        // Junk-screened like every other copyright build site.
+        if let Some(refined) = refine_copyright(&raw).filter(|r| !is_junk_copyright(r)) {
             copyrights.push(CopyrightDetection {
                 copyright: refined,
                 start_line: LineNumber::new(ln).unwrap(),

--- a/src/copyright/detector/pattern_extract/extraction/mod.rs
+++ b/src/copyright/detector/pattern_extract/extraction/mod.rs
@@ -15,7 +15,7 @@ use crate::copyright::detector::token_utils::normalize_whitespace;
 use crate::copyright::line_tracking::{LineNumberIndex, PreparedLines};
 use crate::copyright::prepare::prepare_text_line;
 use crate::copyright::refiner::{
-    refine_copyright, refine_holder, refine_holder_in_copyright_context,
+    is_junk_copyright, refine_copyright, refine_holder, refine_holder_in_copyright_context,
 };
 use crate::copyright::types::{CopyrightDetection, HolderDetection};
 use crate::models::LineNumber;

--- a/src/copyright/refiner/copyrights_junk_patterns.rs
+++ b/src/copyright/refiner/copyrights_junk_patterns.rs
@@ -234,7 +234,8 @@ pub(super) static COPYRIGHTS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new
         r"(?i)^copyright protection\b",
         r"(?i)^copyright owner\b",
         r"(?i)^copyright [a-z]$",
-        r"(?i)^copyright yyyy\b",
+        // Any marker/sign combination followed by a `YYYY` placeholder year.
+        r"(?i)^(?:copyright|copr\.?|\(c\)|©)(?:\s*(?:\(c\)|©))*\s+y{4}\b",
         r"(?i)^copyright exceptions\b",
         r"(?i)^copyright or patent\b",
         r"(?i)^copyright is claimed\b",
@@ -545,7 +546,6 @@ pub(super) static COPYRIGHTS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new
         r"(?i)^\(c\) io\\0",
         r"(?i)^\(c\) ecfieldelement\b",
         r"(?i)^\(c\) distributed\b",
-        r"(?i)^\(c\) yyyy\b",
         r"(?i)^\(c\) rebel\b",
         r"(?i)^\(c\) metastuff\b",
         r"(?i)^\(c\) mihai\b",

--- a/src/copyright/refiner/holders_junk_patterns.rs
+++ b/src/copyright/refiner/holders_junk_patterns.rs
@@ -203,6 +203,8 @@ pub(super) static HOLDERS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(||
         r"(?i)\bpkg\.(author|homepage)\b",
         r"(?i)\bdate\.year\b",
         r"(?i)\bYYYY-MM-DD\b",
+        // A `YYYY` placeholder in the year slot means the party name is one too.
+        r"(?i)^y{4}(?:\s*-\s*y{4})?\b",
         r"(?i)<\s*pkg\.[a-zA-Z0-9_.-]+\s*>",
         r"(?i)^http://www\.quirksmode\b",
         r"[→⟶]",

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -1136,8 +1136,10 @@ pub(crate) fn is_path_like_code_fragment(s: &str) -> bool {
 /// this predicate. We require syntax specific to code: namespace `::`, a
 /// method/property call (`ident.ident(`), a C-style address-of argument closing
 /// a call or statement (` &copyRegion)` / ` &result;`), a keyword/assignment
-/// call argument (`create(pk=1`), or a Django-style ORM access (`.objects.`,
-/// `models.ForeignKey`/`ManyToManyField`/`OneToOneField`).
+/// call argument (`create(pk=1`), a Django-style ORM access (`.objects.`,
+/// `models.ForeignKey`/`ManyToManyField`/`OneToOneField`), a string literal
+/// spliced around bare variables (`"Copyright Acme ", Year, ". All ..."`),
+/// `#{...}` interpolation, or a spaced ` <- ` arrow.
 ///
 /// The strong structural signals (namespace, method call, address-of-in-call,
 /// ORM) are always honoured — including on a raw source span that happens to
@@ -1149,7 +1151,7 @@ pub(crate) fn looks_like_source_code(s: &str) -> bool {
     // Structural code signals that never appear in a real name or notice.
     static STRONG_SOURCE_CODE_RE: LazyLock<Regex> = LazyLock::new(|| {
         compile_static_regex(
-            r"(?x)
+            r#"(?x)
             # namespace resolution: ident::ident
             \b[A-Za-z_][A-Za-z0-9_]*::[A-Za-z_~]
             # method or property call: foo.bar(...). The `(` must follow the
@@ -1164,7 +1166,15 @@ pub(crate) fn looks_like_source_code(s: &str) -> bool {
             # code. The trailing `)` also excludes name fragments such as
             # `Ernst &young` that are not followed by call punctuation.
           | (?:^|[\s(,])&[a-z][A-Za-z0-9_]*\s*\)
-            ",
+            # a notice spliced from string literals and bare variables:
+            # `"Copyright Acme ", Year, ". All ..."`. Requiring the quote to
+            # reopen is what keeps a quoted party (`"Acme", Inc.`) out.
+          | "\s*,\s*(?:[A-Za-z_$][A-Za-z0-9_$]*\s*,\s*)+"
+            # string interpolation: Elixir/Ruby/CoffeeScript `#{expr}`.
+          | \#\{
+            # a spaced ` <- ` binding/comprehension arrow.
+          | \s<-\s
+            "#,
         )
     });
     static ORM_RE: LazyLock<Regex> = LazyLock::new(|| {

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -3271,3 +3271,67 @@ fn test_junk_copyright_keeps_notices_naming_the_holder_after_the_marker() {
         );
     }
 }
+
+#[test]
+fn test_looks_like_source_code_rejects_notice_built_by_code() {
+    // Erlang/Elixir source that assembles a notice from string literals and
+    // variables, as found in erlang/otp's header tooling.
+    for code in [
+        r#"[["Copyright Ericsson AB ", StartYear, LastUpdatedYear, ". All Rights Reserved."] | T]"#,
+        r#"[["Copyright Ericsson AB ", LastUpdatedYear, ". All Rights Reserved."]]"#,
+        r#"Copyright Ericsson AB ", Years, ". All Rights Reserved."#,
+        "end || Copyright <- Copyrights], {Copyrights, Rest};",
+        r#"~s'<p>Copyright © 1996-#{current_datetime.year} Ericsson AB</p>'"#,
+    ] {
+        assert!(looks_like_source_code(code), "kept {code:?}");
+    }
+}
+
+#[test]
+fn test_looks_like_source_code_keeps_notices_with_quotes_brackets_and_pipes() {
+    for notice in [
+        "Copyright (c) 2024 Example Corp. (http://example.com)",
+        "Copyright 2024 Example, Inc. [All rights reserved]",
+        r#"Copyright (c) 2001 John "Jack" Doe, Inc."#,
+        r#"Copyright 2020 "Acme", Inc."#,
+        "| Copyright (c) 2020 Acme Ltd | MIT |",
+        "Copyright Ericsson AB 2011-2025. All Rights Reserved.",
+        // A banner sharing its line with ordinary code: `||` is too common in
+        // real source to treat as a code signal on its own.
+        "/*! Copyright (c) 2020 Acme Inc. All rights reserved. */ if (a || b) { c(); }",
+    ] {
+        assert!(!looks_like_source_code(notice), "dropped {notice:?}");
+    }
+}
+
+#[test]
+fn test_placeholder_year_after_any_copyright_marker_is_junk() {
+    for template in [
+        "Copyright YYYY CopyrightHolder",
+        "Copyright (c) YYYY CopyrightHolder",
+        "Copyright (C) YYYY-YYYY CopyrightHolder",
+        "Copyright © YYYY Example Corp.",
+        "(c) YYYY Example Corp.",
+    ] {
+        assert!(is_junk_copyright(template), "kept {template:?}");
+    }
+    // The holder the template leaves behind is a placeholder too.
+    assert_eq!(refine_holder("YYYY CopyrightHolder"), None);
+    assert_eq!(refine_holder("YYYY-YYYY CopyrightHolder"), None);
+    assert_eq!(refine_holder("YYYY-yyyy Full Name"), None);
+}
+
+#[test]
+fn test_placeholder_year_rule_keeps_real_years_and_holders() {
+    for notice in [
+        "Copyright (c) 2024 Example Corp.",
+        "Copyright © 1996-2024 Ericsson AB",
+        "(c) 2019 The ORT Project Authors",
+    ] {
+        assert!(!is_junk_copyright(notice), "dropped {notice:?}");
+    }
+    assert_eq!(
+        refine_holder("Yyyyaka Tanaka"),
+        Some("Yyyyaka Tanaka".to_string())
+    );
+}

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1627,3 +1627,101 @@ fn test_extract_copyright_information_html_anchor_notice_carries_no_markup() {
         file.holders
     );
 }
+
+#[test]
+fn test_extract_copyright_information_drops_code_and_template_notice_values() {
+    // erlang/otp assembles its own headers in Erlang and Elixir, so the notice
+    // text reaches the detector as a string literal spliced around variables, a
+    // list comprehension, an interpolated sigil, or a documented placeholder.
+    for (name, text) in [
+        (
+            "license-header.es",
+            "[[\"Copyright Ericsson AB \", StartYear, LastUpdatedYear, \". All Rights Reserved.\"] | T]",
+        ),
+        (
+            "license-header.es",
+            "     end || Copyright <- Copyrights],\n    {Copyrights, Rest};",
+        ),
+        (
+            "make_atomics_api",
+            " * Copyright Ericsson AB \", Years, \". All Rights Reserved.",
+        ),
+        (
+            "ex_doc.exs",
+            "      ~s'<p>Copyright © 1996-#{current_datetime.year} <a href=\"https://www.ericsson.com\">Ericsson AB</a></p>'",
+        ),
+        (
+            "FILE-HEADERS.md",
+            "  - `SPDX-FileCopyrightText: Copyright (C) YYYY CopyrightHolder`",
+        ),
+    ] {
+        let mut builder = FileInfoBuilder::default();
+        extract_copyright_information(&mut builder, Path::new(name), text, 120.0, false);
+        let file = build_single_file(builder);
+        assert!(
+            file.copyrights.is_empty(),
+            "copyright leaked from {text:?}: {:?}",
+            file.copyrights
+                .iter()
+                .map(|c| &c.copyright)
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            file.holders.is_empty(),
+            "holder leaked from {text:?}: {:?}",
+            file.holders.iter().map(|h| &h.holder).collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn test_extract_copyright_information_keeps_notices_with_code_like_punctuation() {
+    let text = concat!(
+        "Copyright (c) 2024 Example Corp. (http://example.com)\n",
+        "Copyright 2024 Example, Inc. [All rights reserved]\n",
+        "Copyright (c) 2001 John \"Jack\" Doe, Inc.\n",
+        "Copyright 2020 \"Acme\", Inc.\n",
+        "%% Copyright Ericsson AB 2011-2025. All Rights Reserved.\n",
+    );
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("NOTICE"), text, 120.0, false);
+
+    let file = build_single_file(builder);
+    let values: Vec<&String> = file.copyrights.iter().map(|c| &c.copyright).collect();
+    for expected in [
+        "Copyright (c) 2024 Example Corp. (http://example.com)",
+        "Copyright (c) 2001 John \"Jack\" Doe, Inc.",
+        "Copyright 2020 \"Acme\", Inc.",
+        "Copyright Ericsson AB 2011-2025. All Rights Reserved.",
+    ] {
+        assert!(
+            values.iter().any(|v| v.as_str() == expected),
+            "missing {expected:?} in {values:?}"
+        );
+    }
+    assert!(
+        values
+            .iter()
+            .any(|v| v.starts_with("Copyright 2024 Example")),
+        "missing the bracketed-suffix notice in {values:?}"
+    );
+}
+
+#[test]
+fn test_extract_copyright_information_keeps_banner_on_a_line_shared_with_code() {
+    let text = "/*! Copyright (c) 2020 Acme Inc. All rights reserved. */ if (a || b) { c(); }";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("bundle.js"), text, 120.0, false);
+
+    let file = build_single_file(builder);
+    assert!(
+        file.copyrights
+            .iter()
+            .any(|c| c.copyright.contains("Acme Inc.")),
+        "banner dropped: {:?}",
+        file.copyrights
+            .iter()
+            .map(|c| &c.copyright)
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

- erlang/otp writes its own license headers with Erlang and Elixir tooling, so the notice text reaches the detector as program source. Verifying `6146f0df` with `compare-outputs --profile common` surfaced Provenant-only copyright values that are source code or a documented template, plus their holders.
- Teach `looks_like_source_code` three more structural signals — a string literal spliced around bare variables, `#{...}` interpolation, and a spaced ` <- ` arrow — so both the refined value and the raw source span behind a detection are recognised as code.
- A spaced ` || ` was tried as a fourth signal and rejected: it drops a real banner that shares its line with ordinary source (`/*! Copyright (c) 2020 Acme Inc. */ if (a || b) { c(); }`), and the one line it was needed for carries a ` <- ` too. That case is pinned as a kept-side test.
- Replace the two marker-specific placeholder-year junk patterns with one rule that tolerates a copyright sign between the marker and `YYYY`, and reject a holder that opens with the same placeholder.
- Screen `extract_spdx_filecopyrighttext_c_without_year` with `is_junk_copyright`, which every other copyright build site already applies.

Dropped values, all of which are now gone from the scan:

```text
scripts/license-header.es L371
  copyright [["Copyright Ericsson AB ", StartYear, LastUpdatedYear, ". All Rights Reserved."] | T]
  holder    Ericsson AB StartYear
scripts/license-header.es L383, L385     (same string-splice code, one line each)
  copyright Copyright Ericsson AB
  holder    Ericsson AB
scripts/license-header.es L494-495
  copyright end || Copyright <- Copyrights], {Copyrights, Rest};
erts/lib_src/utils/make_atomics_api L1425
  copyright Copyright Ericsson AB ", Years, ". All Rights Reserved.
  holder    Ericsson AB Years
make/ex_doc.exs L223
  copyright ~s' Copyright © 1996-#{current_datetime.year} https://www.ericsson.com Ericsson AB '
  holder    current_datetime.year Ericsson AB
HOWTO/FILE-HEADERS.md L146-149 (and the backtick-suffixed SPDX-prefixed spellings)
  copyright Copyright (c) YYYY CopyrightHolder
  copyright Copyright (c) YYYY-YYYY CopyrightHolder
  holder    YYYY CopyrightHolder / YYYY-YYYY CopyrightHolder / YYYY-yyyy Full Name
```

Each file's genuine header (`Copyright Ericsson AB 2011-2025. All Rights Reserved.`, `copyright (c) 2011, Rickard Green`, the `Rickard Green <rickard@erlang.org>` author line, …) is unchanged.

## Scope and exclusions

- Included: the three source-code signals, the placeholder-year rule for copyrights and holders, and the missing junk screen on the SPDX extraction path.
- Explicit exclusions:
  - `Copyright Ericsson AB YYYY.` (`HOWTO/FILE-HEADERS.md` L137-138) is left as-is. The placeholder sits after a real holder rather than in the marker's year slot, so it is a different judgment from the marker-adjacent family this PR completes.
  - The prose copyright and holder on L133 of the same file (`The copyright notice must start with ...` / `can have as prefix the SPDX annotation`) is a prose false positive, not a code or template one.
  - The markdown-table artifacts visible in the true-positive fixture below are a separate class and untouched here.

## How to verify

The risk in this change is the kept side, so the interesting check is that real notices carrying code-like punctuation survive. Scan a file containing:

```text
Copyright (c) 2024 Example Corp. (http://example.com)
Copyright 2024 Example, Inc. [All rights reserved]
Copyright (c) 2001 John "Jack" Doe, Inc.
Copyright 2020 "Acme", Inc.
Copyright Ericsson AB 2011-2025. All Rights Reserved.
Copyright (c) 2019 The ORT Project Authors
| Copyright (c) 2020 Acme Ltd | MIT |
Copyright (c) Meta Platforms, Inc. and affiliates.
Copyright (c) 2020 R&D Systems, Inc.
Copyright (c) 1998-2000 The OpenSSL Project. All rights reserved.
```

with `provenant scan --json-pp - --copyright <file>`; every line must still yield its copyright and holder. All ten are byte-identical before and after this branch, and the same set is pinned as unit tests.

Then scan the four upstream files at `6146f0df` (fetch with `curl -sL https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e/<path>`) and confirm only the real headers remain.

## Follow-up work

- Created or intentionally deferred: the year-after-holder placeholder shape (`Copyright Ericsson AB YYYY.`) and the prose false positive on `HOWTO/FILE-HEADERS.md` L133, both described under exclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
