### PR TITLE
fix(copyright): drop fill-in notice templates, schema fields, and data rows

### DIFF
--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -486,10 +486,98 @@ fn drop_placeholder_and_code_junk_by_raw_line(
             || is_copyright_holder_placeholder_line(trimmed)
             || is_pattern_match_binding_line(trimmed)
             || is_notice_template_line(trimmed)
+            || is_delimited_data_row_line(trimmed)
+            || is_documentation_tag_reference_line(trimmed)
+    };
+    // The tagged type is the copyright field's own: on its line, or on the next one.
+    let declares_tagged_type = |start: LineNumber| {
+        raw_lines
+            .iter()
+            .skip(start.get().saturating_sub(1))
+            .take(2)
+            .any(|raw| is_tagged_type_field_declaration_line(raw.trim()))
     };
 
-    copyrights.retain(|c| !is_junk_line(c.start_line));
-    holders.retain(|h| !is_junk_line(h.start_line));
+    copyrights.retain(|c| !is_junk_line(c.start_line) && !declares_tagged_type(c.start_line));
+    holders.retain(|h| !is_junk_line(h.start_line) && !declares_tagged_type(h.start_line));
+}
+
+/// Every form a copyright marker takes at the head of a notice.
+static COPYRIGHT_MARKER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\bcopyright\b|\bcopr\.?|\(c\)|\u{a9}").expect("valid marker regex")
+});
+
+/// Whether the line is a positional data row: many short `;`-delimited fields,
+/// as in a Unicode character-database entry, which makes a `copyright` word on
+/// it a data cell rather than a notice. Every field has to read as a plain cell —
+/// short, and free of the abbreviating periods of prose (`Inc.`) and of code
+/// punctuation — which keeps a semicolon-separated notice and a banner on a
+/// minified stylesheet out of scope, and a dated notice is never a data row
+/// however many fields it is punctuated into.
+fn is_delimited_data_row_line(line: &str) -> bool {
+    const MIN_FIELDS: usize = 8;
+    const MAX_FIELD_LEN: usize = 48;
+    const CODE_PUNCTUATION: &[char] = &[
+        '{', '}', '(', ')', '[', ']', '/', '\\', '*', '=', ':', '|', '"', '.',
+    ];
+
+    if has_copyright_year(line) {
+        return false;
+    }
+
+    let mut fields = 0usize;
+    for field in line.split(';') {
+        let field = field.trim();
+        if field.len() > MAX_FIELD_LEN || field.contains(CODE_PUNCTUATION) {
+            return false;
+        }
+        fields += 1;
+    }
+
+    fields >= MIN_FIELDS
+}
+
+/// Whether the line names a documentation tag (`` `@copyright' `` in edoc,
+/// javadoc, or doxygen prose) rather than asserting a notice. The tag is closed
+/// off by its own quote or inline-code delimiter, so it carries no party name,
+/// and the closing delimiter is what keeps an open quote that does introduce one
+/// (`"@Copyright` above a chip label's party and year) out of scope.
+///
+/// A marker elsewhere on the line that does open on a party name is a real
+/// notice, dated or not, and keeps the line — the tag alone has to account for
+/// every notice-looking marker on it.
+fn is_documentation_tag_reference_line(line: &str) -> bool {
+    static QUOTED_DOC_TAG_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"(?i)["'`\u{2018}\u{201c}][@\\]copyright["'`\u{2019}\u{201d}]"#)
+            .expect("valid doc tag regex")
+    });
+
+    QUOTED_DOC_TAG_RE.is_match(line)
+        && !has_copyright_year(line)
+        && !COPYRIGHT_MARKER_RE.find_iter(line).any(|marker| {
+            !line[..marker.start()].ends_with(['@', '\\'])
+                && opens_on_party_name(&line[marker.end()..])
+        })
+}
+
+/// Whether the text after a marker opens on a capitalized party name, skipping
+/// the bare `c` of a `(c)` sign and any punctuation between them.
+fn opens_on_party_name(tail: &str) -> bool {
+    tail.split_whitespace()
+        .map(|token| token.trim_matches(|c: char| !c.is_alphanumeric()))
+        .find(|word| !word.is_empty() && !word.eq_ignore_ascii_case("c"))
+        .is_some_and(|word| word.starts_with(char::is_uppercase))
+}
+
+/// Whether the line declares a tagged type field (`[0] IMPLICIT SET OF`), the
+/// ASN.1 notation that makes a neighboring `copyright` field name a schema
+/// member rather than a notice.
+fn is_tagged_type_field_declaration_line(line: &str) -> bool {
+    static TAGGED_TYPE_FIELD_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\[\s*\d+\s*\]\s+(?:IMPLICIT|EXPLICIT)\b").expect("valid tagged type regex")
+    });
+
+    TAGGED_TYPE_FIELD_RE.is_match(line)
 }
 
 fn is_copyright_holder_placeholder_line(line: &str) -> bool {
@@ -521,21 +609,34 @@ fn is_copyright_holder_placeholder_line(line: &str) -> bool {
 ///
 /// Every marker must be a template: a detection records no column and so cannot
 /// be tied to one marker, which means a line that also asserts a real notice —
-/// dated or not — keeps all of its detections.
+/// dated or not — keeps all of its detections. The one marker that opens no
+/// notice at all is `copyright notice`, a term of art naming the form rather
+/// than claiming it.
 fn is_notice_template_line(line: &str) -> bool {
-    static MARKER_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?i)\bcopyright\b|\bcopr\.?|\(c\)|\u{a9}").expect("valid marker regex")
-    });
-
-    let mut saw_marker = false;
-    for marker in MARKER_RE.find_iter(line) {
-        saw_marker = true;
-        if !year_slot_is_placeholder(&line[marker.end()..]) {
+    let mut saw_template = false;
+    for marker in COPYRIGHT_MARKER_RE.find_iter(line) {
+        let tail = &line[marker.end()..];
+        if names_a_notice_form(tail) {
+            continue;
+        }
+        if !year_slot_is_placeholder(tail) {
             return false;
         }
+        saw_template = true;
     }
 
-    saw_marker
+    saw_template
+}
+
+/// Whether the marker is the term of art `copyright notice(s)` — the phrase
+/// refers to notices instead of asserting one, so it never supplies a party name.
+fn names_a_notice_form(tail: &str) -> bool {
+    tail.split_whitespace().next().is_some_and(|word| {
+        matches!(
+            word.trim_end_matches([',', ':', ';', '.']),
+            "notice" | "notices"
+        )
+    })
 }
 
 /// Whether the year slot of the notice opening at a marker holds a `YYYY`
@@ -546,11 +647,33 @@ fn is_notice_template_line(line: &str) -> bool {
 /// is lowercase (`Copyright Acme Corp. Release dates use the YYYY format.`),
 /// title-cased (`... Corp. Release Dates Use YYYY`), or behind a semicolon or
 /// colon (`... Corp; dates use YYYY`).
+///
+/// A fill-in slot written longhand collapses to `YYYY` before the walk and takes
+/// the same positional path. Only two forms count: a substitution variable
+/// (`[$date-of-software]`, `${year}`), which is text some tool is meant to
+/// replace, and a slot that instructs the reader to supply the date
+/// (`<insert year>`). A bare slot name (`<year>`, `{YEAR}`) is deliberately out
+/// of scope — it is how a project writes its own credit line, and the party it
+/// names is real.
 fn year_slot_is_placeholder(tail: &str) -> bool {
+    static DATE_FILL_IN_SLOT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            \$ \{? [\w.-]* \b (?: year | date ) \b [\w.-]*
+            |
+            [\[<{] [^\[\]<>{}]{0,20}
+            \b (?: insert | enter | fill | specify | your ) \b
+            [^\[\]<>{}]{0,20} \b (?: year | date ) \b [^\[\]<>{}]{0,20} [\]>}]
+            ",
+        )
+        .expect("valid date fill-in slot regex")
+    });
     static PLACEHOLDER_YEAR_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\by{4}\b").expect("valid placeholder year regex"));
     static PLAIN_YEAR_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"\b(?:19|20)\d{2}\b").expect("valid plain year regex"));
+
+    let tail = DATE_FILL_IN_SLOT_RE.replace_all(tail, " YYYY ");
 
     let mut previous_ended_sentence = false;
     let mut previous_ended_clause = false;

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -254,9 +254,11 @@ pub(super) fn opens_with_modal_instead_of_party(s: &str) -> bool {
 /// comparison is case-sensitive for the same reason: a trailing middle initial
 /// (`Jane A`) is not the article `a`.
 pub(super) fn is_truncated_lowercase_prose_holder(s: &str) -> bool {
+    // Modals are dangling tails too: they open the predicate a party name never has.
     const DANGLING_TAIL_WORDS: &[&str] = &[
-        "a", "an", "and", "as", "at", "but", "by", "for", "from", "in", "into", "of", "on", "onto",
-        "or", "over", "per", "the", "to", "under", "upon", "via", "with", "within", "without",
+        "a", "an", "and", "as", "at", "but", "by", "can", "for", "from", "in", "into", "may",
+        "must", "of", "on", "onto", "or", "over", "per", "shall", "should", "the", "to", "under",
+        "upon", "via", "will", "with", "within", "without", "would",
     ];
 
     let trimmed = s.trim().trim_end_matches(['.', ',', ';', ':']);

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -3414,9 +3414,14 @@ fn test_holder_that_is_prose_at_both_ends_is_junk() {
     for value in [
         "detection heuristics of REUSE tool in",
         "the copyright holders or",
+        // A modal opens the predicate a party name never has.
+        "in documents granted to the IETF Trust by contributors to Alternate Stream as though granted pursuant to RFC 5378, and shall",
+        "licenses of copyrights in documents which may",
     ] {
         assert_eq!(refine_holder(value), None, "kept {value:?}");
     }
+    assert!(!is_truncated_lowercase_prose_holder("Marshall Will"));
+    assert!(!is_truncated_lowercase_prose_holder("Jane May"));
     // A value that still names a capitalized party is left to the clause
     // strippers, and a trailing middle initial is not the article `a`.
     assert!(!is_truncated_lowercase_prose_holder(

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1708,6 +1708,196 @@ fn test_extract_copyright_information_keeps_notices_with_code_like_punctuation()
 }
 
 #[test]
+fn test_extract_copyright_information_drops_fill_in_year_notice_templates() {
+    // License texts that instruct how to write a notice put a substitution
+    // variable or a fill-in instruction where the year belongs, with or without
+    // a prose lead-in quoting the template.
+    for (name, text) in [
+        (
+            "LicenseRef-scancode-ietf-trust.txt",
+            "Copyright (c) <insert year> IETF Trust and the persons identified as the document authors.  All",
+        ),
+        (
+            "LicenseRef-scancode-ietf-trust.txt",
+            "BSD License: Copyright (c) <insert year> IETF Trust and the persons identified as authors of the code.",
+        ),
+        (
+            "W3C-19980720.txt",
+            "redistributed or derivative code: \"Copyright \u{a9} [$date-of-software] World Wide",
+        ),
+        (
+            "w3c-copyright-19990405.html",
+            "    doesn't exist, a notice of the form: \"Copyright \u{a9} [$date-of-document] <a href=\"http://www.w3.org/\">World Wide Web Consortium</a>,",
+        ),
+        (
+            "LicenseRef-scancode-w3c-docs-19990405.txt",
+            "The pre-existing copyright notice of the original author, or if it doesn't exist, a notice of the form: \"Copyright \u{a9} [$date-of-document] World Wide Web Consortium, (Massachusetts Institute of Technology).",
+        ),
+        ("NOTICE", "Copyright ${year} Acme Corp."),
+    ] {
+        let mut builder = FileInfoBuilder::default();
+        extract_copyright_information(&mut builder, Path::new(name), text, 120.0, false);
+        let file = build_single_file(builder);
+        assert!(
+            file.copyrights.is_empty(),
+            "copyright leaked from {text:?}: {:?}",
+            file.copyrights
+                .iter()
+                .map(|c| &c.copyright)
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            file.holders.is_empty(),
+            "holder leaked from {text:?}: {:?}",
+            file.holders.iter().map(|h| &h.holder).collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn test_extract_copyright_information_keeps_notices_beside_fill_in_templates() {
+    // A bare slot name is how a project writes its own credit line, so the party
+    // it names stays; so do real notices in the same files as the templates, and
+    // a line that both asserts a notice and quotes the template form.
+    for (name, text, expected_holder) in [
+        (
+            "W3C-19980720.txt",
+            "Copyright \u{a9} 1994-2002 World Wide Web Consortium, (Massachusetts Institute of",
+            "World Wide Web Consortium",
+        ),
+        (
+            "LicenseRef-scancode-w3c-docs-19990405.txt",
+            "Copyright \u{a9}  World Wide Web Consortium, (Massachusetts Institute of Technology,",
+            "World Wide Web Consortium",
+        ),
+        (
+            "NOTICE",
+            "Portions of this software are copyright \u{a9} <year> The FreeType Project (www.freetype.org).",
+            "The FreeType Project",
+        ),
+        (
+            "Nokia",
+            "Copyright \u{a9} <year> Nokia and others. All Rights Reserved.",
+            "Nokia and others",
+        ),
+        (
+            "not-real-copyrights",
+            "Copyright \" {YEAR} United States Government as represented by",
+            "United States Government",
+        ),
+        (
+            "FILE-HEADERS.md",
+            "Copyright Acme AB. New files must read Copyright Acme AB <insert year>.",
+            "Acme AB",
+        ),
+        (
+            "arcnet-hardware.txt",
+            "C2 -- \"@Copyright\n       Waterloo Microsystems Inc.\n       1985\"",
+            "Waterloo Microsystems Inc.",
+        ),
+        (
+            "overview.edoc",
+            "The `@copyright' tag documents the Copyright (c) Acme Corp notice.",
+            "Acme Corp",
+        ),
+        (
+            "HEADERS.md",
+            "The copyright notice reads: Copyright (c) Acme Corp",
+            "Acme Corp",
+        ),
+    ] {
+        let mut builder = FileInfoBuilder::default();
+        extract_copyright_information(&mut builder, Path::new(name), text, 120.0, false);
+        let file = build_single_file(builder);
+        assert!(
+            file.holders
+                .iter()
+                .any(|h| h.holder.contains(expected_holder)),
+            "holder {expected_holder:?} dropped from {text:?}: {:?}",
+            file.holders.iter().map(|h| &h.holder).collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn test_extract_copyright_information_drops_schema_fields_and_data_rows() {
+    for (name, text) in [
+        (
+            "Document-Profile-Descriptor.asn1",
+            concat!(
+                "Other-User-Information ::= SET {\n",
+                "  copyright\n",
+                "    [0] IMPLICIT SET OF\n",
+                "                   SET {copyright-information\n",
+                "                          [0] IMPLICIT SET OF Character-Data OPTIONAL,\n",
+                "                        copyright-dates\n",
+                "                          [1] IMPLICIT SET OF Date-and-Time OPTIONAL} OPTIONAL,\n",
+            ),
+        ),
+        (
+            "UnicodeData.txt",
+            concat!(
+                "2116;NUMERO SIGN;So;0;ON;<compat> 004E 006F;;;;N;NUMERO;;;;\n",
+                "2117;SOUND RECORDING COPYRIGHT;So;0;ON;;;;;N;;;;;\n",
+                "2118;SCRIPT CAPITAL P;Sm;0;ON;;;;;N;SCRIPT P;;;;\n",
+            ),
+        ),
+        (
+            "overview.edoc",
+            concat!(
+                "<dt><a name=\"mtag-copyright\">`@copyright'</a></dt>\n",
+                "      <dd>Specifies the module copyrights. The content can be\n",
+                "      arbitrary text; for example:\n",
+            ),
+        ),
+    ] {
+        let mut builder = FileInfoBuilder::default();
+        extract_copyright_information(&mut builder, Path::new(name), text, 120.0, false);
+        let file = build_single_file(builder);
+        assert!(
+            file.copyrights.is_empty(),
+            "copyright leaked from {name}: {:?}",
+            file.copyrights
+                .iter()
+                .map(|c| &c.copyright)
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn test_extract_copyright_information_keeps_semicolon_dense_notices() {
+    // Enough fields to look like a data row; the abbreviating periods and the
+    // stylesheet's code punctuation say otherwise.
+    for (name, text) in [
+        (
+            "NOTICE",
+            concat!(
+                "Copyright (c) 2020 Acme Inc.; 2021 Beta Ltd.; 2022 Gamma S.A.; 2023 Delta Oy;",
+                " 2024 Eps AB; 2025 Zeta AS; 2026 Eta B.V.; 2027 Theta Inc."
+            ),
+        ),
+        (
+            "bundle.min.css",
+            "/*! Copyright 2020 Acme Inc */body{margin:0;padding:0;color:red;border:0;top:0;left:0;right:0;bottom:0}",
+        ),
+        (
+            "CREDITS",
+            "Copyright 2020 Acme Inc;2021 Beta;2022 Gamma;2023 Delta;2024 Eps;2025 Zeta;2026 Eta;2027 Theta",
+        ),
+    ] {
+        let mut builder = FileInfoBuilder::default();
+        extract_copyright_information(&mut builder, Path::new(name), text, 120.0, false);
+        let file = build_single_file(builder);
+        assert!(
+            file.holders.iter().any(|h| h.holder.contains("Acme Inc")),
+            "holder dropped from {name}: {:?}",
+            file.holders.iter().map(|h| &h.holder).collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
 fn test_extract_copyright_information_keeps_banner_on_a_line_shared_with_code() {
     let text = "/*! Copyright (c) 2020 Acme Inc. All rights reserved. */ if (a || b) { c(); }";
     let mut builder = FileInfoBuilder::default();

--- a/testdata/copyright-golden/copyrights/misco4/linux8/insert-year.txt.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux8/insert-year.txt.yml
@@ -2,8 +2,6 @@ what:
   - copyrights
   - holders
   - authors
-copyrights:
-  - Copyright (c) IETF Trust
-holders:
-  - IETF Trust
+copyrights: []
+holders: []
 authors: []


### PR DESCRIPTION
## Summary

- Verifying [erlang/otp](https://github.com/erlang/otp) at `6146f0df` surfaced four more Provenant-only copyright/holder false-positive classes across six files. ScanCode emits none of them.
- **Fill-in year slots (the big one, 7 sites).** `is_notice_template_line` from #1385 already read a `YYYY` placeholder in the year slot; it now also reads the slot written longhand, either as a substitution variable (`[$date-of-software]`, `[$date-of-document]`, `${year}`) or as an instruction to supply the date (`<insert year>`). Both collapse to `YYYY` before the existing positional walk, so the slot still has to be the first year-like token in the run of party-name tokens after the marker — a placeholder in prose *after* a notice still cannot condemn it. This clears `LICENSES/W3C-19980720.txt:24`, `LICENSES/LicenseRef-scancode-ietf-trust.txt:55`/`:112`/`:123`/`:166`, `lib/xmerl/test/xmerl_xsd_Sun2002-01-16_SUITE_data/w3c-copyright-19990405.html:32`, and `lib/xmerl/test/xmerl_sax_std_SUITE_data/w3c-copyright-19980720.html:37`.
  - One marker is exempted rather than required to be a template: `copyright notice(s)` is a term of art naming the form instead of claiming it, so it never supplies a party name. That is what reaches `LICENSES/LicenseRef-scancode-w3c-docs-19990405.txt:12`, where the template is quoted after `The pre-existing copyright notice of the original author, or if it doesn't exist, a notice of the form: ...`. The exemption only ever fires on a line that already carries a template marker, so a line asserting a real notice is untouched.
  - A **bare** slot name (`<year>`, `{YEAR}`) is deliberately out of scope. That is how a project writes its own credit line and the party it names is real — `Portions of this software are copyright © <year> The FreeType Project (www.freetype.org).` and `Copyright © <year> Nokia and others.` are the only statements naming those holders in their own NOTICE/license files. Restricting the rule to substitution variables and explicit fill-in instructions keeps all three of those goldens (`freetype-FreeType`, `ics/freetype/NOTICE`, `nokia-Nokia`, `misco3/not-real-copyrights`) byte-identical.
- **Schema fields.** An ASN.1 tagged-type declaration (`[0] IMPLICIT SET OF`) makes a neighboring `copyright` field a schema member, not a notice. The notation sits on the line *after* the field name, so the check reads the detection's start line and the one line following it — `lib/asn1/test/asn1_SUITE_data/rfcs/Document-Profile-Descriptor.asn1:322` names the field on one line and its type on the next, and the holder starts on the declaration line itself. Restricting it to that pair ties the declaration to the copyright token rather than letting any declaration anywhere in a long candidate span condemn it.
- **Data rows.** A positional row of many short `;`-delimited fields is data, not prose. `lib/stdlib/uc_spec/UnicodeData.txt:7635` (`2117;SOUND RECORDING COPYRIGHT;So;0;ON;;;;;N;;;;;`) no longer manufactures a copyright and a holder out of three merged rows. This is a shape rule, not a filename rule: the existing `contains_unicode_segmentation_markers` guard covers only the UCD *break-test* files via their `÷`/`×` markers and does not reach this one. Four guards bound it — a copyright year anywhere on the line, a field over 48 characters, an abbreviating period (`Inc.`), or code punctuation all disqualify the line, which is what keeps both a semicolon-chained notice and a banner on a minified stylesheet.
- **Documentation tags.** A `@copyright` tag closed off by its own quote or inline-code delimiter (`` `@copyright' ``) names the tag rather than asserting a notice, clearing `lib/edoc/test/edoc_SUITE_data/overview.edoc:200`. Two guards bound it. The *closing* delimiter: an open quote that does introduce a notice (`C2 -- "@Copyright` above a chip label's party and year, in the `arcnet-hardware.txt` golden) must survive, and an earlier form of this rule dropped it. And, as in `is_notice_template_line`, the tag has to account for every notice-looking marker on the line — a marker outside it that opens on a capitalized party name is a real notice, dated or not, and keeps the line.
- **Modal tails.** A holder that is lowercase prose opening onto a modal verb — `in documents granted to the IETF Trust by contributors to Alternate Stream as though granted pursuant to RFC 5378, and shall` — is a clause, not a party name, so `DANGLING_TAIL_WORDS` gained the modals. The lowercase-opener requirement from #1385 is what keeps `Read the`, `Wind River Systems Inc Implemented by`, and friends.

## Issues

- Covers: erlang/otp benchmark verification follow-ups (copyright false positives).

## Scope and exclusions

- Included: `is_notice_template_line` and three new raw-source-line predicates in `src/copyright/detector/phases/postprocess.rs`, the dangling-tail word list in `src/copyright/refiner/junk.rs`, and tests in the owning files.
- Explicit exclusions: no author-detection changes, no license-index changes, no `BENCHMARKS.md` row. `contains_regex_or_template_marker` and the `:=` predicate are left alone — #1386 owns those.

## How to verify

- Fetch the six upstream files and scan them; every remaining value should be a real notice:

  ```bash
  base=https://raw.githubusercontent.com/erlang/otp/6146f0df6794451472fac4735e694ec1f56b873e
  curl -sL -o w3c.txt          $base/LICENSES/W3C-19980720.txt
  curl -sL -o ietf-trust.txt   $base/LICENSES/LicenseRef-scancode-ietf-trust.txt
  curl -sL -o w3c-docs.txt     $base/LICENSES/LicenseRef-scancode-w3c-docs-19990405.txt
  curl -sL -o doc.html         $base/lib/xmerl/test/xmerl_xsd_Sun2002-01-16_SUITE_data/w3c-copyright-19990405.html
  curl -sL -o sw.html          $base/lib/xmerl/test/xmerl_sax_std_SUITE_data/w3c-copyright-19980720.html
  curl -sL -o descriptor.asn1  $base/lib/asn1/test/asn1_SUITE_data/rfcs/Document-Profile-Descriptor.asn1
  curl -sL -o UnicodeData.txt  $base/lib/stdlib/uc_spec/UnicodeData.txt
  curl -sL -o overview.edoc    $base/lib/edoc/test/edoc_SUITE_data/overview.edoc
  provenant scan --json-pp - --copyright .
  ```

  `descriptor.asn1` and `UnicodeData.txt` should report nothing at all. The two HTML fixtures should report only their line-10 `Copyright © 1994-2002 ... World Wide Web Consortium ...` notice, `w3c.txt` only line 3, `w3c-docs.txt` only line 3, and `overview.edoc` only the two dated `@copyright ... Richard Carlsson` tags.
- The kept side is where the risk lives, so it is worth poking directly. All of these must still detect: a real dated notice in the same file and the same wording as the template it precedes; a notice with **no** year at all (`Copyright ©  World Wide Web Consortium, ...` in `w3c-docs.txt:3` — an undated notice is not a template); a bare `<year>`/`{YEAR}` slot; a line that both asserts a notice and quotes the template form (`Copyright Acme AB. New files must read Copyright Acme AB <insert year>.`); an open-quoted `"@Copyright` followed by a party and a year on later lines; and a genuinely semicolon-heavy notice line, where the abbreviating periods (`Inc.`, `S.A.`) are what separate it from a data row.

## Intentional differences from Python

- ScanCode emits none of these values, so this is a Provenant-only false-positive removal rather than a parity change — except for `insert-year.txt` below, where Provenant now deliberately reports less than ScanCode.

## Follow-up work

- Created or intentionally deferred:
  - `lib/edoc/test/edoc_SUITE_data/overview.edoc:201` still yields the holder `Specifies the` (and line 174 yields the same as an *author*). That is the same shape as the known `Copyright 2002 Read the` / `Read the` false positive in `testdata/copyright-golden/ics/oprofile-utils/opcontrol.yml` noted as a follow-up on #1385 — a capitalized verb plus a dangling article — and any rule reaching one reaches the other, so both are left to a single later change rather than shifted here.
  - `LicenseRef-scancode-ietf-trust.txt` still yields four prose fragments unrelated to the template class (`:21`, `:103`, `:225`, and the copyright at `:249` whose holder this PR drops). They are running legal prose swept up by a bare `copyrights` token, not placeholder templates.

## Expected-output fixture changes

- Files changed: `testdata/copyright-golden/copyrights/misco4/linux8/insert-year.txt.yml` — `Copyright (c) IETF Trust` / holder `IETF Trust` become empty.
- Why the new expected output is correct: that fixture is a one-line file containing `Copyright (c) <insert year> IETF Trust`, which is *the same RFC 5378 boilerplate* as the required target `LicenseRef-scancode-ietf-trust.txt:112`/`:166`. There is no signal that separates them, so fixing the target necessarily moves this golden. The old value is the exact harm #1385 was written to stop: refinement strips the placeholder and leaves an output value indistinguishable from a real dated notice, so a user reading the scan sees an IETF Trust copyright claim in a file that only contains a template authors are told to fill in. Reporting nothing is the honest answer.
- The four other goldens that a broader form of this rule moved (`freetype-FreeType`, `ics/freetype/NOTICE`, `nokia-Nokia`, `misco3/not-real-copyrights`) are **unchanged**: restricting the rule to substitution variables and fill-in instructions, rather than any bracketed year slot, keeps their holders. The `arcnet-hardware.txt` golden likewise drove the closing-delimiter requirement on the documentation-tag rule. Everything else passes unchanged — the full `copyright_golden` corpus, `post_processing_golden`, and `scanner_integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
