### PR TITLE
docs(benchmarks): refresh the erlang/otp row at v1.0.8

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 254 of 254 recorded runs, with a **19.7× median speedup** and **19.7× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **37.9×** on 10k+ file targets.
+> Provenant is faster on 254 of 254 recorded runs, with a **19.7× median speedup** and **19.7× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **37.2×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -322,12 +322,12 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Timing: Provenant `4.88s`; ScanCode `51.28s`
 - Direct Hex package and dependency extraction (`1` vs `0` packages, `13` vs `0` dependencies): a `pkg:hex/plug` package from `mix.exs` carrying locked `plug_crypto`, `telemetry`, `ex_doc`, and sibling Hex pins from `mix.lock` that ScanCode leaves at zero, with Unicode-preserving `Loïc Hoguin` holder normalization
 
-##### [erlang/otp @ 6146f0d](https://github.com/erlang/otp/tree/6146f0df6794451472fac4735e694ec1f56b873e) — **38.99× faster**
+##### [erlang/otp @ 6146f0d](https://github.com/erlang/otp/tree/6146f0df6794451472fac4735e694ec1f56b873e) — **32.84× faster**
 
 - Files: 11,803
-- Run context: 2026-08-20 · macOS 26.6.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
-- Timing: Provenant `51.90s`; ScanCode `2023.39s`
-- Broader OTP package and dependency visibility (`51` vs `0` packages, `16` vs `9` dependencies): one `pkg:hex/<app>` package per committed `lib/*/src/*.app.src` (`41`, with bounded `%PLACEHOLDER%` handling that keeps canonical manifests such as `diameter.app.src` scannable) alongside `10` `pkg:autotools` packages from per-application `configure.ac` build manifests and the `mix.lock` Hex pins ScanCode leaves unread, plus lower-noise detection across the doc and test tree, where ScanCode reads Erlang identifiers as licenses (`mpl-2.0` from `ModemDescriptor_mpl`, `boost-1.0` from the `bsl` bit-shift operator), a code comment as `proprietary-license`, Erlang variables as copyright holders (`(c), Ctxt, Ren, Env`), and an Erlang `.app` filename as `http://ftp.app/`, with more precise license composition on the vendored `ryu` sources — whose alternative grant reads `(apache-2.0 OR boost-1.0)` rather than a conjunction — third-party `vendor.info` notices recorded without the trailing JSON key ScanCode appends, and Unicode-preserving party names such as `Björn Gustavsson`, `Mickaël Rémond`, and `Claes Wikström`
+- Run context: 2026-08-21 · macOS 26.6.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `61.62s`; ScanCode `2023.39s`
+- Broader OTP package and dependency visibility (`51` vs `0` packages, `16` vs `9` dependencies): one `pkg:hex/<app>` package per committed `lib/*/src/*.app.src` (`41`, with bounded `%PLACEHOLDER%` handling that keeps canonical manifests such as `diameter.app.src` scannable) alongside `10` `pkg:autotools` packages from per-application `configure.ac` build manifests and the `mix.lock` Hex pins ScanCode leaves unread, plus markedly lower-noise party and license detection across the doc and test tree, where ScanCode reads Erlang identifiers as licenses (`mpl-2.0` on `24` sites from `ModemDescriptor_mpl`, `boost-1.0` from the `bsl` bit-shift operator, `bsd-new` from `bsd style pthread_set_name_np`), a code comment as `proprietary-license`, Erlang variables as copyright holders (`(c), Ctxt, Ren, Env`), and an Erlang `.app` filename as `http://ftp.app/`; more precise license composition on the vendored `ryu` sources, whose alternative grant reads `(apache-2.0 OR boost-1.0)` rather than a conjunction; third-party `vendor.info` notices recorded without the trailing JSON key ScanCode appends; and source-faithful parties throughout — email addresses in their original case (`Paul.Green@stratus.com`) and Unicode-preserving names such as `Björn Gustavsson`, `Mickaël Rémond`, and `Claes Wikström`
 
 ##### [livebook-dev/livebook @ 77cbcd9](https://github.com/livebook-dev/livebook/tree/77cbcd98df133045f5a4adf7273e4cd077307714) — **17.14× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -1504,9 +1504,9 @@ Provenant: 48.49s</title></circle>
     <circle cx="741.15" cy="452.64" r="4.5" fill="#2563eb"><title>spring-projects/spring-boot @ 53827d4
 Files: 11643
 Provenant: 44.52s</title></circle>
-    <circle cx="742.09" cy="445.39" r="4.5" fill="#2563eb"><title>erlang/otp @ 6146f0d
+    <circle cx="742.09" cy="437.28" r="4.5" fill="#2563eb"><title>erlang/otp @ 6146f0d
 Files: 11803
