### PR TITLE
fix(copyright): drop notice templates, tooling prose, and format strings

### DIFF
--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -485,6 +485,7 @@ fn drop_placeholder_and_code_junk_by_raw_line(
             || is_copyright_edit_note_line(trimmed)
             || is_copyright_holder_placeholder_line(trimmed)
             || is_pattern_match_binding_line(trimmed)
+            || is_notice_template_line(trimmed)
     };
 
     copyrights.retain(|c| !is_junk_line(c.start_line));
@@ -509,6 +510,80 @@ fn is_copyright_holder_placeholder_line(line: &str) -> bool {
     });
 
     COPYRIGHT_HOLDER_PLACEHOLDER_RE.is_match(line.trim())
+}
+
+/// Whether the line shows copyright *templates* only: every copyright marker on
+/// it has a `YYYY` placeholder in its year slot. Documentation that quotes the
+/// required header reads that way, and the line — not the value — is what shows
+/// it, because refinement strips the placeholder off the value
+/// (`` `Copyright Acme AB YYYY.` `` yields the apparently real
+/// `Copyright Acme AB`, whatever spacing or punctuation the source used).
+///
+/// Every marker must be a template: a detection records no column and so cannot
+/// be tied to one marker, which means a line that also asserts a real notice —
+/// dated or not — keeps all of its detections.
+fn is_notice_template_line(line: &str) -> bool {
+    static MARKER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)\bcopyright\b|\bcopr\.?|\(c\)|\u{a9}").expect("valid marker regex")
+    });
+
+    let mut saw_marker = false;
+    for marker in MARKER_RE.find_iter(line) {
+        saw_marker = true;
+        if !year_slot_is_placeholder(&line[marker.end()..]) {
+            return false;
+        }
+    }
+
+    saw_marker
+}
+
+/// Whether the year slot of the notice opening at a marker holds a `YYYY`
+/// placeholder. The slot is the first year-like token in the run of party-name
+/// tokens after the marker, and the run stops at the end of the notice: at a
+/// lowercase prose word, or at a sentence or clause boundary. So `YYYY` in the
+/// text following a notice never supplies that notice's year, whether the text
+/// is lowercase (`Copyright Acme Corp. Release dates use the YYYY format.`),
+/// title-cased (`... Corp. Release Dates Use YYYY`), or behind a semicolon or
+/// colon (`... Corp; dates use YYYY`).
+fn year_slot_is_placeholder(tail: &str) -> bool {
+    static PLACEHOLDER_YEAR_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)\by{4}\b").expect("valid placeholder year regex"));
+    static PLAIN_YEAR_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\b(?:19|20)\d{2}\b").expect("valid plain year regex"));
+
+    let mut previous_ended_sentence = false;
+    let mut previous_ended_clause = false;
+    for token in tail.split_whitespace() {
+        let opens_new_sentence =
+            previous_ended_sentence && token.chars().next().is_some_and(char::is_uppercase);
+        if previous_ended_clause || opens_new_sentence {
+            return false;
+        }
+        if PLACEHOLDER_YEAR_RE.is_match(token) {
+            return true;
+        }
+        if PLAIN_YEAR_RE.is_match(token) || !is_party_name_token(token) {
+            return false;
+        }
+        // `Inc.`/`Ltd.` end a token without ending the notice, so a period only
+        // closes the sentence when the next token opens one.
+        previous_ended_sentence = token.ends_with('.');
+        previous_ended_clause = token.ends_with([';', ':']);
+    }
+
+    false
+}
+
+/// Whether a token can belong to the party name between a marker and its year:
+/// a capitalized word, a bare `c` from a `(c)` sign, or pure punctuation such as
+/// a dash or `&`. Anything else — notably a lowercase prose word — is not part of
+/// the notice's party name.
+fn is_party_name_token(token: &str) -> bool {
+    let word = token.trim_matches(|c: char| !c.is_alphanumeric());
+    word.is_empty()
+        || word.eq_ignore_ascii_case("c")
+        || word.chars().next().is_some_and(char::is_uppercase)
 }
 
 /// Whether the line binds values with a pattern-match or short-declaration

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -1120,3 +1120,198 @@ fn test_table_of_contents_dot_leader_line_is_not_an_author() {
 
     assert!(authors.is_empty(), "authors: {authors:?}");
 }
