### PR TITLE
fix(copyright): require local fallback evidence

### DIFF
--- a/src/copyright/detector/diagnostics.rs
+++ b/src/copyright/detector/diagnostics.rs
@@ -105,8 +105,12 @@ fn trace_candidate_groups(content: &str) -> Vec<CandidateGroupTrace> {
 }
 
 #[test]
-fn test_nameslist_rows_are_attributed_to_span_fallback() {
+fn test_nameslist_rows_are_rejected_by_span_fallback() {
     let input = concat!(
+        "00A8\tDIAERESIS\n",
+        "\t* this is a spacing character\n",
+        "\tx (combining diaeresis - 0308)\n",
+        "\t# 0020 0308\n",
         "00A9\tCOPYRIGHT SIGN\n",
         "\tx (sound recording copyright - 2117)\n",
         "\tx (circled latin capital letter c - 24B8)\n",
@@ -118,7 +122,7 @@ fn test_nameslist_rows_are_attributed_to_span_fallback() {
     let traces = trace_candidate_groups(input);
     let trace = traces
         .iter()
-        .find(|trace| trace.lines.contains(&2))
+        .find(|trace| trace.lines.contains(&6))
         .expect("candidate group containing the copyright cross-reference");
 
     assert!(!trace.has_top_level_nodes, "trace: {trace:#?}");
@@ -134,8 +138,8 @@ fn test_nameslist_rows_are_attributed_to_span_fallback() {
         .iter()
         .find(|detections| detections.origin == DetectionOrigin::SpanFallback)
         .expect("span-fallback origin");
-    assert!(!span.copyrights.is_empty(), "trace: {trace:#?}");
-    assert!(!span.holders.is_empty(), "trace: {trace:#?}");
+    assert!(span.copyrights.is_empty(), "trace: {trace:#?}");
+    assert!(span.holders.is_empty(), "trace: {trace:#?}");
     assert!(span.authors.is_empty(), "trace: {trace:#?}");
 }
 

--- a/src/copyright/detector/tests_false_positives.rs
+++ b/src/copyright/detector/tests_false_positives.rs
@@ -1380,3 +1380,178 @@ fn test_placeholder_prose_behind_any_punctuation_keeps_the_notice() {
         );
     }
 }
+
+#[test]
+fn test_unicode_name_cross_references_are_not_copyright_notices() {
+    let data_groups = [
+        concat!(
+            "00A8\tDIAERESIS\n",
+            "\t* this is a spacing character\n",
+            "\tx (combining diaeresis - 0308)\n",
+            "\t# 0020 0308\n",
+            "00A9\tCOPYRIGHT SIGN\n",
+            "\tx (sound recording copyright - 2117)\n",
+            "\tx (circled latin capital letter c - 24B8)\n",
+            "\tx (copyleft symbol - 1F12F)\n",
+            "\tx (mask work symbol - 1F1AD)\n",
+            "00AA\tFEMININE ORDINAL INDICATOR\n",
+        ),
+        concat!(
+            "2117\tSOUND RECORDING COPYRIGHT\n",
+            "\t= published\n",
+            "\t= phonorecord sign\n",
+            "\tx (copyright sign - 00A9)\n",
+            "\tx (circled latin capital letter p - 24C5)\n",
+            "2118\tSCRIPT CAPITAL P\n",
+        ),
+        concat!(
+            "24B8\tCIRCLED LATIN CAPITAL LETTER C\n",
+            "\tx (copyright sign - 00A9)\n",
+            "\t# <circle> 0043\n",
+            "24B9\tCIRCLED LATIN CAPITAL LETTER D\n",
+        ),
+        concat!(
+            "24C5\tCIRCLED LATIN CAPITAL LETTER P\n",
+            "\tx (sound recording copyright - 2117)\n",
+            "\t# <circle> 0050\n",
+            "24C6\tCIRCLED LATIN CAPITAL LETTER Q\n",
+        ),
+        concat!(
+            "1F1AD\tMASK WORK SYMBOL\n",
+            "\t* indicates intellectual property protection for integrated circuit layouts\n",
+            "\tx (copyright sign - 00A9)\n",
+            "\tx (circled latin capital letter m - 24C2)\n",
+            "@\t\tRegional indicator symbols\n",
+            "@+\t\tThese characters can be used in pairs to represent regional codes.\n",
+            "1F1E6\tREGIONAL INDICATOR SYMBOL LETTER A\n",
+        ),
+    ];
+
+    for input in data_groups {
+        let (copyrights, holders, authors) = detect_copyrights_from_text(input);
+        assert!(copyrights.is_empty(), "copyrights: {copyrights:#?}");
+        assert!(holders.is_empty(), "holders: {holders:#?}");
+        assert!(authors.is_empty(), "authors: {authors:#?}");
+    }
+
+    let (copyrights, holders, _authors) =
+        detect_copyrights_from_text("@+\t\t© 2022 Unicode®, Inc.\n");
+    assert_eq!(copyrights[0].copyright, "(c) 2022 Unicode(r), Inc.");
+    assert_eq!(holders[0].holder, "Unicode(r), Inc.");
+}
+
+#[test]
+fn test_document_section_headings_are_not_copyright_notices() {
+    for heading in [
+        "=head1 COPYRIGHT AND LICENSE",
+        "=head1 COPYRIGHT & LICENSE",
+        "=head1 COPYRIGHT AND DISCLAIMERS",
+        ".SH \"COPYRIGHT AND LICENSE\"",
+        "COPYRIGHT AND LICENSE",
+    ] {
+        let (copyrights, holders, _authors) = detect_copyrights_from_text(heading);
+        assert!(
+            copyrights.is_empty(),
+            "heading produced copyrights: {copyrights:?} for {heading:?}"
+        );
+        assert!(
+            holders.is_empty(),
+            "heading produced holders: {holders:?} for {heading:?}"
+        );
+    }
+}
+
+#[test]
+fn test_copyright_operational_prose_is_not_a_notice() {
+    for prose in [
+        "23. Update copyrights. crc32.c, deflate.c, globals.c, revision.h, ziperr.h",
+        "1. Update copyrights to 2008. zip.c, zipcloak.c, zipfile.c",
+        "NOTE on copyright history:",
+    ] {
+        let (copyrights, holders, _authors) = detect_copyrights_from_text(prose);
+        assert!(
+            copyrights.is_empty(),
+            "prose produced copyrights: {copyrights:?} for {prose:?}"
+        );
+        assert!(
+            holders.is_empty(),
+            "prose produced holders: {holders:?} for {prose:?}"
+        );
+    }
+}
+
+#[test]
+fn test_non_ownership_copyright_descriptions_are_not_notices() {
+    for description in [
+        "CP = 1 (Copyright unasserted)\nAN = 0 (Audio data)\nP = 0 (Consumer)",
+        "Le logiciel est protege par un copyright et licencie par des fournisseurs de Sun.",
+    ] {
+        let (copyrights, holders, _authors) = detect_copyrights_from_text(description);
+        assert!(
+            copyrights.is_empty(),
+            "description produced copyrights: {copyrights:?} for {description:?}"
+        );
+        assert!(
+            holders.is_empty(),
+            "description produced holders: {holders:?} for {description:?}"
+        );
+    }
+}
+
+#[test]
+fn test_copyright_identifiers_are_not_notices() {
+    for code in [
+        "extern ZCONST char *copyright[1];",
+        "nlm_COPYRIGHT = Op Copyright '$(copyright)'",
+        "const char *copyright_notice;",
+    ] {
+        let (copyrights, holders, _authors) = detect_copyrights_from_text(code);
+        assert!(
+            copyrights.is_empty(),
+            "code produced copyrights: {copyrights:?} for {code:?}"
+        );
+        assert!(
+            holders.is_empty(),
+            "code produced holders: {holders:?} for {code:?}"
+        );
+    }
+}
+
+#[test]
+fn test_fallback_evidence_keeps_real_undated_notices() {
+    for (notice, expected_holder) in [
+        ("Copyright CERN", "CERN"),
+        ("Copyright The NetBSD Foundation, Inc.", "NetBSD Foundation"),
+        (
+            "(c) Free Software Foundation, Inc.",
+            "Free Software Foundation",
+        ),
+        (
+            "This code is copyrighted by Acme Research.",
+            "Acme Research",
+        ),
+    ] {
+        let (copyrights, holders, _authors) = detect_copyrights_from_text(notice);
+        assert!(!copyrights.is_empty(), "notice was rejected: {notice:?}");
+        assert!(
+            holders
+                .iter()
+                .any(|holder| holder.holder.contains(expected_holder)),
+            "holder missing from {holders:?} for {notice:?}"
+        );
+    }
+}
+
+#[test]
+fn test_fallback_does_not_flatten_structured_holder_record() {
+    let input = concat!(
+        "copyrights:\n",
+        "  - holder: Russ Allbery <rra@cpan.org>\n",
+        "    years: 1999-2010, 2012-2022\n",
+    );
+
+    let (copyrights, holders, _authors) = detect_copyrights_from_text(input);
+
+    assert!(copyrights.is_empty(), "copyrights: {copyrights:#?}");
+    assert!(holders.is_empty(), "holders: {holders:#?}");
+}

--- a/src/copyright/detector/tree_walk/copyright/spans.rs
+++ b/src/copyright/detector/tree_walk/copyright/spans.rs
@@ -16,21 +16,6 @@ use crate::copyright::types::{
     AuthorDetection, CopyrightDetection, HolderDetection, ParseNode, PosTag, Token,
 };
 
-/// Whether a fallback copyright span carries a real holder anchor: a proper
-/// noun, company/university token, email/URL, or a year.
-///
-/// The grammar productions never build a copyright from `<Copy>` plus only
-/// common-noun (`<NN>`) prose — a holder must be an `<NNP>`/`<NAME>`/`<COMPANY>`
-/// or a year must be present. The span fallbacks run only when the grammar
-/// produced no copyright node, and they otherwise sweep in common nouns, so a
-/// bare `copyright paperwork` / `copyright and the source code` prose fragment
-/// slips through. Requiring the same holder anchor the grammar demands keeps the
-/// fallback from manufacturing copyrights out of ordinary prose that merely
-/// mentions the word "copyright".
-fn span_has_strong_holder_or_year(span: &[&Token]) -> bool {
-    span.iter().any(|t| is_strong_holder_or_year_token(t))
-}
-
 /// Whether one token can anchor a copyright span: a year, a proper noun /
 /// company / university token, an email or URL, or an organization acronym.
 fn is_strong_holder_or_year_token(t: &Token) -> bool {
@@ -51,6 +36,60 @@ fn is_strong_holder_or_year_token(t: &Token) -> bool {
                     | PosTag::Url2
             )
             || is_acronym_like(&t.value))
+}
+
+/// Whether a word-form copyright marker occurs where an ownership assertion
+/// can begin.
+///
+/// A fallback is allowed at the start of a prepared line, after punctuation,
+/// or after an ownership connective (`is copyrighted`, `portions copyright`).
+/// This keeps a rejected grammar parse from turning an operational phrase such
+/// as `Update copyrights to 2008` or an inline data description into a notice.
+fn marker_has_notice_context(tokens: &[&Token], marker_index: usize) -> bool {
+    let marker = tokens[marker_index];
+    if marker.tag == PosTag::SpdxContrib || is_bare_c_sign(marker) {
+        return true;
+    }
+
+    let next = tokens[marker_index + 1..]
+        .iter()
+        .copied()
+        .find(|token| token.start_line == marker.start_line);
+    if next.is_some_and(|token| matches!(token.tag, PosTag::Copy | PosTag::Holder)) {
+        return true;
+    }
+    if marker.value == "Copyright" && next.is_some_and(detector::token_utils::is_year_like_token) {
+        return true;
+    }
+
+    let Some(previous) = tokens[..marker_index]
+        .iter()
+        .rev()
+        .copied()
+        .find(|token| token.start_line == marker.start_line)
+    else {
+        return true;
+    };
+
+    if matches!(
+        previous.tag,
+        PosTag::Is | PosTag::Held | PosTag::By | PosTag::Portions
+    ) {
+        return true;
+    }
+    if previous.tag == PosTag::Dash || (previous.tag == PosTag::Cc && previous.value.trim() == ",")
+    {
+        return true;
+    }
+
+    let word = previous
+        .value
+        .trim_matches(|character: char| character.is_ascii_punctuation())
+        .to_ascii_lowercase();
+    matches!(
+        word.as_str(),
+        "are" | "was" | "were" | "remain" | "remains" | "owned" | "owns" | "not"
+    ) || previous.value.ends_with('.')
 }
 
 /// Whether the token is a bare `(c)` copyright sign, the only copyright marker
@@ -101,11 +140,82 @@ fn bare_c_span_names_holder_up_front(span: &[&Token]) -> bool {
         .is_some_and(|t| is_strong_holder_or_year_token(t))
 }
 
-/// Whether a fallback span carries a usable holder anchor. `leads_with_bare_c`
-/// tightens the check to an up-front holder when the span opens on a bare `(c)`
-/// sign; see [`bare_c_span_names_holder_up_front`].
-fn span_has_holder_anchor(span: &[&Token], leads_with_bare_c: bool) -> bool {
-    span_has_strong_holder_or_year(span)
+/// Whether the marker is followed locally by a year or holder.
+///
+/// Flat fallback spans can cover several continuation lines. An entity-like
+/// token at the far end of that span is not evidence for the marker near its
+/// beginning: data dictionaries commonly contain a `copyright` cross-reference
+/// followed by an unrelated all-caps record name. Require the evidence on the
+/// marker line, or on the immediately following line when the marker line ends
+/// with only connective punctuation.
+fn marker_has_local_holder_or_year(marker_span: &[&Token]) -> bool {
+    let Some(marker) = marker_span.first() else {
+        return false;
+    };
+
+    let evaluate_line = |tokens: &[&Token]| -> Option<bool> {
+        if tokens
+            .iter()
+            .any(|token| detector::token_utils::is_year_like_token(token))
+        {
+            return Some(true);
+        }
+
+        tokens
+            .iter()
+            .copied()
+            .find(|token| {
+                if token.tag == PosTag::Copy {
+                    return false;
+                }
+                let word = token
+                    .value
+                    .trim_matches(|character: char| !character.is_alphanumeric())
+                    .to_ascii_lowercase();
+                !(matches!(
+                    word.as_str(),
+                    "" | "the" | "a" | "an" | "by" | "is" | "held"
+                ) || matches!(token.tag, PosTag::Dash)
+                    || token.tag == PosTag::Holder && token.start_line == marker.start_line
+                    || token.tag == PosTag::Cc && token.value.trim() == ",")
+            })
+            .map(is_strong_holder_or_year_token)
+    };
+
+    let same_line: Vec<&Token> = marker_span
+        .iter()
+        .copied()
+        .skip(1)
+        .take_while(|token| token.start_line == marker.start_line)
+        .collect();
+    if let Some(has_evidence) = evaluate_line(&same_line) {
+        return has_evidence;
+    }
+
+    let Some(next_line) = marker_span
+        .iter()
+        .skip(1)
+        .find(|token| token.start_line != marker.start_line)
+        .map(|token| token.start_line)
+    else {
+        return false;
+    };
+    let continuation: Vec<&Token> = marker_span
+        .iter()
+        .copied()
+        .skip(1)
+        .filter(|token| token.start_line == next_line)
+        .collect();
+    evaluate_line(&continuation).unwrap_or(false)
+}
+
+/// Whether a fallback span carries usable, locally owned evidence.
+fn span_has_holder_anchor(
+    span: &[&Token],
+    marker_span: &[&Token],
+    leads_with_bare_c: bool,
+) -> bool {
+    marker_has_local_holder_or_year(marker_span)
         && (!leads_with_bare_c || bare_c_span_names_holder_up_front(span))
 }
 
@@ -313,7 +423,10 @@ pub fn extract_from_spans(
                     .iter()
                     .any(|t| detector::token_utils::is_year_like_token(t));
                 let filtered = detector::token_utils::strip_all_rights_reserved_slice(span);
-                if span_has_holder_anchor(&filtered, leads_with_bare_c)
+                let marker_span = &all_leaves[copy_idx..i];
+                let has_fallback_evidence = marker_has_notice_context(&all_leaves, copy_idx)
+                    && span_has_holder_anchor(&filtered, marker_span, leads_with_bare_c);
+                if has_fallback_evidence
                     && let Some(det) = detector::token_utils::build_copyright_from_tokens(&filtered)
                 {
                     copyrights.push(det);
@@ -323,7 +436,7 @@ pub fn extract_from_spans(
                     continue;
                 }
 
-                if !skip_holder_from_span && span_has_holder_anchor(&filtered, leads_with_bare_c) {
+                if !skip_holder_from_span && has_fallback_evidence {
                     let holder_span = filtered.as_slice();
                     let holder_tokens: Vec<&Token> = holder_span
                         .iter()
@@ -564,7 +677,10 @@ pub fn extract_copyrights_from_spans(
 
                 let leads_with_bare_c = start == copy_idx && is_bare_c_sign(token);
                 let filtered = detector::token_utils::strip_all_rights_reserved_slice(span);
-                if span_has_holder_anchor(&filtered, leads_with_bare_c)
+                let marker_span = &all_leaves[copy_idx..i];
+                let has_fallback_evidence = marker_has_notice_context(&all_leaves, copy_idx)
+                    && span_has_holder_anchor(&filtered, marker_span, leads_with_bare_c);
+                if has_fallback_evidence
                     && let Some(det) = detector::token_utils::build_copyright_from_tokens(&filtered)
                 {
                     copyrights.push(det);
@@ -574,7 +690,7 @@ pub fn extract_copyrights_from_spans(
                     continue;
                 }
 
-                if !skip_holder_from_span && span_has_holder_anchor(&filtered, leads_with_bare_c) {
+                if !skip_holder_from_span && has_fallback_evidence {
                     let holder_span = filtered.as_slice();
                     let holder_tokens: Vec<&Token> = holder_span
                         .iter()

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/sound/pci/emu10k1/emu10k1_main.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/sound/pci/emu10k1/emu10k1_main.c.yml
@@ -3,14 +3,12 @@ what:
   - holders
   - authors
 copyrights:
-  - (Copyright unasserted) AN 0 (Audio data) P 0 (Consumer)
   - (c) by Jaroslav Kysela <perex@perex.cz>
   - Copyright (c) by James Courtier-Dutton <James@superbug.co.uk>
   - Copyright (c) by Jaroslav Kysela <perex@perex.cz> Creative Labs, Inc. Routines
 holders:
   - James Courtier-Dutton
   - Jaroslav Kysela Creative Labs, Inc. Routines
-  - unasserted AN 0 (Audio data) P 0 (Consumer)
 authors:
   - James@superbug.co.uk
   - michael@gernoth.net

--- a/testdata/copyright-golden/copyrights/web_app_dtd_sun_twice-web_app_b_dtd.dtd.yml
+++ b/testdata/copyright-golden/copyrights/web_app_dtd_sun_twice-web_app_b_dtd.dtd.yml
@@ -4,12 +4,8 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 2000 Sun Microsystems, Inc.
-  - copyright et licencie par des fournisseurs de Sun
 holders:
   - Sun Microsystems, Inc.
-  - et licencie par des fournisseurs de Sun
 holders_summary:
   - value: Sun Microsystems
-    count: 1
-  - value: et licencie par des fournisseurs de Sun
     count: 1


### PR DESCRIPTION
## Summary

- Require copyright evidence to be local to a fallback marker instead of accepting a holder-like token anywhere in a broad candidate span.
- Preserve established undated and nonstandard notice shapes through explicit positive grammar cues.
- Add a varied regression corpus covering Unicode data, POD/man headings, prose, code identifiers, structured metadata, and valid undated notices.

## Issues

- Covers: #1391

## Scope and exclusions

- Included: the last-resort span fallback evidence policy and directly owned copyright goldens.
- Explicit exclusions: structured markup and string-literal output projection, handled by the next stack layer.

## How to verify

- Scan Perl 5.38.4 unicore/NamesList.txt with --copyright and confirm only the real Unicode Inc. header remains; the six data-row detections from #1391 must be absent.
- On the full Perl 5.38.4 tree, compare copyright output before and after: this branch removed 166 detections and added none; audit the removals as headings, schema rows, identifiers, or prose.

## Intentional differences from Python

- ScanCode behavior is used as a regression signal, but the implementation is a local-evidence invariant rather than a port of its top-node traversal and leaf-skipping details.

## Expected-output fixture changes

- Files changed: two copyright golden YAML files for an audio placeholder and French licensing prose.
- Why the new expected output is correct: both removed values are non-attribution prose that reached the broad span fallback; surrounding valid notices remain covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)