-Provenant: 51.90s</title></circle>
+Provenant: 61.62s</title></circle>
     <circle cx="742.86" cy="446.23" r="4.5" fill="#2563eb"><title>apache/airflow @ 47ce5f3
 Files: 11935
 Provenant: 50.99s</title></circle>


### PR DESCRIPTION
## Summary

- The previous row was measured at `bf3e260f`. **Nine** detection PRs landed after it (#1379–#1387), so it described a scanner revision that no longer exists. Re-measured at the **v1.0.8** tag (`9a7a722d`): Provenant `61.62s` vs ScanCode `2023.39s` across 11,803 files.
- The outcome bullet gains three things and drops nothing: the `bsd-new` clue ScanCode reads out of `bsd style pthread_set_name_np`, the site count for the `mpl-2.0` identifier misreads (`24`), and source-case email addresses.
- Chart and the 10k+ median-gap figure regenerated via `generate-benchmark-chart`.

## Issues

- Covers: the verification campaign behind #1365 and its two follow-up rounds (#1373–#1387).

## Scope and exclusions

- Included: the one `erlang/otp` row plus the regenerated chart and summary figure.
- **Excluded, deliberately:** the largest single false-positive removal of this campaign — `bsd_bare_word_only.RULE`, 301 sites of operating-system prose — is **not** claimed as an advantage. That rule was Provenant-invented, so ScanCode emits zero hits for it; removing it cleaned up our own noise rather than beating ScanCode. Same for the other Provenant-only fixes (notice templates, `~p`/`~n` format directives, UCD data rows, ASN.1 schema fields). Only differences where ScanCode actually emits the worse value are claimed.

## On the timing — please read before comparing to the previous row

The recorded number went `51.90s` → `61.62s`, which looks like a regression and is not one. This host swings ~±20% run to run; five earlier measurements of the same target spanned 51.4s–70.9s.

I checked it directly with `perf-ab --base bf3e260f --head 9a7a722d --rounds 5`, which interleaves both sides so machine drift is shared:

```
round | base (s) | head (s)
    1 |   61.569 |  61.578
    2 |   60.121 |  60.272
    3 |   53.847 |  63.571
    4 |   51.849 |  60.814
    5 |   60.493 |  64.125
  base median 60.121s   head median 61.578s   → 2.42% slower
```

Two near-identical pairs then three divergent ones — the base caught two fast runs mid-sequence rather than head being consistently slow. Intra-side spread is 19% on base, so a 2.4% effect is not resolvable here; there is no evidence of a real regression, and a small one would be plausible on first principles since these PRs added filter predicates. The perf-ab head median (`61.58s`) matches the recorded compare run (`61.62s`), so today's figure is representative of the host's current state rather than an outlier. That A/B number is not recorded in the document — `perf-ab` timings do not belong there.

## How to verify

```
cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- \
  --repo-url https://github.com/erlang/otp.git \
  --repo-ref 6146f0df6794451472fac4735e694ec1f56b873e --profile common
```

**No regressions from the nine PRs.** The ScanCode-favored queue fell 487 → 473, Provenant-favored signals 2,004 → 1,823, and email deltas 30 → 7 (the source-case fix). Of the 21 ScanCode-favored values that are *new* since the last run, every one is a case where ScanCode emits junk and Provenant now does not — `Copyright (c) YYYY CopyrightHolder`, `Copyright Ericsson AB 2020-~p`, `Ericsson AB Years`, `current_datetime.year Ericsson AB`, `Emacs. An`. Getting cleaner than ScanCode registers as a ScanCode-favored delta, because the comparison cannot tell that a value only ScanCode has is junk.

## Follow-up work

- Created or intentionally deferred: a residual long tail remains in doc/RFC/test-fixture files — roughly a dozen sites including UCD-row holders in `EastAsianWidth.txt`/`PropList.txt`, `Appendix B.` as an author in `rfc7068.txt`, a field label swept into an author in `file_server.erl`, and truncated prose holders in `ietf-trust.txt`. My sweep is clean against its current heuristics, which is a weaker claim than absolute cleanliness and is stated that way on purpose.
- Two architectural fixes were investigated and **rejected on evidence**, both worth recording so they are not retried blindly. Making the detector's raw-line junk filter span-wide (aligning it with the scanner-level `render_raw_span`) is a no-op: zero output change across 11,806 files. Pruning holders with no surviving copyright looked ideal — 8/8 false positives on this target — but the golden corpus showed it destroys deliberate behavior, namely holder recovery from a malformed marker (`opyright 2014 Baidu Inc.`, `Copyright 2010 Ben Dooks <ben-linux <at> fluff.org>`, `all files are opyright to Sven Olaf Oostenbrink`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)