+
+#[test]
+fn test_notice_format_documentation_is_not_a_notice() {
+    // Documentation *about* the required header: prose that states the rule, and
+    // template lines whose year slot is a `YYYY` placeholder. The last line
+    // quotes the template mid-sentence, so refinement drops the placeholder and
+    // only the raw line still shows that the notice is a template.
+    let content = "\
+The copyright notice must start with `Copyright`, and can have as prefix the SPDX annotation `SPDX-FileCopyrightText: `
+followed by the holders of the copyright, as follows:
+
+1. To be used exclusively by OTP team
+   - `Copyright Ericsson AB YYYY. All Rights Reserved.`
+   - `Copyright Ericsson AB YYYY-YYYY. All Rights Reserved.`
+
+> For any contributions made by the Erlang/OTP team, the copyright statement must
+> be `Copyright Ericsson AB YYYY. All Rights Reserved.`. The `license-header.es` script
+";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    assert!(
+        copyrights.is_empty(),
+        "unexpected copyrights: {copyrights:?}"
+    );
+    assert!(holders.is_empty(), "unexpected holders: {holders:?}");
+}
+
+#[test]
+fn test_real_notices_beside_the_format_documentation_are_kept() {
+    // The same document carries genuine notices, dated and undated, which the
+    // template and prose rules must leave untouched.
+    let content = "\
+Copyright Ericsson AB 2025. All Rights Reserved.
+SPDX-FileCopyrightText: Copyright (C) 2019 The ORT Project Authors
+Copyright (c) Meta Platforms, Inc. and affiliates.
+";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    assert_eq!(
+        copyrights
+            .iter()
+            .map(|c| c.copyright.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "Copyright Ericsson AB 2025",
+            "Copyright (c) 2019 The ORT Project Authors",
+            "Copyright (c) Meta Platforms, Inc. and affiliates",
+        ],
+        "expected the real notices, got {copyrights:?}"
+    );
+    assert_eq!(
+        holders
+            .iter()
+            .map(|h| h.holder.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "Ericsson AB",
+            "The ORT Project Authors",
+            "Meta Platforms, Inc. and affiliates",
+        ],
+        "expected the real holders, got {holders:?}"
+    );
+}
+
+#[test]
+fn test_compliance_tooling_prose_and_format_strings_are_not_notices() {
+    // An Erlang compliance script: a comment about running a copyright *scanner*,
+    // and a diagnostic format string whose `~ts`/`~n` directives make its words a
+    // template. Only the file's own header notice is a notice.
+    let content = "\
+%% Copyright Ericsson AB 2024-2026. All Rights Reserved.
+%%
+%% Ignore copyright detection heuristics of REUSE tool in this file.
+%%    throw({warn, \"Invalid Copyright: '~ts' in '~ts for ~ts~n'\", [C, Filename, Regex]});
+";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    assert_eq!(
+        copyrights
+            .iter()
+            .map(|c| c.copyright.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Copyright Ericsson AB 2024-2026"],
+        "expected only the header notice, got {copyrights:?}"
+    );
+    assert_eq!(
+        holders
+            .iter()
+            .map(|h| h.holder.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Ericsson AB"],
+        "expected only the header holder, got {holders:?}"
+    );
+}
+
+#[test]
+fn test_placeholder_elsewhere_on_the_line_does_not_condemn_a_genuine_notice() {
+    // The placeholder must fill this notice's own year slot: an unrelated one
+    // further along the line leaves an undated but genuine notice alone.
+    let content = "# Copyright Acme Corp. Release dates in this file use the YYYY format.\n";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    assert_eq!(
+        copyrights
+            .iter()
+            .map(|c| c.copyright.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Copyright Acme Corp."],
+        "expected the undated notice, got {copyrights:?}"
+    );
+    assert_eq!(
+        holders
+            .iter()
+            .map(|h| h.holder.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Acme Corp."],
+        "expected the undated holder, got {holders:?}"
+    );
+}
+
+#[test]
+fn test_unrelated_year_on_the_line_does_not_excuse_a_quoted_template() {
+    // The year that matters is the detection's own: a real year elsewhere in the
+    // prose must not make the quoted template read as a dated notice.
+    let content = "> In 2025 the notice must read `Copyright Acme AB YYYY. All Rights Reserved.`\n";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    assert!(
+        copyrights.is_empty(),
+        "unexpected copyrights: {copyrights:?}"
+    );
+    assert!(holders.is_empty(), "unexpected holders: {holders:?}");
+}
+
+#[test]
+fn test_line_that_asserts_and_then_templates_the_same_notice_keeps_the_assertion() {
+    // A detection records only its line, so when the value occurs twice the
+    // placeholder cannot be pinned to one of them; the assertion wins.
+    let content = "# Copyright Acme AB. New files must read Copyright Acme AB YYYY.\n";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright Acme AB"),
+        "expected the asserted notice, got {copyrights:?}"
+    );
+    assert!(
+        holders.iter().any(|h| h.holder == "Acme AB"),
+        "expected the asserted holder, got {holders:?}"
+    );
+}
+
+#[test]
+fn test_template_is_recognized_however_its_notice_is_spaced_or_punctuated() {
+    // The year slot is read off the source line, so a template survives none of
+    // the spellings that refinement would normalize away in the value.
+    for content in [
+        "# Copyright  Acme  AB  YYYY.\n",
+        "# Copyright Acme AB, YYYY.\n",
+        "> the notice must read `Copyright  Acme  AB  YYYY. All Rights Reserved.`. See below\n",
+        "> the notice must read `Copyright Acme AB, YYYY. All Rights Reserved.`. See below\n",
+        "> the notice must read `\u{a9} Acme  AB YYYY. All Rights Reserved.`. See below\n",
+    ] {
+        let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+        assert!(
+            copyrights.is_empty(),
+            "template produced copyrights {copyrights:?} for {content:?}"
+        );
+        assert!(
+            holders.is_empty(),
+            "template produced holders {holders:?} for {content:?}"
+        );
+    }
+}
+
+#[test]
+fn test_placeholder_prose_behind_any_punctuation_keeps_the_notice() {
+    // The year slot ends where the notice does — at a lowercase prose word, or at
+    // a sentence or clause boundary — so no punctuation and no title-cased prose
+    // can pull an unrelated `YYYY` into the notice.
+    for content in [
+        "# Copyright Acme Corp; dates use YYYY\n",
+        "# Copyright Acme Corp: dates use YYYY\n",
+        "# Copyright Acme Corp \u{2014} dates use YYYY\n",
+        "# Copyright Acme Corp (dates use YYYY)\n",
+        "# Copyright Acme Corp. Release Dates Use YYYY\n",
+        "# Copyright Acme Corp; Dates Use YYYY\n",
+        "# Copyright Acme Corp: Dates Use YYYY\n",
+    ] {
+        let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+        assert!(
+            copyrights.iter().any(|c| c.copyright.contains("Acme Corp")),
+            "expected the notice, got {copyrights:?} for {content:?}"
+        );
+        assert!(
+            holders.iter().any(|h| h.holder.contains("Acme Corp")),
+            "expected the holder, got {holders:?} for {content:?}"
+        );
+    }
+}

--- a/src/copyright/refiner/copyrights_junk_patterns.rs
+++ b/src/copyright/refiner/copyrights_junk_patterns.rs
@@ -236,6 +236,9 @@ pub(super) static COPYRIGHTS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new
         r"(?i)^copyright [a-z]$",
         // Any marker/sign combination followed by a `YYYY` placeholder year.
         r"(?i)^(?:copyright|copr\.?|\(c\)|©)(?:\s*(?:\(c\)|©))*\s+y{4}\b",
+        // A `YYYY` placeholder closing the statement is the same template with
+        // the year slot after the party name (`Copyright Acme AB YYYY-YYYY.`).
+        r"(?i)\by{4}(?:\s*-\s*y{4})?\.?$",
         r"(?i)^copyright exceptions\b",
         r"(?i)^copyright or patent\b",
         r"(?i)^copyright is claimed\b",

--- a/src/copyright/refiner/holders_junk_patterns.rs
+++ b/src/copyright/refiner/holders_junk_patterns.rs
@@ -203,8 +203,10 @@ pub(super) static HOLDERS_JUNK_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(||
         r"(?i)\bpkg\.(author|homepage)\b",
         r"(?i)\bdate\.year\b",
         r"(?i)\bYYYY-MM-DD\b",
-        // A `YYYY` placeholder in the year slot means the party name is one too.
+        // A `YYYY` placeholder in the year slot — before or after the name —
+        // means the party name is a template too.
         r"(?i)^y{4}(?:\s*-\s*y{4})?\b",
+        r"(?i)\by{4}(?:\s*-\s*y{4})?\.?$",
         r"(?i)<\s*pkg\.[a-zA-Z0-9_.-]+\s*>",
         r"(?i)^http://www\.quirksmode\b",
         r"[→⟶]",

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -211,6 +211,64 @@ fn prefix_names_holder(prefix: &str) -> bool {
         })
 }
 
+/// Return true if a modal verb stands where the party name belongs, once the
+/// copyright markers and any leading conjunction are skipped (`Copyright and can
+/// have as prefix ...`, `can have as prefix ...`). Documentation that states how
+/// a notice must be written reads that way; a real notice never does.
+///
+/// Only modals are treated this way, not the copula: `Copyright is held by Acme
+/// Corp.` still names a party. Requiring the modal to be lowercase keeps
+/// capitalized personal names (`May`, `Will`, `Can`) out of scope.
+pub(super) fn opens_with_modal_instead_of_party(s: &str) -> bool {
+    const MODALS: &[&str] = &[
+        "can", "cannot", "could", "may", "might", "must", "shall", "should", "will", "would",
+    ];
+    const SKIPPABLE: &[&str] = &[
+        "copyright",
+        "copyrights",
+        "copyrighted",
+        "copr",
+        "copr.",
+        "(c)",
+        "©",
+        "c",
+        "and",
+        "or",
+        "but",
+    ];
+
+    s.split_whitespace()
+        .map(|word| word.trim_matches(|c: char| c == ',' || c == ';' || c == ':'))
+        .find(|word| !SKIPPABLE.contains(&word.to_ascii_lowercase().as_str()))
+        .is_some_and(|word| MODALS.contains(&word))
+}
+
+/// Return true if a holder is prose at both ends: it opens on a lowercase common
+/// word and closes on a dangling function word (`detection heuristics of REUSE
+/// tool in`). A party name is a complete noun phrase, so a value that trails off
+/// into a preposition, conjunction, or article is prose the marker swept in.
+///
+/// The lowercase opener is what keeps a value that still names a capitalized
+/// party (`Wind River Systems Inc Implemented by`, `Matthew Wilcox willy at`)
+/// with the trailing-clause strippers rather than discarding it. The tail
+/// comparison is case-sensitive for the same reason: a trailing middle initial
+/// (`Jane A`) is not the article `a`.
+pub(super) fn is_truncated_lowercase_prose_holder(s: &str) -> bool {
+    const DANGLING_TAIL_WORDS: &[&str] = &[
+        "a", "an", "and", "as", "at", "but", "by", "for", "from", "in", "into", "of", "on", "onto",
+        "or", "over", "per", "the", "to", "under", "upon", "via", "with", "within", "without",
+    ];
+
+    let trimmed = s.trim().trim_end_matches(['.', ',', ';', ':']);
+    if !trimmed.starts_with(char::is_lowercase) {
+        return false;
+    }
+
+    trimmed
+        .rsplit_once(char::is_whitespace)
+        .is_some_and(|(_, last)| DANGLING_TAIL_WORDS.contains(&last))
+}
+
 /// Return true if `s` matches any known junk copyright pattern.
 pub fn is_junk_copyright(s: &str) -> bool {
     if looks_like_structured_copyright_notice_with_year(s) {
@@ -224,6 +282,7 @@ pub fn is_junk_copyright(s: &str) -> bool {
         || is_junk_c_sign_path_fragment(s)
         || is_creative_commons_license_prose(s)
         || spans_prose_sentence_boundary(s)
+        || opens_with_modal_instead_of_party(s)
         || contains_unicode_segmentation_markers(s)
         || is_bare_markup_tag(s)
         || looks_like_source_code(s)
@@ -326,8 +385,12 @@ pub(crate) fn has_copyright_year(s: &str) -> bool {
 }
 
 pub(super) fn is_junk_copyright_scan_phrase(s: &str) -> bool {
-    static COPYRIGHT_SCAN_RE: LazyLock<Regex> =
-        LazyLock::new(|| compile_static_regex(r"(?i)\bcopyright\s+scan(?:s|ner|ning)?\b"));
+    // Compliance-tooling vocabulary: text about *finding* notices, never a notice.
+    static COPYRIGHT_SCAN_RE: LazyLock<Regex> = LazyLock::new(|| {
+        compile_static_regex(
+            r"(?i)\bcopyright\s+(?:scan(?:s|ner|ning)?|detect(?:ion|or|ing)|heuristics?)\b",
+        )
+    });
 
     !has_copyright_year(s) && COPYRIGHT_SCAN_RE.is_match(s)
 }
@@ -427,6 +490,8 @@ pub(crate) fn is_junk_holder(s: &str) -> bool {
         || is_creative_commons_license_prose(s)
         || looks_like_source_code(s)
         || starts_with_sentence_connective(s)
+        || opens_with_modal_instead_of_party(s)
+        || is_truncated_lowercase_prose_holder(s)
         || contains_unicode_segmentation_markers(s)
         || is_bare_markup_tag(s)
         || s.eq_ignore_ascii_case("MIT")
@@ -576,8 +641,13 @@ pub(super) fn is_junk_copyright_symbol_garbage(s: &str) -> bool {
 }
 
 pub(super) fn contains_regex_or_template_marker(s: &str) -> bool {
+    // Erlang/`io:format` control sequences: the words around them are a template.
+    static FORMAT_DIRECTIVE_RE: LazyLock<Regex> =
+        LazyLock::new(|| compile_static_regex(r"~(?:t?[psw]|n)\b"));
+
     let trimmed = s.trim();
-    trimmed.contains("(?")
+    FORMAT_DIRECTIVE_RE.is_match(trimmed)
+        || trimmed.contains("(?")
         || trimmed.contains("?:")
         || trimmed.contains(r"\d")
         || trimmed.contains(r"\s")

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -3383,3 +3383,93 @@ fn test_placeholder_year_rule_keeps_real_years_and_holders() {
         Some("Yyyyaka Tanaka".to_string())
     );
 }
+
+#[test]
+fn test_modal_verb_where_the_party_belongs_is_junk() {
+    // Documentation that states how a notice must be written, not a notice.
+    for value in [
+        "Copyright and can have as prefix the SPDX annotation",
+        "Copyright must start with Copyright",
+        "(c) may be omitted",
+    ] {
+        assert!(is_junk_copyright(value), "kept {value:?}");
+    }
+    assert_eq!(
+        refine_holder("can have as prefix the SPDX annotation"),
+        None
+    );
+    // The copula still introduces a party, and a capitalized name is not a modal.
+    assert!(!opens_with_modal_instead_of_party(
+        "Copyright is held by Acme Corp."
+    ));
+    assert!(!opens_with_modal_instead_of_party(
+        "Copyright 2020 Will Smith"
+    ));
+    assert_eq!(refine_holder("May Kwan"), Some("May Kwan".to_string()));
+    assert_eq!(refine_holder("Will Smith"), Some("Will Smith".to_string()));
+}
+
+#[test]
+fn test_holder_that_is_prose_at_both_ends_is_junk() {
+    for value in [
+        "detection heuristics of REUSE tool in",
+        "the copyright holders or",
+    ] {
+        assert_eq!(refine_holder(value), None, "kept {value:?}");
+    }
+    // A value that still names a capitalized party is left to the clause
+    // strippers, and a trailing middle initial is not the article `a`.
+    assert!(!is_truncated_lowercase_prose_holder(
+        "Wind River Systems Inc Implemented by"
+    ));
+    assert!(!is_truncated_lowercase_prose_holder(
+        "Matthew Wilcox willy at"
+    ));
+    assert!(!is_truncated_lowercase_prose_holder("Jane A."));
+    assert!(!is_truncated_lowercase_prose_holder("Ericsson AB"));
+    assert_eq!(
+        refine_holder("Ericsson AB"),
+        Some("Ericsson AB".to_string())
+    );
+    assert_eq!(
+        refine_holder("Meta Platforms, Inc. and affiliates"),
+        Some("Meta Platforms, Inc. and affiliates".to_string())
+    );
+}
+
+#[test]
+fn test_copyright_tooling_vocabulary_is_junk() {
+    for value in [
+        "copyright detection heuristics of REUSE tool in",
+        "Copyright detector",
+        "Copyright scanner",
+    ] {
+        assert!(is_junk_copyright(value), "kept {value:?}");
+    }
+    // A dated notice is never reclassified by the tooling vocabulary.
+    assert!(!is_junk_copyright(
+        "Copyright (c) 2020 Copyright Detection Inc."
+    ));
+}
+
+#[test]
+fn test_format_string_directives_are_junk() {
+    // Erlang `io:format` control sequences make the words a diagnostic template.
+    assert!(is_junk_copyright("Copyright ~ts in ~ts for ~ts~n C"));
+    assert_eq!(refine_holder("ts in ~ts for ~ts~n"), None);
+    // A tilde that is not a directive leaves a real notice alone.
+    assert!(!is_junk_copyright("Copyright (c) 2020 ~ Acme Corp."));
+}
+
+#[test]
+fn test_placeholder_year_after_a_real_party_name_is_junk() {
+    for template in [
+        "Copyright Ericsson AB YYYY.",
+        "Copyright Ericsson AB YYYY-YYYY.",
+    ] {
+        assert!(is_junk_copyright(template), "kept {template:?}");
+    }
+    assert_eq!(refine_holder("Ericsson AB YYYY."), None);
+    assert_eq!(refine_holder("Ericsson AB YYYY-YYYY."), None);
+    assert!(!is_junk_copyright("Copyright Ericsson AB 2011-2025."));
+}


### PR DESCRIPTION
## Summary

- Verifying [erlang/otp](https://github.com/erlang/otp) at `6146f0df` surfaced seven Provenant-only copyright/holder false positives that ScanCode does not emit. Two files carry them: `HOWTO/FILE-HEADERS.md` (documentation *about* the required header format) and `.github/scripts/otp-compliance.es` (a compliance script that talks about copyright scanning).
- **Notice templates.** The value-level placeholder rules gained the trailing year slot, so `Copyright Ericsson AB YYYY.` / `Copyright Ericsson AB YYYY-YYYY.` (`:137`, `:138`) are templates and `refine_holder("Ericsson AB YYYY.")` no longer returns a holder. The value alone is not enough, though: `:152` quotes the template mid-sentence, and refinement strips the placeholder off the value and leaves an apparently real `Copyright Ericsson AB`. A source line is therefore read as a template when **every** copyright marker on it has a `YYYY` placeholder in its year slot — the first year-like token in the run of party-name tokens after the marker. The run stops where the notice does: at a lowercase prose word, or at a sentence or clause boundary, so `YYYY` in text following a notice never supplies that notice's year. Requiring every marker on the line to be a template keeps a line that also asserts a real notice, dated or not.
- **Modal verb in the party slot.** `The copyright notice must start with ... and can have as prefix the SPDX annotation` (`:133`) yielded the copyright `Copyright and can have as prefix the SPDX annotation` and the holder `can have as prefix the SPDX annotation`. A modal verb standing where the party name belongs now marks the value as a rule *about* notices. Only modals count, not the copula, so `Copyright is held by Acme Corp.` still names a party; the modal must be lowercase, so `May`/`Will`/`Can` as personal names are out of scope.
- **Compliance-tooling vocabulary and truncated prose.** `Ignore copyright detection heuristics of REUSE tool in this file.` produced both a copyright and a holder. The existing `copyright scan(ner|ning)` rule now also covers `detection`/`detector`/`detecting`/`heuristics`, and a holder that is prose at *both* ends — a lowercase opener plus a dangling preposition, conjunction, or article — is junk.
- **Format strings.** `throw({warn, "Invalid Copyright: '~ts' in '~ts for ~ts~n'", ...})` yielded the copyright `Copyright ~ts in ~ts for ~ts~n C` and the holder `ts in ~ts for ~ts~n`. Erlang/`io:format` control sequences (`~ts`, `~n`, `~p`, `~w`) now count as template markers, so the words around them are a format string rather than a notice.

## Issues

- Covers: erlang/otp benchmark verification follow-ups (copyright false positives).

## Scope and exclusions

- Included: copyright/holder junk predicates in `src/copyright/refiner/junk.rs`, the two junk-pattern tables, and one raw-line filter in `src/copyright/detector/phases/postprocess.rs`.
- Explicit exclusions: no author-detection changes (`author_heuristics`, `authors_junk_patterns.rs` are untouched — a sibling PR owns those), no license-index changes, no `BENCHMARKS.md` row.

## How to verify

- Fetch the two upstream files and scan them; every remaining value should be a real notice:

  ```bash
  curl -sLO https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e/HOWTO/FILE-HEADERS.md
  curl -sL -o otp-compliance.es https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e/.github/scripts/otp-compliance.es
  provenant scan --json-pp - --copyright FILE-HEADERS.md otp-compliance.es
  ```

  `FILE-HEADERS.md` should report exactly the five `Copyright Ericsson AB 2025. All Rights Reserved.` headers (`:7`, `:88`, `:112`, `:166`, `:183`), `Copyright (c) 2019 The ORT Project Authors` (`:167`), and `Copyright (c) Meta Platforms, Inc. and affiliates.` (`:206`); `otp-compliance.es` should report only its own header notice with the holder `Ericsson AB`.
- Worth poking at the guards, since they are what bounds the blast radius. A holder that still names a capitalized party (`Wind River Systems Inc Implemented by`, `Matthew Wilcox willy at` — both live in the copyright goldens) must survive the dangling-tail rule. For the template rule, all of these must hold: prose mentioning `YYYY` after a notice does not condemn it, lowercase or title-cased, and whatever separates them — a period, semicolon, colon, em dash, or parenthetical (`# Copyright Acme Corp; dates use YYYY`, `# Copyright Acme Corp. Release Dates Use YYYY`); `Inc.`/`Ltd.` stay inside their notice (`Copyright (c) Meta Platforms, Inc. and affiliates.`); a year elsewhere on the line does not excuse a template (`> In 2025 the notice must read ...YYYY...`); a line that both asserts a notice and quotes it as a template keeps the assertion (`# Copyright Acme AB. New files must read Copyright Acme AB YYYY.`); and the template is caught however its notice is spaced or punctuated (double spaces, a comma before the placeholder, a `©` marker). Real Erlang sources are the counterpart check for the format-directive rule: `lib/stdlib/src/io_lib.erl` and `shell.erl` carry 8 and 43 tilde sequences and must still report their `Copyright Ericsson AB 1996-2026` headers.

## Intentional differences from Python

- ScanCode emits none of these seven values either, so this is a Provenant-only false-positive removal rather than a parity change. No golden fixture shifted.

## Follow-up work

- Created or intentionally deferred: `Copyright 2002 Read the` in `testdata/copyright-golden/ics/oprofile-utils/opcontrol.yml` is still a false positive (a `# Read the file COPYING` continuation glued onto a bare `Copyright 2002`); its holder is retained here on purpose because the value opens with a capitalized word, and fixing the statement itself belongs to a separate change.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: n/a — the full copyright golden corpus (2452 fixtures across `copyright_golden`), `post_processing_golden`, and `scanner_integration` pass unchanged. An earlier, broader form of the dangling-tail rule did shift five golden holders (`Read the`, `Joseph Gil found at`, `Wind River Systems Inc Implemented by`, `Matthew Wilcox willy at`, `Richard Hirst rhirst with`); requiring a lowercase opener keeps all of them and still removes the target false positive, so the rule was tightened instead of the fixtures being updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
