### PR TITLE
fix(copyright): reject authors and holders that source lines disprove

### DIFF
--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -9,7 +9,9 @@ use regex::Regex;
 use super::super::token_utils::normalize_whitespace;
 use crate::copyright::line_tracking::PreparedLines;
 use crate::copyright::prepare::prepare_text_line;
-use crate::copyright::refiner::{looks_like_name_with_parenthesized_url, refine_author};
+use crate::copyright::refiner::{
+    contains_xml_markup_declaration_token, looks_like_name_with_parenthesized_url, refine_author,
+};
 use crate::copyright::types::{AuthorDetection, CopyrightDetection};
 use crate::models::LineNumber;
 
@@ -454,6 +456,75 @@ pub(in super::super) fn drop_markup_element_value_authors(
             return true;
         };
         !window_contains_markup_element_author_value(&window, &author.author)
+    });
+}
+
+/// Drop authors detected on an XML/DTD markup declaration line, such as the
+/// `<!ELEMENT module (args?, description?, author*, copyright?,` and
+/// `<!ATTLIST author` content models embedded in Erlang edoc comments. There the
+/// `author` token names an element, not a person, and refinement has already
+/// dropped the declaration marker the value would otherwise be filtered on.
+pub(in super::super) fn drop_markup_declaration_authors(
+    raw_lines: &[&str],
+    authors: &mut Vec<AuthorDetection>,
+) {
+    if raw_lines.is_empty() || authors.is_empty() {
+        return;
+    }
+
+    authors.retain(|author| {
+        !(author.start_line.get()..=author.end_line.get()).any(|line_number| {
+            raw_lines
+                .get(line_number.saturating_sub(1))
+                .is_some_and(|line| contains_xml_markup_declaration_token(line))
+        })
+    });
+}
+
+/// Drop an author harvested by an author-label word that closes a prose
+/// sentence: `... have been regular contributors.  Brian Rosen did tremendous
+/// service ...` and the RFC running footer `Groves, et al.    Standards Track
+/// [Page 169]`. The capitalized words after the period open a new sentence or a
+/// new footer column, so the label does not introduce them.
+pub(in super::super) fn drop_authors_after_sentence_final_label(
+    raw_lines: &[&str],
+    authors: &mut Vec<AuthorDetection>,
+) {
+    // The label is required to be lowercase and to follow a lowercase prose
+    // word, so a heading (`Authors.  Jane Doe`) still introduces its author.
+    static SENTENCE_FINAL_LABEL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\p{Ll}[\p{Ll}']*\s+(?:al|authors?|contributors?|maintainers?)\.\s+$").unwrap()
+    });
+
+    if raw_lines.is_empty() || authors.is_empty() {
+        return;
+    }
+
+    authors.retain(|author| {
+        let Some(name) = author.author.split_whitespace().next() else {
+            return true;
+        };
+        if !name.starts_with(char::is_uppercase) {
+            return true;
+        }
+        let line_number = author.start_line.get();
+        let Some(line) = raw_lines.get(line_number.saturating_sub(1)) else {
+            return true;
+        };
+        // The label can sit on the previous line when prose wraps, so both lines
+        // are searched for the sentence end that precedes the name.
+        let previous = line_number
+            .checked_sub(2)
+            .and_then(|index| raw_lines.get(index))
+            .copied()
+            .unwrap_or_default();
+        !line.match_indices(name).any(|(at, _)| {
+            line[..at]
+                .chars()
+                .next_back()
+                .is_none_or(|ch| !ch.is_alphanumeric())
+                && SENTENCE_FINAL_LABEL_RE.is_match(&format!("{previous} {}", &line[..at]))
+        })
     });
 }
 

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -5,6 +5,7 @@
 // Derived from ScanCode Toolkit (Apache-2.0); modified. See NOTICE.
 
 use crate::copyright::line_tracking::PreparedLines;
+use crate::copyright::refiner::has_copyright_year;
 use crate::copyright::types::{AuthorDetection, CopyrightDetection, HolderDetection};
 use crate::models::LineNumber;
 use regex::Regex;
