### PR TITLE
fix(detection): decode POD contact markup

### DIFF
--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -423,13 +423,31 @@ fn should_keep_angle_bracket_content(m: &str) -> bool {
     false
 }
 
+fn unwrap_simple_pod_formatting(text: &str) -> String {
+    static POD_FORMATTING_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\b[BCFILS]<(?P<text>[^/<>][^<>]*)>").expect("valid POD formatting regex")
+    });
+
+    let mut unwrapped = text.to_string();
+    for _ in 0..3 {
+        if !POD_FORMATTING_RE.is_match(&unwrapped) {
+            break;
+        }
+        unwrapped = POD_FORMATTING_RE
+            .replace_all(&unwrapped, "$text")
+            .into_owned();
+    }
+    unwrapped
+}
+
 /// Prepare a text `line` for copyright detection.
 ///
 /// Applies a sequence of normalizations to clean up raw text before
 /// copyright/author detection. This mirrors the Python `prepare_text_line()`
 /// function from ScanCode Toolkit.
 pub fn prepare_text_line(line: &str) -> String {
-    let mut s = line.to_string();
+    let mut s = line.replace("E<lt>", "<").replace("E<gt>", ">");
+    s = unwrap_simple_pod_formatting(&s);
 
     s.retain(|ch| ch != '\0');
 
@@ -1026,6 +1044,22 @@ mod tests {
     #[test]
     fn test_html_entity_amp() {
         assert_eq!(prepare_text_line("foo &amp; bar"), "foo & bar");
+    }
+
+    #[test]
+    fn test_perl_pod_angle_escapes() {
+        assert_eq!(
+            prepare_text_line("Maintained by Jane Doe E<lt>jane@example.comE<gt>"),
+            "Maintained by Jane Doe <jane@example.com>"
+        );
+    }
+
+    #[test]
+    fn test_perl_pod_visible_formatting_is_unwrapped() {
+        assert_eq!(
+            prepare_text_line("The C<$buffer> is modified by C<inflate>. On completion"),
+            "The $buffer is modified by inflate. On completion"
+        );
     }
 
     #[test]

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -30,7 +30,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = truncate_omap_dual_mode_clause(&a);
     a = strip_initials_before_angle_email(&a);
     a = normalize_obfuscated_angle_contact(&a);
-    a = strip_trailing_comma_year_after_angle_email(&a);
+    a = strip_trailing_year_after_angle_email(&a);
     a = strip_trailing_comma_year(&a);
     a = strip_trailing_comma_month_year(&a);
     a = strip_trailing_on_date(&a);
@@ -922,12 +922,15 @@ fn strip_trailing_comma_and(s: &str) -> String {
     s.to_string()
 }
 
-fn strip_trailing_comma_year_after_angle_email(s: &str) -> String {
-    static COMMA_YEAR_AFTER_ANGLE_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"^(?P<prefix>.+<[^>\s]*@[^>\s]*>)\s*,\s*(?P<year>19\d{2}|20\d{2})\s*$").unwrap()
+fn strip_trailing_year_after_angle_email(s: &str) -> String {
+    static YEAR_AFTER_ANGLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"^(?P<prefix>.+<[^>\s]*@[^>\s]*>)\s*,?\s*(?P<year>(?:19|20)\d{2}(?:-(?:(?:19|20)\d{2})?)?)\s*$",
+        )
+        .unwrap()
     });
     let trimmed = s.trim();
