### PR TITLE
fix(copyright): drop Erlang format directives and sigil-keyed bindings

### DIFF
--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -594,34 +594,63 @@ fn is_pattern_match_binding_line(line: &str) -> bool {
     line.contains(":=") && !has_quoted_copyright(line) && !has_copyright_year(line)
 }
 
-/// Whether `copyright` appears inside a quoted segment of the line, which makes
-/// it assigned text rather than an identifier. Walking the line tracks which
-/// delimiter opened the string and which are escaped, so neither an escaped
-/// quote nor an escaped backslash before a real one shifts the boundaries.
+/// Whether one quoted segment of the line spells out a copyright notice, which
+/// makes it assigned text rather than an identifier. A quoted key name is not
+/// such a notice: Erlang's `~"copyrights" := Cs` binds a map key, and JSON-shaped
+/// keys read the same way. Segments are tested one by one, so two neighbouring
+/// strings cannot combine into a marker that neither of them contains.
 fn has_quoted_copyright(line: &str) -> bool {
+    quoted_segments(line).iter().any(|segment| {
+        segment.to_ascii_lowercase().contains("copyright") && !is_bare_identifier(segment)
+    })
+}
+
+/// Whether `s` is a lone identifier-shaped token — the shape of a map key or
+/// struct field (`copyrights`, `copyright_notice`), never of a notice, which
+/// always carries punctuation or a party name alongside its marker.
+fn is_bare_identifier(s: &str) -> bool {
+    let trimmed = s.trim();
+    !trimmed.is_empty()
+        && trimmed
+            .chars()
+            .all(|ch| ch.is_alphanumeric() || matches!(ch, '_' | '-'))
+}
+
+/// The quoted string literals of `line`, without their delimiters. Walking the
+/// line tracks which delimiter opened the string and which characters are
+/// escaped, so neither an escaped quote nor an escaped backslash before a real
+/// one shifts the boundaries; an unterminated final string still yields its text.
+fn quoted_segments(line: &str) -> Vec<String> {
+    let mut segments = Vec::new();
     let mut open_quote: Option<char> = None;
     let mut escaped = false;
-    let mut quoted = String::new();
+    let mut current = String::new();
     for ch in line.chars() {
         if escaped {
             escaped = false;
             if open_quote.is_some() {
-                quoted.push(ch);
+                current.push(ch);
             }
         } else if ch == '\\' {
             escaped = true;
         } else if matches!(ch, '"' | '\'') {
             match open_quote {
-                Some(opener) if opener == ch => open_quote = None,
-                Some(_) => quoted.push(ch),
+                Some(opener) if opener == ch => {
+                    open_quote = None;
+                    segments.push(std::mem::take(&mut current));
+                }
+                Some(_) => current.push(ch),
                 None => open_quote = Some(ch),
             }
         } else if open_quote.is_some() {
-            quoted.push(ch);
+            current.push(ch);
         }
     }
+    if open_quote.is_some() {
+        segments.push(current);
+    }
 
-    quoted.to_ascii_lowercase().contains("copyright")
+    segments
 }
 
 fn is_embedded_c_sign_code_fragment_line(line: &str) -> bool {

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -1107,6 +1107,71 @@ classify_copyright_result(Filename) ->
 }
 
 #[test]