@@ -311,6 +312,8 @@ fn run_author_extraction_and_repairs(
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
     super::author_heuristics::drop_markup_element_value_authors(raw_lines, authors);
+    super::author_heuristics::drop_markup_declaration_authors(raw_lines, authors);
+    super::author_heuristics::drop_authors_after_sentence_final_label(raw_lines, authors);
     seen.rebuild_authors_from(authors);
 }
 
@@ -481,6 +484,7 @@ fn drop_placeholder_and_code_junk_by_raw_line(
         is_embedded_c_sign_code_fragment_line(trimmed)
             || is_copyright_edit_note_line(trimmed)
             || is_copyright_holder_placeholder_line(trimmed)
+            || is_pattern_match_binding_line(trimmed)
     };
 
     copyrights.retain(|c| !is_junk_line(c.start_line));
@@ -505,6 +509,44 @@ fn is_copyright_holder_placeholder_line(line: &str) -> bool {
     });
 
     COPYRIGHT_HOLDER_PLACEHOLDER_RE.is_match(line.trim())
+}
+
+/// Whether the line binds values with a pattern-match or short-declaration
+/// operator (Erlang `#{<<"path">> := Path} = Copyright,`, Go `x := y`), which
+/// makes a bare `Copyright` token on it a variable rather than a notice. A
+/// quoted notice being assigned, or a year anywhere on the line, keeps it.
+fn is_pattern_match_binding_line(line: &str) -> bool {
+    line.contains(":=") && !has_quoted_copyright(line) && !has_copyright_year(line)
+}
+
+/// Whether `copyright` appears inside a quoted segment of the line, which makes
+/// it assigned text rather than an identifier. Walking the line tracks which
+/// delimiter opened the string and which are escaped, so neither an escaped
+/// quote nor an escaped backslash before a real one shifts the boundaries.
+fn has_quoted_copyright(line: &str) -> bool {
+    let mut open_quote: Option<char> = None;
+    let mut escaped = false;
+    let mut quoted = String::new();
+    for ch in line.chars() {
+        if escaped {
+            escaped = false;
+            if open_quote.is_some() {
+                quoted.push(ch);
+            }
+        } else if ch == '\\' {
+            escaped = true;
+        } else if matches!(ch, '"' | '\'') {
+            match open_quote {
+                Some(opener) if opener == ch => open_quote = None,
+                Some(_) => quoted.push(ch),
+                None => open_quote = Some(ch),
+            }
+        } else if open_quote.is_some() {
+            quoted.push(ch);
+        }
+    }
+
+    quoted.to_ascii_lowercase().contains("copyright")
 }
 
 fn is_embedded_c_sign_code_fragment_line(line: &str) -> bool {

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -975,3 +975,133 @@ SOFTWARE OR DOCUMENTATION.</p>
     );
     assert!(holders.is_empty(), "unexpected holders: {holders:?}");
 }
