### PR TITLE
fix(copyright): drop TOC dot-leader authors and truncate over-run author spans

### DIFF
--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -988,3 +988,42 @@ fn test_single_by_conjoined_name_list_stays_one_author() {
         "primary author missing: {values:?}"
     );
 }
+
+#[test]
+fn test_acknowledgements_author_list_stops_at_the_sentence_boundary() {
+    // RFC 3525 acknowledgements: the `authors,` label introduces a genuine name
+    // list, but the collected span used to run past `Pickett.` and swallow the
+    // next sentence. The list itself must survive.
+    let input = concat!(
+        "   Megaco/H.248 owes a large initial debt to the MGCP protocol (RFC\n",
+        "   2705), and thus to its authors, Mauricio Arango, Andrew Dugan, Ike\n",
+        "   Elliott, Christian Huitema, and Scott Pickett.  Flemming Andreasen\n",
+        "   does not appear on this list of authors, but was a major contributor\n",
+    );
+    let (_c, _h, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+
+    assert_eq!(
+        values,
+        vec!["Mauricio Arango, Andrew Dugan, Ike Elliott, Christian Huitema, and Scott Pickett"],
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_author_list_closed_by_a_period_is_kept() {
+    for input in [
+        "Authors: Jane Doe, John Smith.\n",
+        "@author Jane Doe. John Smith\n",
+    ] {
+        let (_c, _h, authors) = detect_copyrights_from_text(input);
+        let values: Vec<&str> = authors.iter().map(|a| a.author.as_str()).collect();
+
+        assert!(
+            values
+                .iter()
+                .any(|a| a.contains("Jane Doe") && a.contains("John Smith")),
+            "author list lost for {input:?}: {authors:?}"
+        );
+    }
+}

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -1105,3 +1105,18 @@ classify_copyright_result(Filename) ->
         );
     }
 }
