### PR TITLE
fix(copyright): require credible author evidence

### DIFF
--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -528,6 +528,41 @@ pub(in super::super) fn drop_authors_after_sentence_final_label(
     });
 }
 
+/// Drop a weak, single-word author when it was harvested from surrounding
+/// prose rather than from an explicit attribution. Lowercase mononyms remain
+/// valid when the source gives them strong local evidence such as `Author:` or
+/// `written by`.
+pub(in super::super) fn drop_weak_single_word_prose_authors(
+    raw_lines: &[&str],
+    authors: &mut Vec<AuthorDetection>,
+) {
+    authors.retain(|author| {
+        let candidate = author.author.trim();
+        if candidate.split_whitespace().count() != 1
+            || !candidate.chars().all(|ch| ch.is_alphabetic())
+            || !candidate.chars().all(char::is_lowercase)
+        {
+            return true;
+        }
+
+        let Some(raw_line) = raw_lines.get(author.start_line.get().saturating_sub(1)) else {
+            return true;
+        };
+        if raw_line.split_whitespace().count() <= 2 {
+            return true;
+        }
+
+        let lower = raw_line.to_lowercase();
+        let candidate_lower = candidate.to_lowercase();
+        let has_explicit_label = ["author:", "author :", "authors:", "authors :"]
+            .iter()
+            .any(|label| lower.contains(&format!("{label} {candidate_lower}")));
+        let has_by_attribution = lower.contains(&format!("by {candidate_lower}"));
+
+        has_explicit_label || has_by_attribution
+    });
+}
+
 fn window_contains_markup_element_author_value(window: &str, author: &str) -> bool {
     let normalized = normalize_whitespace(window);
     if !(normalized.contains('<') && normalized.contains('>')) {

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -2171,10 +2171,13 @@ pub(in super::super) fn extract_comment_author_label_authors(
         LazyLock::new(|| Regex::new(r"(?i)^\\author\s+(?P<who>.+?)\s*$").unwrap());
     static YEAR_ONLY_COPY_LINE_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?ix)^copyright\s*\(c\)\s*[0-9\s,\-–/]+$").unwrap());
+    static COMMENT_PREFIX_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^\s*(?:#+|;+|//+|/\*+|\*+|!+|--+|>+|\|+|\.\!+)\s*").unwrap());
     let normalize_comment_line = |line: &str| {
         line.trim()
             .trim_start_matches(|ch: char| {
-                ch.is_whitespace() || matches!(ch, '#' | ';' | '/' | '*' | '!' | '-' | '>')
+                ch.is_whitespace()
+                    || matches!(ch, '#' | ';' | '/' | '*' | '!' | '-' | '>' | '|' | '.')
             })
             .trim()
             .to_string()
@@ -2223,9 +2226,20 @@ pub(in super::super) fn extract_comment_author_label_authors(
                 continue;
             }
 
-            if who.contains('<') && who.contains('>') && who_lower.contains(" at ") {
+            let has_comment_prefix = COMMENT_PREFIX_RE.is_match(raw_line);
+            let has_obfuscated_angle_contact =
+                who.contains('<') && who.contains('>') && who_lower.contains(" at ");
+            if has_obfuscated_angle_contact {
                 authors.push(AuthorDetection {
                     author: who.to_string(),
+                    start_line,
+                    end_line: start_line,
+                });
+            } else if has_comment_prefix
+                && let Some(author) = refine_author_with_optional_handle_suffix(who)
+            {
+                authors.push(AuthorDetection {
+                    author,
                     start_line,
                     end_line: start_line,
                 });

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -90,6 +90,82 @@ fn test_extract_comment_author_label_authors_keeps_obfuscated_angle_contact() {
 }
 
 #[test]
+fn test_extract_comment_author_label_authors_requires_comment_evidence() {
+    let raw_lines = vec![
+        "! Author: Hunter Goatley",
+        "| Author: Bill Davidsen",
+        "author: package metadata value",
+    ];
+    let authors = extract_comment_author_label_authors(&raw_lines);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(values.contains(&"Hunter Goatley"), "authors: {values:?}");
+    assert!(values.contains(&"Bill Davidsen"), "authors: {values:?}");
+    assert!(
+        !values.contains(&"package metadata value"),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_detect_comment_author_label_when_grammar_has_no_author() {
+    let input = "!  Program: CVTHELP.TPU\n!  Author: Hunter Goatley\n!  Date: January 12, 1992\n";
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(
+        authors
+            .iter()
+            .any(|author| author.author == "Hunter Goatley"),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_comment_author_after_year_only_copyright_remains_holder_only() {
+    let raw_lines = vec![
+        "* Copyright (C) 2016-2018",
+        "* Author: Matt Ranostay <matt.ranostay@konsulko.com>",
+    ];
+    let authors = extract_comment_author_label_authors(&raw_lines);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_drop_weak_single_word_authors_uses_local_attribution_evidence() {
+    let raw_lines = vec![
+        "Contributors, please see AUTHORS",
+        "let the script author decide",
+        "Written by chunchu",
+    ];
+    let mut authors = vec![
+        AuthorDetection {
+            author: "please".to_string(),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::ONE,
+        },
+        AuthorDetection {
+            author: "decide".to_string(),
+            start_line: LineNumber::new(2).expect("valid line"),
+            end_line: LineNumber::new(2).expect("valid line"),
+        },
+        AuthorDetection {
+            author: "chunchu".to_string(),
+            start_line: LineNumber::new(3).expect("valid line"),
+            end_line: LineNumber::new(3).expect("valid line"),
+        },
+    ];
+
+    drop_weak_single_word_prose_authors(&raw_lines, &mut authors);
+
+    assert_eq!(authors.len(), 1, "authors: {authors:?}");
+    assert_eq!(authors[0].author, "chunchu");
+}
+
+#[test]
 fn test_extract_comment_author_label_authors_detects_doxygen_author_tags() {
     let raw_lines = vec![
         "*> \\author Univ. of California Berkeley",

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -309,11 +309,17 @@ fn run_author_extraction_and_repairs(
     authors.extend(new_a);
 
     let mut new_a = super::author_heuristics::extract_comment_author_label_authors(raw_lines);
+    new_a.retain(|candidate| {
+        !authors
+            .iter()
+            .any(|author| author.start_line == candidate.start_line)
+    });
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
     super::author_heuristics::drop_markup_element_value_authors(raw_lines, authors);
     super::author_heuristics::drop_markup_declaration_authors(raw_lines, authors);
     super::author_heuristics::drop_authors_after_sentence_final_label(raw_lines, authors);
+    super::author_heuristics::drop_weak_single_word_prose_authors(raw_lines, authors);
     seen.rebuild_authors_from(authors);
 }
 

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -195,11 +195,12 @@ fn looks_like_prose_fragment_author(s: &str) -> bool {
         return true;
     }
 
-    if contains_email_address(trimmed) {
+    let contains_email = contains_email_address(trimmed);
+    if contains_email && trimmed.split_whitespace().count() <= 6 {
         return false;
     }
 
-    if contains_html_like_fragment(trimmed) {
+    if contains_html_like_fragment(trimmed) && !contains_email {
         return true;
     }
 
@@ -1292,19 +1293,38 @@ fn truncate_trailing_clause_after_contact(s: &str) -> String {
         return s.to_string();
     }
 
-    let tail_lower = tail.to_ascii_lowercase();
+    let prose_tail = tail
+        .trim_start_matches(|ch: char| ch.is_whitespace() || matches!(ch, '\'' | '"' | '-' | '–'))
+        .trim();
+    let tail_lower = prose_tail.to_ascii_lowercase();
     let prose_like_tail = [
         "the ", "a ", "an ", "i ", "since ", "this ", "these ", "those ", "is ", "was ", "visit ",
         "for ", "from ",
     ]
     .iter()
     .any(|prefix_text| tail_lower.starts_with(prefix_text));
+    let is_author_qualifier = tail_lower == "et al"
+        || tail_lower == "et al."
+        || looks_like_conjoined_author_tail(prose_tail)
+        || ((tail_lower.starts_with("(http://") || tail_lower.starts_with("(https://"))
+            && tail_lower.ends_with(')'))
+        || (prose_tail.starts_with("(@") && prose_tail.ends_with(')'));
 
-    if prose_like_tail {
+    if !is_author_qualifier && (prose_like_tail || looks_like_prose_fragment_author(prose_tail)) {
         return prefix.to_string();
     }
 
     s.to_string()
+}
+
+fn looks_like_conjoined_author_tail(tail: &str) -> bool {
+    static CONJOINED_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"^(?:and|or)\s+(?:\p{Lu}[\p{L}'’.-]*|(?:de|da|del|la|van|von))(?:\s+(?:\p{Lu}[\p{L}'’.-]*|(?:de|da|del|la|van|von))){1,5}(?:\s*<[^>\s]+@[^>\s]+>)?$",
+        )
+        .expect("valid conjoined author regex")
+    });
+    CONJOINED_NAME_RE.is_match(tail.trim().trim_end_matches('.'))
 }
 
 /// Truncate a trailing website/homepage label followed by a URL.

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -249,6 +249,18 @@ fn test_refine_author_truncates_trailing_prose_after_contact() {
 }
 
 #[test]
+fn test_refine_author_keeps_conjoined_name_after_contact() {
+    assert_eq!(
+        refine_author("John Smith <js@example.com> and Jane Doe"),
+        Some("John Smith <js@example.com> and Jane Doe".to_string())
+    );
+    assert_eq!(
+        refine_author("John Smith <js@example.com> and this module is maintained"),
+        Some("John Smith <js@example.com>".to_string())
+    );
+}
+
+#[test]
 fn test_refine_author_truncates_prose_sentence_after_a_name() {
     assert_eq!(
         refine_author(
@@ -2418,6 +2430,42 @@ fn test_refine_author_empty() {
 fn test_refine_author_junk() {
     assert_eq!(refine_author("james hacker"), None);
     assert_eq!(refine_author("who hopes"), None);
+}
+
+#[test]
+fn test_refine_author_does_not_let_email_bypass_prose_evidence() {
+    assert_eq!(
+        refine_author(
+            "Development questions, bug reports, and patches should be sent to the Module-Build mailing list at <module-build@perl.org>"
+        ),
+        None
+    );
+    assert_eq!(
+        refine_author("Jane Smith <jane@example.com>"),
+        Some("Jane Smith <jane@example.com>".to_string())
+    );
+    assert_eq!(
+        refine_author("maintainer@example.com"),
+        Some("maintainer@example.com".to_string())
+    );
+    assert_eq!(
+        refine_author(
+            "Ken Williams <kwilliams@cpan.org> ' - 'Development questions, bug reports, and patches should be sent to the Module-Build mailing list at <module-build@perl.org>"
+        ),
+        Some("Ken Williams <kwilliams@cpan.org>".to_string())
+    );
+    assert_eq!(
+        refine_author("Nasca Iacob <sy@another-d-mention.ro> (https://github.com/cthackers)"),
+        Some("Nasca Iacob <sy@another-d-mention.ro> (https://github.com/cthackers)".to_string())
+    );
+    assert_eq!(
+        refine_author(
+            "Donald Becker (becker@scyld.com), Rowan Hughes (x-csrdh@jcu.edu.au), David Hinds (dahinds@users.sourceforge.net), and Erik Stahlman (erik@vt.edu). Donald wrote the code"
+        ),
+        Some(
+            "Donald Becker (becker@scyld.com), Rowan Hughes (x-csrdh@jcu.edu.au), David Hinds (dahinds@users.sourceforge.net), and Erik Stahlman (erik@vt.edu)".to_string()
+        )
+    );
 }
 
 #[test]

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/media/radio/radio-gemtek.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/media/radio/radio-gemtek.c.yml
@@ -13,6 +13,5 @@ holders:
 authors:
   - Alan Cox <alan@lxorguk.ukuu.org.uk>
   - Hans Verkuil <hans.verkuil@cisco.com>
-  - Hans Verkuil <hans.verkuil@cisco.com> Converted
   - Mauro Carvalho Chehab <mchehab@kernel.org>
   - Russell Kroll <rkroll@exploits.org>

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/media/radio/radio-rtrack2.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/media/radio/radio-rtrack2.c.yml
@@ -14,7 +14,6 @@ authors:
   - Converted to new API by Alan Cox <alan@lxorguk.ukuu.org.uk>
   - Converted to the radio-isa framework by Hans Verkuil <hans.verkuil@cisco.com>
   - Hans Verkuil <hans.verkuil@cisco.com>
-  - Hans Verkuil <hans.verkuil@cisco.com> Converted
   - Mauro Carvalho Chehab <mchehab@kernel.org>
   - Russell Kroll <rkroll@exploits.org>
   - Various bugfixes and enhancements by Russell Kroll <rkroll@exploits.org>

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/net/ethernet/smsc/smc91c92_cs.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/net/ethernet/smsc/smc91c92_cs.c.yml
@@ -8,4 +8,4 @@ holders:
   - David A. Hinds
 authors:
   - Donald Becker (becker@scyld.com), Rowan Hughes (x-csrdh@jcu.edu.au), David Hinds (dahinds@users.sourceforge.net)
-  - Donald Becker (becker@scyld.com), Rowan Hughes (x-csrdh@jcu.edu.au), David Hinds (dahinds@users.sourceforge.net), and Erik Stahlman (erik@vt.edu). Donald wrote the SMC 91c92 code
+  - Donald Becker (becker@scyld.com), Rowan Hughes (x-csrdh@jcu.edu.au), David Hinds (dahinds@users.sourceforge.net), and Erik Stahlman (erik@vt.edu)


### PR DESCRIPTION
## Summary

- Require local attribution evidence before keeping weak single-word authors harvested from prose.
- Keep short, name-shaped email contacts while treating long email-bearing sentences as prose and trimming them after an already complete contact.
- Recover singular `Author:` values from clear comment syntax when the grammar produced no author at that line.

## Issues

- Covers: related author precision and recall defects found while validating #1391 on Perl 5.38.4 and Info-ZIP 3.0

## Scope and exclusions

- Included: author evidence, contact-tail boundaries, and comment-label fallback extraction.
- Explicit exclusions: revision/date suffix cleanup and broader `changes by` attribution, which are isolated in later stack layers; unrelated package and license deltas.

## How to verify

- Scan Perl 5.38.4 with `--copyright` and confirm prose fragments such as `please`, `independently`, `decide`, and Module-Build mailing-list instructions are absent from `authors[]`.
- Scan Info-ZIP 3.0 and confirm `vms/cvthelp.tpu` reports `Hunter Goatley` while existing multi-line author rosters remain unchanged.

## Intentional differences from Python

- Provenant requires source-local attribution evidence for weak author tokens and preserves bounded contact syntax; ScanCode output is used as a regression signal, not as the acceptance criterion.

## Follow-up work

- Created or intentionally deferred: later stacked PRs handle `changes by` attribution and revision/contact/line-boundary cleanup.

## Expected-output fixture changes

- Files changed: `radio-gemtek.c.yml`, `radio-rtrack2.c.yml`, and `smc91c92_cs.c.yml` in the copyright golden corpus.
- Why the new expected output is correct: the first two remove an absorbed `Converted` prose tail, and the third stops the author before the following `Donald wrote` sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)