+
+#[test]
+fn test_dtd_markup_declaration_comments_are_not_authors() {
+    // Erlang edoc modules embed the edoc DTD in comments, where `author` names an
+    // element in a content model. The refined values ("copyright?",
+    // "EMPTY !ATTLIST") no longer carry the declaration marker, so the raw source
+    // line is what identifies them.
+    let content = "\
+%% @author Richard Carlsson <carlsson.richard@gmail.com>
+%%
+%% <!ELEMENT module (args?, description?, author*, copyright?,
+%%                   version?, since?, deprecated?, see*, reference*,
+%%                   functions)>
+%% <!ELEMENT author EMPTY>
+%% <!ATTLIST author
+%%   name CDATA #REQUIRED
+%%   email CDATA #IMPLIED>
+";
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(content);
+    let vals: Vec<&String> = authors.iter().map(|a| &a.author).collect();
+    assert_eq!(
+        vals,
+        vec!["Richard Carlsson <carlsson.richard@gmail.com>"],
+        "expected only the tagged author, got {vals:?}"
+    );
+}
+
+#[test]
+fn test_author_label_closing_a_sentence_does_not_name_the_next_sentence() {
+    // A lowercase `contributors.`/`et al.` that ends a sentence is no label for the
+    // capitalized words after the period: those open a new sentence, or — in an RFC
+    // running footer — a new column.
+    for text in [
+        "   The most active people have been Tom Taylor and Kevin Boyle, but\n   many other people have been regular\n   contributors.  Brian Rosen did tremendous service in putting together\n   the Megaco interoperability tests.\n",
+        "   many other people have been regular contributors.\n   Brian Rosen did tremendous service in putting together the tests.\n",
+        "Groves, et al.              Standards Track                   [Page 169]\n",
+    ] {
+        let (_copyrights, _holders, authors) = detect_copyrights_from_text(text);
+        let vals: Vec<&String> = authors.iter().map(|a| &a.author).collect();
+        assert!(
+            vals.is_empty(),
+            "prose produced authors: {vals:?} for {text:?}"
+        );
+    }
+}
+
+#[test]
+fn test_labels_that_really_introduce_an_author_are_kept() {
+    // The sentence-final-label rule must keep a trailing collective author and a
+    // capitalized `Authors.` heading that does introduce the names beside it.
+    for (text, expected) in [
+        (
+            "This product includes software developed by Jane Doe and its contributors.\n",
+            "Jane Doe and its contributors",
+        ),
+        ("Authors.  Jane Doe wrote this.\n", "Jane Doe wrote"),
+    ] {
+        let (_copyrights, _holders, authors) = detect_copyrights_from_text(text);
+        let vals: Vec<&String> = authors.iter().map(|a| &a.author).collect();
+        assert!(
+            vals.iter().any(|a| a.as_str() == expected),
+            "expected author {expected:?} in {vals:?} for {text:?}"
+        );
+    }
+}
+
+#[test]
+fn test_holder_drops_a_trailing_see_cross_reference() {
+    let content = "## Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)\n";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    let vals: Vec<&String> = holders.iter().map(|h| &h.holder).collect();
+    assert_eq!(
+        vals,
+        vec!["The ORT Project Authors"],
+        "expected the bare holder, got {vals:?}"
+    );
+    // The statement itself keeps the whole notice, reference and all.
+    assert!(
+        copyrights.iter().any(|c| c.copyright
+            == "Copyright (c) 2022 The ORT Project Authors (see https://github.com/oss-review-toolkit/ort/blob/main/NOTICE )"),
+        "expected the full statement, got {copyrights:?}"
+    );
+}
+
+#[test]
+fn test_pattern_match_binding_lines_are_not_copyrights() {
+    // Erlang pattern matching binds a `Copyright` variable, so the word is an
+    // identifier and the next line's variable is not its holder.
+    let content = "\
+classify_copyright_result(Filename) ->
+    lists:foldl(fun (Copyright, Acc) ->
+                        #{<<\"statement\">> := CopyrightSt} = Copyright,
+                        #{<<\"path\">> := Path} = Location,
+                        Acc#{Path => CopyrightSt}
+                    end, #{}, Copyrights).
+";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    assert!(
+        copyrights.is_empty(),
+        "unexpected copyrights: {copyrights:?}"
+    );
+    assert!(holders.is_empty(), "unexpected holders: {holders:?}");
+
+    // A real notice being assigned on such a line is kept, dated or not: the
+    // quotes, or a year, say the words are text rather than an identifier.
+    for (text, expected) in [
+        (
+            "\tnotice := \"Copyright (c) 2020 Acme Corp. All rights reserved.\"\n",
+            "Copyright (c) 2020 Acme Corp.",
+        ),
+        (
+            "\tnotice := \"Copyright Acme Corp. All rights reserved.\"\n",
+            "Copyright Acme Corp.",
+        ),
+        (
+            "\tnotice := \"Say \\\" then Copyright Acme Corp. All rights reserved.\"\n",
+            "Copyright Acme Corp.",
+        ),
+    ] {
+        let (copyrights, holders, _authors) = detect_copyrights_from_text(text);
+        assert!(
+            copyrights.iter().any(|c| c.copyright == expected),
+            "expected {expected:?} for {text:?}, got {copyrights:?}"
+        );
+        assert!(
+            holders.iter().any(|h| h.holder == "Acme Corp."),
+            "expected the assigned holder for {text:?}, got {holders:?}"
+        );
+    }
+}