+
+#[test]
+fn test_table_of_contents_dot_leader_line_is_not_an_author() {
+    // RFC 3525 table of contents: the `Authors'` label heads a dot-leader run and
+    // a page number, and the collected span also picks up the next entry's first
+    // word. ScanCode emits nothing.
+    let input = concat!(
+        "   Acknowledgments...............................................211\n",
+        "   Authors' Addresses............................................212\n",
+        "   Full Copyright Statement......................................213\n",
+    );
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -16,6 +16,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = strip_trailing_parenthesized_email_contact(&a);
     a = strip_trailing_at_handle(&a);
     a = truncate_trailing_collective_contributors_prose(&a);
+    a = truncate_prose_sentence_after_name(&a);
     a = strip_leading_maintainers_label(&a);
     a = strip_trailing_javadoc_tags(&a);
     a = strip_trailing_paren_years(&a);
@@ -630,6 +631,46 @@ fn truncate_trailing_collective_contributors_prose(s: &str) -> String {
     } else {
         s.to_string()
     }
+}
+
+/// Truncate an author value at a sentence boundary the collector ran past, as in
+/// the RFC 3525 acknowledgements `... and Scott Pickett. Flemming Andreasen does
+/// not appear`. Only a name-shaped head followed by a prose tail is an over-run
+/// span; a prose head, or a tail that is itself a name, is left to other rules.
+fn truncate_prose_sentence_after_name(s: &str) -> String {
+    // These carry a name-internal period, so theirs does not close a sentence.
+    const NAME_ABBREVIATIONS: &[&str] = &[
+        "inc", "ltd", "llc", "plc", "co", "corp", "gmbh", "jr", "sr", "dr", "mr", "mrs", "ms",
+        "prof", "st", "univ", "dept", "ed", "eds",
+    ];
+    static SENTENCE_BOUNDARY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"^(?P<head>.*?(?P<last>\p{Lu}[\p{L}'\x{2019}-]+))\.\s+(?P<tail>\p{Lu}.*)$")
+            .expect("valid author prose-sentence truncation regex")
+    });
+
+    let trimmed = s.trim();
+    let Some(cap) = SENTENCE_BOUNDARY_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let head = cap.name("head").map(|m| m.as_str()).unwrap_or("").trim();
+    let tail = cap.name("tail").map(|m| m.as_str()).unwrap_or("").trim();
+    let last = cap
+        .name("last")
+        .map(|m| m.as_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    if NAME_ABBREVIATIONS.contains(&last.as_str()) {
+        return s.to_string();
+    }
+    if head.split_whitespace().count() < 2 || looks_like_prose_fragment_author(head) {
+        return s.to_string();
+    }
+    if !looks_like_prose_fragment_author(tail) {
+        return s.to_string();
+    }
+
+    head.to_string()
 }
 
 fn looks_like_leading_the_institution_author(s: &str) -> bool {

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -402,9 +402,21 @@ pub(super) fn is_junk_copyright_code_fragment(s: &str) -> bool {
     (has_code_markers || has_prose_markers) && !has_copyright_year(trimmed)
 }
 
+/// Return true if `s` carries table-of-contents structure — a run of dot leaders
+/// closed by a page number, as in the RFC 3525 entry `Authors'
+/// Addresses............212`, which is never part of a name. Three dots stay out
+/// of scope so a prose ellipsis does not match.
+fn contains_toc_dot_leader_page_number(s: &str) -> bool {
+    static TOC_DOT_LEADER_RE: LazyLock<Regex> =
+        LazyLock::new(|| compile_static_regex(r"\.{4,}\s*\d"));
+    TOC_DOT_LEADER_RE.is_match(s)
+}
+
 /// Return true if `s` matches any known junk author pattern.
 pub(super) fn is_junk_author(s: &str) -> bool {
-    AUTHORS_JUNK_PATTERNS.iter().any(|re| re.is_match(s)) || looks_like_source_code(s)
+    AUTHORS_JUNK_PATTERNS.iter().any(|re| re.is_match(s))
+        || looks_like_source_code(s)
+        || contains_toc_dot_leader_page_number(s)
 }
 
 /// Return true if `s` matches any known junk holder pattern.

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -249,6 +249,54 @@ fn test_refine_author_truncates_trailing_prose_after_contact() {
 }
 
 #[test]
+fn test_refine_author_truncates_prose_sentence_after_a_name() {
+    assert_eq!(
+        refine_author(
+            "Mauricio Arango, Andrew Dugan, Ike Elliott, Christian Huitema, and Scott Pickett. Flemming Andreasen does not appear"
+        ),
+        Some(
+            "Mauricio Arango, Andrew Dugan, Ike Elliott, Christian Huitema, and Scott Pickett"
+                .to_string()
+        )
+    );
+    assert_eq!(
+        refine_author("Intel Corporation. Intel specifically disclaims all warranties"),
+        Some("Intel Corporation".to_string())
+    );
+}
+
+#[test]
+fn test_refine_author_keeps_names_across_a_period_that_closes_no_prose() {
+    // A tail that is itself a name, and a period that belongs to a company
+    // abbreviation, are both left alone.
+    assert_eq!(
+        refine_author("Jane Doe. John Smith"),
+        Some("Jane Doe. John Smith".to_string())
+    );
+    assert_eq!(
+        refine_author("Jane Doe, John Smith."),
+        Some("Jane Doe, John Smith".to_string())
+    );
+    assert_eq!(
+        refine_author("Sun Microsystems, Inc. All Rights Reserved"),
+        Some("Sun Microsystems, Inc.".to_string())
+    );
+}
+
+#[test]
+fn test_refine_author_rejects_table_of_contents_dot_leaders() {
+    assert_eq!(
+        refine_author("Addresses............................................212 Full"),
+        None
+    );
+    // A three-dot ellipsis is prose punctuation, not a dot-leader run.
+    assert_eq!(
+        refine_author("Jane Doe, John Smith ... 2019"),
+        Some("Jane Doe, John Smith ... 2019".to_string())
+    );
+}
+
+#[test]
 fn test_refine_author_preserves_full_written_by_author_list() {
     assert_eq!(
         refine_author("Jean-Marc Valin, Gregory Maxwell, and Timothy B. Terriberry"),

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/arch/microblaze/lib/memcpy.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/arch/microblaze/lib/memcpy.c.yml
@@ -13,4 +13,4 @@ holders:
   - Michal Simek
   - PetaLogix
 authors:
-  - Intel Corporation. Intel
+  - Intel Corporation


### PR DESCRIPTION
## Summary

- The RFC 3525 copy vendored in erlang/otp (`lib/megaco/doc/standard/rfc3525.txt`, `6146f0df`) produced exactly two authors for a 12k-line document, and both were false positives. ScanCode emits neither.
- `is_junk_author` now rejects a value carrying a table-of-contents dot-leader run closed by a page number, which kills `Addresses............................................212 Full`. The `Authors'` label in the TOC entry `Authors' Addresses............212` was being read as a name label; a dot-leader run plus a page number is TOC structure and never part of a name.
- `refine_author` gains `truncate_prose_sentence_after_name`, which truncates an author value at a sentence boundary the collector ran past — but only when the head is name-shaped and the tail is prose. `Mauricio Arango, Andrew Dugan, Ike Elliott, Christian Huitema, and Scott Pickett. Flemming Andreasen does not appear` becomes the genuine author list, so the fix recovers a true positive rather than dropping the detection.
- The existing `drop_authors_after_sentence_final_label` does not cover the second case: it only fires when a *lowercase author-label word* (`al`, `authors`, `contributors`, …) closes the sentence, and here the sentence ends on a proper name (`Scott Pickett.`). Truncation also lives with the ~40 sibling `truncate_*` steps already in `refine_author`, so no parallel mechanism was introduced.

Before / after on `lib/megaco/doc/standard/rfc3525.txt`:

| | before | after |
|---|---|---|
| (a) | `Addresses............................................212 Full` | *(dropped)* |
| (b) | `Mauricio Arango, Andrew Dugan, Ike Elliott, Christian Huitema, and Scott Pickett. Flemming Andreasen does not appear` | `Mauricio Arango, Andrew Dugan, Ike Elliott, Christian Huitema, and Scott Pickett` |

## Issues

- Covers: author false positives in vendored IETF/ITU-T specification text.

## Scope and exclusions

- Included: author-side junk and refinement only — `is_junk_author` and one new `refine_author` truncation step, plus regression tests.
- Explicit exclusions: no change to copyright or holder detection, `copyrights_junk_patterns.rs`, `holders_junk_patterns.rs`, or the license index. The `\.{4,}\s*\d` dot-leader signal is deliberately wired only into `is_junk_author`, not into `is_junk_copyright`/`is_junk_holder`, since the observed defect is author-side.

## How to verify

Beyond CI, the end-to-end check is the source document and its two siblings in the same submodule:

```bash
B=6146f0df6794451472fac4735e694ec1f56b873e
for f in lib/megaco/doc/standard/rfc3525.txt \
         lib/megaco/doc/standard/draft-ietf-megaco-h248v2-04.txt \
         lib/inets/doc/archive/rfc2616.txt; do
  curl -sLO "https://raw.githubusercontent.com/erlang/otp/$B/$f"
done
provenant scan --json-pp - --copyright . | jq '.files[] | {path, authors}'
```

Observed:

- `rfc3525.txt`: both junk authors gone; the acknowledgements name list is kept, truncated at the sentence boundary.
- `draft-ietf-megaco-h248v2-04.txt`: carried the same acknowledgements defect and is fixed the same way (`... and Scott Pickett. Flemming Andreasen does not appear` → `... and Scott Pickett`).
- `rfc2616.txt`: unchanged — no authors before or after, two `The Internet Society` copyrights in both runs.

Also worth poking: an author list that legitimately ends in a period (`Authors: Jane Doe, John Smith.`), one whose tail after a period is another name (`@author Jane Doe. John Smith`), and a company abbreviation (`Sun Microsystems, Inc. All Rights Reserved`). All three are pinned by tests as *kept*, since preserving true positives is the main risk here.

## Intentional differences from Python

- ScanCode reports no author at all in the acknowledgements paragraph. Provenant keeps the truncated name list, which the source sentence `... and thus to its authors, Mauricio Arango, ...` genuinely attributes. That is a better result than silence, so parity was not the target.

## Follow-up work

- Created or intentionally deferred: the truncated detection keeps the original span's `end_line` (it still points at the line where the dropped prose tail started). Narrowing a detection's line span after refinement truncates the value is a pre-existing property of every `truncate_*`/`strip_*` step in `refine_author`, not something this change introduces, so it is left out of scope.

## Expected-output fixture changes

- Files changed: `testdata/copyright-golden/copyrights/misco4/linux-copyrights/arch/microblaze/lib/memcpy.c.yml` (one author value).
- Why the new expected output is correct: the source reads `This software has been developed by Intel Corporation.` followed by a new sentence opening `Intel specifically disclaims all warranties`. The old expectation `Intel Corporation. Intel` glued the next sentence's first word onto the author; the new `Intel Corporation` is exactly the entity the `developed by` clause names. Regenerated with `update-copyright-golden --sync-actual`, not hand-edited. It is the only fixture that moved out of 1882 in the copyright golden corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