+fn test_sigil_quoted_map_keys_do_not_rescue_a_pattern_match_binding_line() {
+    // Erlang's `~"..."` binary sigil quotes a map *key* here, so the quoted word
+    // names a field and the line still binds variables rather than text.
+    let content = "\
+restore_from_cache(Files, [#{ ~\"scanner\" := Scanner, ~\"summary\" := Summary} | T]) ->
+    #{ ~\"copyrights\" := Copyrights, ~\"licenses\" := Licenses} = Summary,
+    ok.
+";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    assert!(
+        copyrights.is_empty(),
+        "unexpected copyrights: {copyrights:?}"
+    );
+    assert!(holders.is_empty(), "unexpected holders: {holders:?}");
+
+    // A quoted notice on such a line carries more than the bare marker, so it is
+    // still read as assigned text.
+    let assigned = "    #{ ~\"notice\" := \"Copyright Acme Corp. All rights reserved.\" },\n";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(assigned);
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright Acme Corp."),
+        "expected the assigned notice, got {copyrights:?}"
+    );
+    assert!(
+        holders.iter().any(|h| h.holder == "Acme Corp."),
+        "expected the assigned holder, got {holders:?}"
+    );
+}
+
+#[test]
+fn test_erlang_format_string_that_builds_a_notice_is_not_a_notice() {
+    // A `~p`/`~n` control sequence makes the surrounding words a template, and
+    // the literal year it interpolates around does not make it a real notice.
+    let content = "\
+      %% Copyright Ericsson AB 2020-~p. All Rights Reserved.
+\t\" * Portions created by Ericsson are Copyright 2007, Ericsson AB.~n\"
+";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(content);
+    assert!(
+        copyrights.is_empty(),
+        "unexpected copyrights: {copyrights:?}"
+    );
+    assert!(holders.is_empty(), "unexpected holders: {holders:?}");
+
+    // The same file's own dated header stays a notice, tildes elsewhere or not.
+    let header = "\
+      %% Copyright Ericsson AB 1996-2026. All Rights Reserved.
+    io:format(\"~ts~n\", [Chars]).
+";
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(header);
+    assert!(
+        copyrights
+            .iter()
+            .any(|c| c.copyright == "Copyright Ericsson AB 1996-2026"),
+        "expected the header notice, got {copyrights:?}"
+    );
+    assert!(
+        holders.iter().any(|h| h.holder == "Ericsson AB"),
+        "expected the header holder, got {holders:?}"
+    );
+}
+
+#[test]
 fn test_table_of_contents_dot_leader_line_is_not_an_author() {
     // RFC 3525 table of contents: the `Authors'` label heads a dot-leader run and
     // a page number, and the collected span also picks up the next entry's first

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -450,7 +450,7 @@ pub(super) fn is_junk_copyright_code_fragment(s: &str) -> bool {
         || contains_malformed_spaced_year(trimmed);
     let has_prose_markers = is_obvious_prose_fragment(trimmed);
 
-    if has_windows_versioninfo_markers {
+    if has_windows_versioninfo_markers || contains_format_control_directive(trimmed) {
         return true;
     }
 
@@ -583,6 +583,7 @@ pub(super) fn is_junk_holder_code_fragment(s: &str) -> bool {
     let has_prose_markers = is_obvious_prose_fragment(trimmed);
 
     has_windows_versioninfo_markers
+        || contains_format_control_directive(trimmed)
         || ((has_code_markers || has_prose_markers) && !has_copyright_year(trimmed))
 }
 
@@ -640,13 +641,21 @@ pub(super) fn is_junk_copyright_symbol_garbage(s: &str) -> bool {
         || (tail.len() >= 10 && non_ascii_count >= 4 && ascii_alpha_count <= 2 && symbol_count >= 2)
 }
 
-pub(super) fn contains_regex_or_template_marker(s: &str) -> bool {
-    // Erlang/`io:format` control sequences: the words around them are a template.
+/// Whether `s` carries an Erlang/`io:format` control sequence (`~ts`, `~n`,
+/// `~p`, `~w`). A notice never interpolates, so the words around one build a
+/// string — and a literal year inside a format string is part of the template
+/// rather than evidence of a real notice, which is why callers must not exempt
+/// such a value on the strength of its year.
+pub(super) fn contains_format_control_directive(s: &str) -> bool {
     static FORMAT_DIRECTIVE_RE: LazyLock<Regex> =
         LazyLock::new(|| compile_static_regex(r"~(?:t?[psw]|n)\b"));
 
+    FORMAT_DIRECTIVE_RE.is_match(s.trim())
+}
+
+pub(super) fn contains_regex_or_template_marker(s: &str) -> bool {
     let trimmed = s.trim();
-    FORMAT_DIRECTIVE_RE.is_match(trimmed)
+    contains_format_control_directive(trimmed)
         || trimmed.contains("(?")
         || trimmed.contains("?:")
         || trimmed.contains(r"\d")

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -3462,6 +3462,31 @@ fn test_format_string_directives_are_junk() {
 }
 
 #[test]
+fn test_format_directive_beats_a_literal_year_in_the_template() {
+    // A year inside a format string is part of the template, so it cannot
+    // exempt the value from the directive rule.
+    for value in [
+        "Copyright Ericsson AB 2020-~p. All Rights Reserved.",
+        "Copyright Ericsson AB 2021-~p. All Rights Reserved.",
+        "Copyright 2007, Ericsson AB.~n",
+    ] {
+        assert!(is_junk_copyright(value), "kept {value:?}");
+    }
+    assert_eq!(refine_holder("Ericsson AB 2020-~p"), None);
+    assert_eq!(refine_holder("Ericsson AB.~n"), None);
+
+    // A dated notice with no directive keeps both its value and its holder.
+    for value in [
+        "Copyright Ericsson AB 1996-2026. All Rights Reserved.",
+        "Copyright Ericsson AB 2020-2024.",
+    ] {
+        assert!(!is_junk_copyright(value), "dropped {value:?}");
+    }
+    // Year stripping is a later step; what matters here is that the holder survives.
+    assert!(refine_holder("Ericsson AB 1996-2026").is_some());
+}
+
+#[test]
 fn test_placeholder_year_after_a_real_party_name_is_junk() {
     for template in [
         "Copyright Ericsson AB YYYY.",


### PR DESCRIPTION
## Summary

- Verifying [erlang/otp](https://github.com/erlang/otp) at `6146f0df` — after the four earlier rounds of copyright fixes — still surfaced five Provenant-only copyright/holder false positives across four Erlang files. ScanCode emits none of them. Both classes are Erlang syntax that the existing guards already had a predicate for, and in both cases the predicate was never reached.
- **A format directive standing in for the end year.** `lib/stdlib/scripts/update_deprecations:144`, `lib/stdlib/test/shell_docs_SUITE.erl:223`, and `erts/emulator/test/send_term_SUITE.erl:334` build a notice with `io:format`, so the source reads `Copyright Ericsson AB 2020-~p. All Rights Reserved.` and `Copyright 2007, Ericsson AB.~n`. #1385 already made `~ts`/`~n`/`~p`/`~w` count as template markers, but it put that test inside the `has_code_markers` set that `is_junk_copyright_code_fragment` / `is_junk_holder_code_fragment` gate on `&& !has_copyright_year(trimmed)` — and every one of these values carries a literal year in the template's own prefix (`2020`, `2021`, `2007`). The year exemption fired first and the directive test never ran. This is the same ordering hazard Greptile flagged on #1385 for the placeholder rule, in a second place.

  The directive test is now its own predicate, `contains_format_control_directive`, and it short-circuits *ahead* of the year exemption in both functions — the way `contains_windows_versioninfo_token` already does. A year inside a format string is part of the template rather than evidence of a notice, so it cannot excuse one. `contains_regex_or_template_marker` delegates to the new predicate rather than duplicating the regex, so its other (weaker) markers — `\d`, `{{`, a trailing `$` — keep the year exemption they had.
- **A sigil-quoted map key rescuing a binding line.** `.github/scripts/ort-scanner.es:220` and `:398` are Erlang map patterns: `#{ ~"copyrights" := Copyrights, ~"licenses" := Licenses} = Summary,`. #1382's `is_pattern_match_binding_line` covers `:=` lines, but it exempts any line whose quoted text mentions copyright — the guard that keeps a real `notice := "Copyright (c) 2020 Acme Corp."`. Erlang 27's `~"..."` binary sigil made the *map key* a quoted string containing `copyrights`, so every one of these lines looked like an assigned notice.

  A quoted key name is not an assigned notice. `has_quoted_copyright` now tests quoted segments one at a time and ignores a segment that is a lone identifier-shaped token (`copyrights`, `copyright_notice`) — a notice always carries punctuation or a party name alongside its marker. Per-segment testing also closes a latent hole in the old whole-line accumulator, where two neighbouring strings could combine into a marker that neither of them contained (`"copy" ++ "right"`).

## Issues

- Covers: erlang/otp benchmark verification follow-ups (copyright false positives).

## Scope and exclusions

- Included: the format-directive predicate and its two call sites in `src/copyright/refiner/junk.rs`, and `has_quoted_copyright` in `src/copyright/detector/phases/postprocess.rs`.
- Explicit exclusions: `is_notice_template_line` and the structured-data/edoc value rules are untouched — a sibling PR owns them. No author-detection, license-index, or `BENCHMARKS.md` changes.

## How to verify

- Fetch the four affected files plus the two guard files and scan them; every remaining value should be a real notice.

  ```bash
  for p in lib/stdlib/scripts/update_deprecations lib/stdlib/test/shell_docs_SUITE.erl \
           erts/emulator/test/send_term_SUITE.erl .github/scripts/ort-scanner.es \
           lib/stdlib/src/io_lib.erl lib/stdlib/src/shell.erl; do
    mkdir -p "$(dirname "$p")"
    curl -sL "https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e/$p" -o "$p"
  done
  provenant scan --json-pp - --copyright lib erts .github
  ```

  Before: `Copyright Ericsson AB 2020-~p. All Rights Reserved.` / holder `Ericsson AB 2020-~p` (`update_deprecations:144`), the same shape with `2021-~p` (`shell_docs_SUITE.erl:223`), `Copyright 2007, Ericsson AB.~n` (`send_term_SUITE.erl:334`), and the two `:=` lines with holder `'licenses Licenses Summary` (`ort-scanner.es:220`, `:398`). After: each file reports only its own header notice with the holder `Ericsson AB`.

- The guards are what bounds the blast radius, so they are worth poking at directly. A real dated notice must survive the directive rule (`Copyright Ericsson AB 1996-2026. All Rights Reserved.`, `Copyright Ericsson AB 2020-2024.`), and a tilde that is not a directive must not condemn one (`Copyright (c) 2020 ~ Acme Corp.` — a `~` followed by a word character is not a control sequence, so `~pete` in a URL is out of scope). `lib/stdlib/src/io_lib.erl` and `lib/stdlib/src/shell.erl` are the counterpart check: real Erlang sources with 8 and 43 tilde sequences and a genuine header, both of which must still report `Copyright Ericsson AB 1996-2026` — the rule is per value, so directives elsewhere in the file are irrelevant. For the key-name rule, a quoted notice being assigned on a `:=` line must survive whether or not it is dated, including on a sigil-keyed line (`#{ ~"notice" := "Copyright Acme Corp. All rights reserved." },`) and with an escaped quote inside the string.

## Intentional differences from Python

- ScanCode emits none of these five values, so this is a Provenant-only false-positive removal rather than a parity change.

## Follow-up work

- Created or intentionally deferred: two holders in `ort-scanner.es` survive and are separate mechanisms rather than this change regressing them — both were present before it. `Area, Mappings` (`:399`) is a holder whose own start line is the `}, Area, Mappings) ->` continuation, which carries neither a `:=` nor a marker, so no line-scoped rule can see it; dropping the copyright it accompanied leaves it orphaned, which is a symptom of the raw-line filter keying on `start_line` alone. `licenses deduplicate H T Found)` (`:476`) is comment prose (`... in their copyrights and licenses`) glued onto the following function head. Both belong to their own changes.

## Expected-output fixture changes

- Files changed: none. The full copyright golden corpus (36 tests / 2452 fixtures in `copyright_golden`), `post_processing_golden` (24), and `scanner_integration` (22) all pass unchanged, as does `cargo test --lib copyright` (1254 tests). Scoping the directive rule to the format-control regex rather than hoisting all of `contains_regex_or_template_marker` above the year exemption is what keeps that true: the weaker markers in that predicate (` ?`, a trailing `$`) would have been much likelier to condemn a real dated notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