--- a/src/copyright/refiner/holder.rs
+++ b/src/copyright/refiner/holder.rs
@@ -60,6 +60,39 @@ pub(super) fn strip_trailing_parenthesized_obfuscated_email_in_holder(s: &str) -
     prefix.to_string()
 }
 
+/// Strip a trailing parenthesized cross-reference from a holder, as in
+/// `The ORT Project Authors (see <https://github.com/.../NOTICE>)`. The
+/// reference target is optional because earlier URL and angle-bracket stripping
+/// can already have emptied the parentheses.
+pub(super) fn strip_trailing_see_reference_in_holder(s: &str) -> String {
+    static SEE_REFERENCE_TAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        compile_static_regex(
+            r"(?ix)
+            ^(?P<prefix>.+?)
+            \s*\(\s*
+            (?:see(?:\s+also)?|refer\s+to|consult)
+            \b[^()]*
+            \)?\s*\.?\s*$
+            ",
+        )
+    });
+
+    let trimmed = s.trim();
+    let Some(cap) = SEE_REFERENCE_TAIL_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let prefix = cap
+        .name("prefix")
+        .map(|m| m.as_str())
+        .unwrap_or("")
+        .trim_end_matches(&[',', ';', ':', ' '][..])
+        .trim();
+    if !prefix.is_empty() && prefix_has_holder_words(prefix) {
+        return prefix.to_string();
+    }
+    s.to_string()
+}
+
 pub(super) fn strip_leading_and_onwards_holder_prefix(s: &str) -> String {
     static AND_ONWARDS_RE: LazyLock<Regex> =
         LazyLock::new(|| compile_static_regex(r"(?i)^(?:and\s+)?onwards\b[\s,;:.-]*"));
@@ -154,6 +187,7 @@ pub(super) fn refine_holder_impl(s: &str, in_copyright_context: bool) -> Option<
     h = remove_some_extra_words_and_punct(&h);
     h = strip_trailing_incomplete_as_represented_by(&h);
     h = strip_trailing_credit_file_reference_in_holder(&h);
+    h = strip_trailing_see_reference_in_holder(&h);
     h = strip_trailing_contributor_clause(&h);
     h = strip_trailing_contact_clause(&h);
     h = strip_trailing_holder_prose_clause(&h);

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -763,7 +763,7 @@ pub(super) fn contains_windows_versioninfo_token(s: &str) -> bool {
             || trimmed.to_ascii_lowercase().contains("legaltrademarks"))
 }
 