-    if let Some(cap) = COMMA_YEAR_AFTER_ANGLE_RE.captures(trimmed) {
+    if let Some(cap) = YEAR_AFTER_ANGLE_RE.captures(trimmed) {
         let prefix = cap.name("prefix").map(|m| m.as_str()).unwrap_or("").trim();
         if !prefix.is_empty() {
             return prefix.to_string();

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1937,6 +1937,18 @@ fn test_refine_author_strips_trailing_comma_year() {
 }
 
 #[test]
+fn test_refine_author_strips_year_range_after_angle_email() {
+    assert_eq!(
+        refine_author("Peter John Acklam <pjacklam@gmail.com> 2010-2021"),
+        Some("Peter John Acklam <pjacklam@gmail.com>".to_string())
+    );
+    assert_eq!(
+        refine_author("Peter John Acklam <pjacklam@gmail.com>, 2011-"),
+        Some("Peter John Acklam <pjacklam@gmail.com>".to_string())
+    );
+}
+
+#[test]
 fn test_refine_author_strips_better_known_as_clause() {
     let result =
         refine_author("Alexander Peslyak, better known as Solar Designer <solar at openwall.com>");

--- a/src/finder/emails.rs
+++ b/src/finder/emails.rs
@@ -9,9 +9,9 @@ use std::sync::LazyLock;
 
 use crate::models::LineNumber;
 
-use super::DetectionConfig;
 use super::host::is_good_email_domain;
 use super::junk_data::classify_email;
+use super::{DetectionConfig, decode_pod_angle_escapes};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct EmailDetection {
@@ -31,6 +31,8 @@ pub fn find_emails(text: &str, config: &DetectionConfig) -> Vec<EmailDetection> 
         let line_number = LineNumber::from_0_indexed(line_index);
         let normalized_line = line.replace("\\r\\n", "\\n").replace("\\r", "\\n");
         for segment in normalized_line.split("\\n") {
+            let segment = decode_pod_angle_escapes(segment);
+            let segment = segment.as_ref();
             for matched in EMAILS_REGEX.find_iter(segment) {
                 // Skip SSH remotes such as `git@github.com:org/repo.git` and
                 // `user@host:port` URL authorities. Only a `:` followed by a
@@ -163,6 +165,14 @@ mod tests {
         assert_eq!(
             emails("mail jane@realcorp.io today"),
             vec!["jane@realcorp.io"]
+        );
+    }
+
+    #[test]
+    fn test_find_emails_decodes_perl_pod_angle_escapes() {
+        assert_eq!(
+            emails("Peter John Acklam E<lt>pjacklam@gmail.comE<gt>"),
+            vec!["pjacklam@gmail.com"]
         );
     }
 }

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -6,8 +6,22 @@ mod host;
 mod junk_data;
 mod urls;
 
+use std::borrow::Cow;
+
 pub use emails::find_emails;
 pub use urls::find_urls;
+
+/// Decode the POD angle-bracket escapes that delimit contacts and links.
+///
+/// Detection is line-based, so replacing these formatting tokens before the
+/// email/URL regexes run preserves line attribution while preventing the final
+/// `E` in `E<gt>` from being swallowed as part of a TLD.
+fn decode_pod_angle_escapes(text: &str) -> Cow<'_, str> {
+    if !text.contains("E<lt>") && !text.contains("E<gt>") {
+        return Cow::Borrowed(text);
+    }
+    Cow::Owned(text.replace("E<lt>", "<").replace("E<gt>", ">"))
+}
 
 #[derive(Debug, Clone)]
 pub struct DetectionConfig {
@@ -109,6 +123,17 @@ mod tests {
 
         assert_eq!(urls.len(), 1, "urls: {urls:#?}");
         assert_eq!(urls[0].url, "http://ftp.gnu.org/gnu/tar/");
+    }
+
+    #[test]
+    fn test_find_urls_decodes_perl_pod_angle_escapes() {
+        let urls = find_urls(
+            "Project page L<E<lt>https://www.perl.comE<gt>>",
+            &DetectionConfig::default(),
+        );
+
+        assert_eq!(urls.len(), 1, "urls: {urls:#?}");
+        assert_eq!(urls[0].url, "https://www.perl.com/");
     }
 
     #[test]

--- a/src/finder/urls.rs
+++ b/src/finder/urls.rs
@@ -11,9 +11,9 @@ use url::Url;
 
 use crate::models::LineNumber;
 
-use super::DetectionConfig;
 use super::host::is_good_url_host_domain;
 use super::junk_data::classify_url;
+use super::{DetectionConfig, decode_pod_angle_escapes};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct UrlDetection {
@@ -226,6 +226,8 @@ pub fn find_urls(text: &str, config: &DetectionConfig) -> Vec<UrlDetection> {
         let normalized_line = line.replace("\\r\\n", "\\n").replace("\\r", "\\n");
 
         for segment in normalized_line.split("\\n") {
+            let segment = decode_pod_angle_escapes(segment);
+            let segment = segment.as_ref();
             for matched in URLS_REGEX.find_iter(segment) {
                 if matched.start() > 0 {
                     let prev_byte = segment.as_bytes()[matched.start() - 1];


### PR DESCRIPTION
## Summary

- Decode Perl POD `E<lt>`/`E<gt>` contact delimiters before copyright, author, email, and URL detection.
- Unwrap bounded visible-text POD formatting codes so inline code markup does not become an author token.
- Prevent the trailing `E` in `E<gt>` from being swallowed into email TLDs and URL hosts.
- Remove maintenance year ranges that follow an angle-bracketed author contact.

## Issues

- Covers: related detection defects found while validating #1391 on Perl 5.38.4

## Scope and exclusions

- Included: POD contact and visible-text normalization plus directly adjacent author year metadata.
- Explicit exclusions: general POD rendering and unrelated package/license comparison deltas.

## How to verify

- Scan a POD line containing `Peter John Acklam E<lt>pjacklam@gmail.comE<gt> 2010-2021` and observe one clean author plus `pjacklam@gmail.com`.
- Scan `C<LE<lt>http://www.perl.comE<gt>>` and observe `http://www.perl.com/`, not the nonexistent `.come` host.
- Scan prose containing `C<inflate>. On completion` and confirm it does not emit `C On` as an author.

## Intentional differences from Python

- This decodes source markup at shared detection boundaries so all contact outputs are internally consistent, rather than preserving malformed parity artifacts.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: focused tests cover normalization and the existing copyright golden corpus remains unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)