### PR TITLE
fix(copyright): recover changes-by credits

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -621,6 +621,78 @@ pub(in super::super) fn extract_name_contributed_authors(
         .collect()
 }
 
+/// Extract explicit `changes by NAME` credits, including the common wrapped
+/// form where `changes` closes one comment line and `by NAME` opens the next.
+pub(in super::super) fn extract_changes_by_authors(
+    prepared_cache: &PreparedLines<'_>,
+) -> Vec<AuthorDetection> {
+    static CHANGES_BY_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)\bchanges\s+by\s+(?P<who>.+)$").unwrap());
+    static BY_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^by\s+(?P<who>.+)$").unwrap());
+
+    let mut authors = Vec::new();
+    for line in prepared_cache.iter_non_empty() {
+        let Some(captures) = CHANGES_BY_RE.captures(line.prepared) else {
+            continue;
+        };
+        let who = captures
+            .name("who")
+            .map(|matched| matched.as_str())
+            .unwrap_or("")
+            .trim();
+        if who
+            .chars()
+            .filter(|ch| ch.is_alphabetic())
+            .all(|ch| ch.is_uppercase())
+        {
+            continue;
+        }
+        if let Some(author) = refine_author(who) {
+            authors.push(AuthorDetection {
+                author,
+                start_line: line.line_number,
+                end_line: line.line_number,
+            });
+        }
+    }
+
+    for (line, next_line) in prepared_cache.adjacent_pairs() {
+        if !line
+            .prepared
+            .trim_end()
+            .to_ascii_lowercase()
+            .ends_with("changes")
+        {
+            continue;
+        }
+        let Some(captures) = BY_RE.captures(next_line.prepared.trim()) else {
+            continue;
+        };
+        let who = captures
+            .name("who")
+            .map(|matched| matched.as_str())
+            .unwrap_or("")
+            .trim();
+        if who
+            .chars()
+            .filter(|ch| ch.is_alphabetic())
+            .all(|ch| ch.is_uppercase())
+        {
+            continue;
+        }
+        if let Some(author) = refine_author(who) {
+            authors.push(AuthorDetection {
+                author,
+                start_line: line.line_number,
+                end_line: next_line.line_number,
+            });
+        }
+    }
+
+    authors
+}
+
 fn looks_like_contributed_person_name_token(word: &str) -> bool {
     let trimmed_word = word.trim_matches(|ch: char| {
         !ch.is_alphabetic() && ch != '\'' && ch != '’' && ch != '.' && ch != '-'

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -1082,6 +1082,41 @@ fn test_name_contributed_line_is_detected_as_author() {
 }
 
 #[test]
+fn test_changes_by_attribution_is_detected_inline_and_across_lines() {
+    let input = concat!(
+        "This platform file is based on unix.c; changes by Ruslan Nickolaev (nruslan@hotbox.ru)\n",
+        "This other port is based on unix.c; changes\n",
+        " by Chris Herborth (chrish@pobox.com).\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(
+        values.contains(&"Ruslan Nickolaev (nruslan@hotbox.ru)"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Chris Herborth (chrish@pobox.com)"),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_changes_by_prose_does_not_create_an_author() {
+    let input = concat!(
+        "The value changes by adding one to the previous result.\n",
+        "The rate changes by 2 percent.\n",
+        "MAJOR CHANGES BY BETA VERSION\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_name_contributed_line_ignores_portions_holder_phrase() {
     let input = "Copyright (c) 2006, Industrial Light & Magic, a division of Lucasfilm\nEntertainment Company Ltd. Portions contributed and copyright held by\nothers as indicated. All rights reserved.";
     let (_c, _h, authors) = super::super::detect_copyrights_from_text(input);

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -308,6 +308,10 @@ fn run_author_extraction_and_repairs(
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
 
+    let mut new_a = super::author_heuristics::extract_changes_by_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
     let mut new_a = super::author_heuristics::extract_comment_author_label_authors(raw_lines);
     new_a.retain(|candidate| {
         !authors


### PR DESCRIPTION
## Summary

- Recover authors from explicit `changes by NAME` credits on one line.
- Support wrapped credits where `changes by` and the credited name appear on adjacent lines.
- Reject prose and all-uppercase version headings that happen to contain the same words.

## Issues

- Covers: missing contribution credits found while validating #1391 on Info-ZIP 3.0

## Scope and exclusions

- Included: bounded extraction for the `changes by` attribution form.
- Explicit exclusions: generic author revision/contact boundary cleanup and passive product-creation phrases; unrelated scan deltas.

## How to verify

- Scan Info-ZIP 3.0 and confirm `atheos/atheos.c` reports Ruslan Nickolaev and `beos/beos.c` reports Chris Herborth, with no other author changes from the preceding stack head.
- Confirm prose such as `changes by the user` and headings such as `MAJOR CHANGES BY BETA VERSION` do not emit authors.

## Intentional differences from Python

- The extractor accepts only party-shaped attribution tails and deliberately rejects heading/prose contexts, rather than treating every lexical `changes by` occurrence as an author.

## Follow-up work

- Created or intentionally deferred: the next stacked PR handles revision metadata, contact instructions, and source-line author boundaries.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: focused detector tests cover inline, wrapped, prose, and heading cases; both copyright golden suites remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)