-pub(super) fn contains_xml_markup_declaration_token(s: &str) -> bool {
+pub(crate) fn contains_xml_markup_declaration_token(s: &str) -> bool {
     let lower = s.to_ascii_lowercase();
     lower.contains("<!element")
         || lower.contains("<!attlist")

--- a/src/copyright/refiner/mod.rs
+++ b/src/copyright/refiner/mod.rs
@@ -63,8 +63,9 @@ pub use copyright::refine_copyright;
 pub use holder::{refine_holder, refine_holder_in_copyright_context};
 pub use junk::is_junk_copyright;
 pub(crate) use junk::{
-    has_copyright_year, hf_tokenizer_merges_line_span, is_junk_holder, is_path_like_code_fragment,
-    is_tokenizer_data_fragment, looks_like_bpe_merges_table, looks_like_source_code,
+    contains_xml_markup_declaration_token, has_copyright_year, hf_tokenizer_merges_line_span,
+    is_junk_holder, is_path_like_code_fragment, is_tokenizer_data_fragment,
+    looks_like_bpe_merges_table, looks_like_source_code,
 };
 
 /// Compile a static regex literal.


### PR DESCRIPTION
## Summary

- Four Provenant-only author/holder false positives found verifying `erlang/otp @ 6146f0df` (`compare-outputs --profile common`) are gone; ScanCode emits none of them, so each fix is a noise reduction rather than a parity move.
- DTD content models embedded in edoc comments (`<!ELEMENT module (args?, description?, author*, copyright?,`, `<!ATTLIST author`) no longer yield the authors `copyright?` and `EMPTY !ATTLIST`. `contains_xml_markup_declaration_token` already guarded `refine_copyright`; the author path now applies it to the raw source line, because refinement strips the declaration marker out of the value before any value-level guard can see it (`copyright?` arrives at `refine_author` already clean).
- A lowercase `contributors.` / `et al.` that closes a prose sentence no longer labels the capitalized words after the period. That one rule kills both `Brian Rosen contributors` (glued across `... have been regular\n contributors.  Brian Rosen did tremendous service ...`) and the RFC running-footer author `Standards Track Page 169` (from `Groves, et al.   Standards Track   [Page 169]`, where `al.` is tagged as an author label). The label must be lowercase *and* follow a lowercase prose word, so a real `Authors.  Jane Doe` heading still introduces its author.
- A holder now drops a trailing parenthesized cross-reference, so `Copyright (C) 2022 The ORT Project Authors (see <.../NOTICE>)` gives the holder `The ORT Project Authors` instead of the malformed `The ORT Project Authors (see`. The statement itself keeps the reference, unchanged.
- An Erlang/Go pattern-match binding line (`#{<<"path">> := Path} = Copyright,`) is code, so a bare `Copyright` token on it is an identifier. Such a line no longer produces the holder `Path` — nor the meaningless copyright `Copyright, Path` it hung from. A notice being assigned is kept, dated or not: a `copyright` inside a quoted segment, or a year anywhere on the line, keeps the line (`notice := "Copyright Acme Corp. All rights reserved."` survives).

## Issues

- Covers: erlang/otp benchmark verification follow-ups (author/holder noise).

## Scope and exclusions

- Included: four generic guards in the copyright detector/refiner, plus regression tests that pin both the dropped and the kept side of each.
- Explicit exclusions: other `erlang/otp` findings left untouched here — the TOC-derived author `Addresses...........212 Full`, the over-long acknowledgements author `Mauricio Arango, ... does not appear` (a real name list, just too wide), and the holders `detection heuristics of REUSE tool in` / `ts in ~ts for ~ts~n`. No golden or benchmark rows are updated in this PR.

## How to verify

- Scan the four upstream files and look at `authors[]` / `holders[]`; before this change they carry the values above, after it they carry only the real ones (`Richard Carlsson <carlsson.richard@gmail.com>`, `Ericsson AB`, `Richard Carlsson`, `The Elixir Team`, `The ORT Project Authors`, `The Internet Society`):

  ```sh
  for f in lib/edoc/src/edoc_data.erl lib/edoc/src/edoc_layout.erl lib/edoc/priv/edoc.dtd \
           .ort/config/config.yml .ort/config/evaluator.rules.kts \
           .github/scripts/otp-compliance.es lib/megaco/doc/standard/rfc3525.txt; do
    curl -sL -O "https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e/$f"
  done
  provenant scan --json-pp - --copyright .
  ```

- Worth poking: a capitalized `Authors.` heading followed by names on the same line, a `Name and its contributors.` notice, and a Go/Pascal `:=` line whose string literal holds a notice, dated or not — all three must still be detected (each is pinned by a test).

## Intentional differences from Python

- ScanCode emits none of these four values, so this is purely a Provenant-side noise reduction; no compatibility lane changes.

## Follow-up work

- Created or intentionally deferred: the excluded `erlang/otp` findings listed above; the erlang/otp `BENCHMARKS.md` row can be refreshed once they are addressed.

## Expected-output fixture changes

- Files changed: none. The copyright, post-processing, scanner-integration, finder, and output-format golden suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
