### PR TITLE
fix(copyright): respect author statement boundaries

### DIFF
--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -563,6 +563,251 @@ pub(in super::super) fn drop_weak_single_word_prose_authors(
     });
 }
 
+/// Prefer a complete `by NAME` credit that ends on its source line over a
+/// parser span that absorbed the following comment sentence.
+pub(in super::super) fn repair_complete_by_line_author_boundaries(
+    raw_lines: &[&str],
+    authors: &mut [AuthorDetection],
+) {
+    static TRAILING_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)\bby\s+(?P<who>[^,;:]+?)\s*$").expect("valid trailing by-author regex")
+    });
+
+    for author in authors {
+        if author.end_line <= author.start_line {
+            continue;
+        }
+        let Some(raw_line) = raw_lines.get(author.start_line.get().saturating_sub(1)) else {
+            continue;
+        };
+        let following = raw_lines
+            .get(author.start_line.get())
+            .map(|line| prepare_text_line(line))
+            .unwrap_or_default();
+        let following_lower = following.to_ascii_lowercase();
+        let following_has_obfuscated_contact =
+            following_lower.contains(" at ") && following_lower.contains(" dot ");
+        if following_lower.starts_with("(http://")
+            || following_lower.starts_with("(https://")
+            || following.contains('@')
+            || following_has_obfuscated_contact
+            || following_lower.starts_with("by ")
+            || following_lower.contains(" by ")
+        {
+            continue;
+        }
+        let prepared = prepare_text_line(raw_line);
+        let Some(captures) = TRAILING_BY_RE.captures(&prepared) else {
+            continue;
+        };
+        let who = captures
+            .name("who")
+            .map(|matched| matched.as_str())
+            .unwrap_or("")
+            .trim();
+        let who_lower = who.to_ascii_lowercase();
+        let trailing_conjunction_words = who_lower
+            .rsplit_once(" and ")
+            .or_else(|| who_lower.rsplit_once(" or "))
+            .map(|(_, tail)| tail.split_whitespace().count());
+        if who_lower.ends_with(" and")
+            || who_lower.ends_with(" or")
+            || trailing_conjunction_words == Some(1)
+        {
+            continue;
+        }
+        let uppercase_words = who
+            .split_whitespace()
+            .filter(|word| {
+                word.chars()
+                    .find(|ch| ch.is_alphabetic())
+                    .is_some_and(|ch| ch.is_uppercase())
+            })
+            .count();
+        if uppercase_words < 2 {
+            continue;
+        }
+        let Some(refined) = refine_author(who) else {
+            continue;
+        };
+        if author.author != refined && author.author.starts_with(&refined) {
+            author.author = refined;
+            author.end_line = author.start_line;
+        }
+    }
+}
+
+/// Repair an author name followed by the first half of a hyphenated prose word
+/// split across two source lines, such as `Name, poss-` / `ibly modified`.
+pub(in super::super) fn repair_hyphenated_prose_tail_authors(
+    raw_lines: &[&str],
+    authors: &mut [AuthorDetection],
+) {
+    for author in authors {
+        if author.end_line <= author.start_line {
+            continue;
+        }
+        let Some((name, fragment)) = author.author.rsplit_once(',') else {
+            continue;
+        };
+        let fragment = fragment.trim();
+        if fragment.len() < 2 || !fragment.chars().all(|ch| ch.is_lowercase()) {
+            continue;
+        }
+        let Some(first_raw) = raw_lines.get(author.start_line.get().saturating_sub(1)) else {
+            continue;
+        };
+        let Some(next_raw) = raw_lines.get(author.start_line.get()) else {
+            continue;
+        };
+        let first = prepare_text_line(first_raw);
+        let next = prepare_text_line(next_raw);
+        if !first.contains(&format!("{fragment}-"))
+            || !next
+                .chars()
+                .find(|ch| ch.is_alphabetic())
+                .is_some_and(|ch| ch.is_lowercase())
+        {
+            continue;
+        }
+        let Some(refined) = refine_author(name.trim()) else {
+            continue;
+        };
+        author.author = refined;
+        author.end_line = author.start_line;
+    }
+}
+
+/// Drop a candidate introduced by `Authors` when that word is embedded in a
+/// larger title-cased product or service name instead of acting as a label.
+pub(in super::super) fn drop_embedded_authors_title_phrases(
+    raw_lines: &[&str],
+    authors: &mut Vec<AuthorDetection>,
+) {
+    authors.retain(|author| {
+        let candidate_lower = author.author.to_lowercase();
+        !(author.start_line.get()..=author.end_line.get()).any(|line_number| {
+            let Some(raw_line) = raw_lines.get(line_number.saturating_sub(1)) else {
+                return false;
+            };
+            let prepared = prepare_text_line(raw_line);
+            let words: Vec<&str> = prepared.split_whitespace().collect();
+            words.windows(2).enumerate().any(|(index, pair)| {
+                let label = pair[0];
+                if label.contains(':')
+                    || !label
+                        .trim_matches(|ch: char| !ch.is_alphabetic())
+                        .eq_ignore_ascii_case("authors")
+                    || index == 0
+                {
+                    return false;
+                }
+                let previous = words[index - 1];
+                let previous_is_title_cased = previous
+                    .chars()
+                    .find(|ch| ch.is_alphabetic())
+                    .is_some_and(|ch| ch.is_uppercase());
+                let tail_lower = words[index + 1..].join(" ").to_lowercase();
+                previous_is_title_cased && tail_lower.contains(&candidate_lower)
+            })
+        })
+    });
+}
+
+/// Drop a multi-line candidate when a complete candidate already ends on the
+/// first line and the next line opens a distinct `... by ...` attribution.
+pub(in super::super) fn drop_shadowed_multiline_author_overruns(
+    raw_lines: &[&str],
+    authors: &mut Vec<AuthorDetection>,
+) {
+    if authors.len() < 2 {
+        return;
+    }
+    let originals = authors.clone();
+
+    authors.retain(|author| {
+        !originals.iter().any(|complete| {
+            if complete.start_line != author.start_line
+                || complete.end_line >= author.end_line
+                || complete.author.len() >= author.author.len()
+                || !author.author.starts_with(&complete.author)
+            {
+                return false;
+            }
+            let boundary = author
+                .author
+                .as_bytes()
+                .get(complete.author.len())
+                .is_some_and(|ch| ch.is_ascii_whitespace() || matches!(ch, b',' | b'.'));
+            if !boundary {
+                return false;
+            }
+            let tail = author.author[complete.author.len()..]
+                .trim_start_matches(|ch: char| ch.is_whitespace() || matches!(ch, ',' | '.'));
+            let tail_lower = tail.to_ascii_lowercase();
+            if tail_lower.starts_with("and ") || tail_lower.starts_with("or ") {
+                return false;
+            }
+
+            raw_lines
+                .get(complete.end_line.get())
+                .map(|line| prepare_text_line(line).to_ascii_lowercase())
+                .is_some_and(|line| line.contains(" by "))
+        })
+    });
+}
+
+/// Stop a contact-backed attribution before the next source line opens a
+/// distinct attribution. This handles wrapped parsers that absorb the first
+/// word of the next sentence into the preceding author.
+pub(in super::super) fn repair_contact_author_before_new_attribution(
+    raw_lines: &[&str],
+    authors: &mut [AuthorDetection],
+) {
+    static TRAILING_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)\bby\s+(?P<who>.+?)\s*$").expect("valid contact by-author regex")
+    });
+
+    for author in authors {
+        if author.end_line <= author.start_line {
+            continue;
+        }
+        let Some(first_raw) = raw_lines.get(author.start_line.get().saturating_sub(1)) else {
+            continue;
+        };
+        let Some(next_raw) = raw_lines.get(author.start_line.get()) else {
+            continue;
+        };
+        let first = prepare_text_line(first_raw);
+        let first_lower = first.to_ascii_lowercase();
+        let next = prepare_text_line(next_raw).to_ascii_lowercase();
+        let has_contact =
+            first.contains('@') || (first_lower.contains(" at ") && first_lower.contains(" dot "));
+        if !has_contact
+            || !next.contains(" by ")
+            || next.starts_with("and ")
+            || next.starts_with("or ")
+        {
+            continue;
+        }
+        let Some(captures) = TRAILING_BY_RE.captures(&first) else {
+            continue;
+        };
+        let who = captures
+            .name("who")
+            .map(|matched| matched.as_str())
+            .unwrap_or("")
+            .trim();
+        let Some(refined) = refine_author(who) else {
+            continue;
+        };
+        if author.author.starts_with(&refined) {
+            author.author = refined;
+            author.end_line = author.start_line;
+        }
+    }
+}
+
 fn window_contains_markup_element_author_value(window: &str, author: &str) -> bool {
     let normalized = normalize_whitespace(window);
     if !(normalized.contains('<') && normalized.contains('>')) {

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -166,6 +166,149 @@ fn test_drop_weak_single_word_authors_uses_local_attribution_evidence() {
 }
 
 #[test]
+fn test_author_cleanup_respects_complete_line_and_hyphenated_prose_boundaries() {
+    let raw_lines = vec![
+        "| Written by Darren Salt",
+        "| Assumes that unzipsfx is on Run$Path",
+        "originally written by Martin Minow, poss-",
+        "ibly modified by Jerry Leichter",
+        "Created by Jason Hunter and Brett McLaughlin",
+        "Revised by Ryusuke Konishi",
+        "Pulled in another direction by Nick Ing-Simmons",
+        "<nick AT ing-simmons DOT net>",
+    ];
+    let mut authors = vec![
+        AuthorDetection {
+            author: "Darren Salt Assumes".to_string(),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::new(2).expect("valid line"),
+        },
+        AuthorDetection {
+            author: "Martin Minow, poss".to_string(),
+            start_line: LineNumber::new(3).expect("valid line"),
+            end_line: LineNumber::new(4).expect("valid line"),
+        },
+        AuthorDetection {
+            author: "Jason Hunter and Brett McLaughlin Revised by Ryusuke Konishi".to_string(),
+            start_line: LineNumber::new(5).expect("valid line"),
+            end_line: LineNumber::new(6).expect("valid line"),
+        },
+        AuthorDetection {
+            author: "Nick Ing-Simmons nick AT ing-simmons DOT net".to_string(),
+            start_line: LineNumber::new(7).expect("valid line"),
+            end_line: LineNumber::new(8).expect("valid line"),
+        },
+    ];
+
+    repair_complete_by_line_author_boundaries(&raw_lines, &mut authors);
+    repair_hyphenated_prose_tail_authors(&raw_lines, &mut authors);
+
+    assert_eq!(authors[0].author, "Darren Salt");
+    assert_eq!(authors[0].end_line, LineNumber::ONE);
+    assert_eq!(authors[1].author, "Martin Minow");
+    assert_eq!(authors[1].end_line, LineNumber::new(3).expect("valid line"));
+    assert_eq!(
+        authors[2].author,
+        "Jason Hunter and Brett McLaughlin Revised by Ryusuke Konishi"
+    );
+    assert_eq!(authors[2].end_line, LineNumber::new(6).expect("valid line"));
+    assert_eq!(
+        authors[3].author,
+        "Nick Ing-Simmons nick AT ing-simmons DOT net"
+    );
+    assert_eq!(authors[3].end_line, LineNumber::new(8).expect("valid line"));
+}
+
+#[test]
+fn test_embedded_authors_product_name_is_not_an_author_label() {
+    let raw_lines = vec!["Perl Authors Upload Server. Contains module links."];
+    let mut authors = vec![AuthorDetection {
+        author: "Upload Server".to_string(),
+        start_line: LineNumber::ONE,
+        end_line: LineNumber::ONE,
+    }];
+
+    drop_embedded_authors_title_phrases(&raw_lines, &mut authors);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_shadowed_multiline_author_overrun_stops_at_new_attribution() {
+    let raw_lines = vec![
+        "Contributed by Artur Bergman <sky AT example DOT net>",
+        "Pulled in another direction by Nick Ing-Simmons",
+        "Original author: Andy Dougherty andy@example.com.",
+        "Additions by Chip Salzenberg",
+    ];
+    let mut authors = vec![
+        AuthorDetection {
+            author: "Artur Bergman sky AT example DOT net Pulled".to_string(),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::new(2).expect("valid line"),
+        },
+        AuthorDetection {
+            author: "Artur Bergman sky AT example DOT net".to_string(),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::ONE,
+        },
+        AuthorDetection {
+            author: "Andy Dougherty andy@example.com Additions".to_string(),
+            start_line: LineNumber::new(3).expect("valid line"),
+            end_line: LineNumber::new(4).expect("valid line"),
+        },
+        AuthorDetection {
+            author: "Andy Dougherty andy@example.com".to_string(),
+            start_line: LineNumber::new(3).expect("valid line"),
+            end_line: LineNumber::new(3).expect("valid line"),
+        },
+    ];
+
+    drop_shadowed_multiline_author_overruns(&raw_lines, &mut authors);
+
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+    assert_eq!(
+        values,
+        vec![
+            "Artur Bergman sky AT example DOT net",
+            "Andy Dougherty andy@example.com"
+        ]
+    );
+
+    let input = "Contributed by Artur Bergman <sky AT example DOT net>\n\
+                 Pulled in another direction by Nick Ing-Simmons\n\
+                 <nick AT example DOT net>";
+    let (_copyrights, _holders, detected) = super::super::detect_copyrights_from_text(input);
+    assert!(
+        detected
+            .iter()
+            .all(|author| !author.author.ends_with(" Pulled")),
+        "authors: {detected:?}"
+    );
+}
+
+#[test]
+fn test_conjoined_contact_attribution_continuation_is_preserved() {
+    let raw_lines = vec![
+        "Written by Sherm Pendley <sherm@example.com>",
+        "and subsequently updated by Dominic Dunlop <dom@example.com>",
+    ];
+    let mut authors = vec![AuthorDetection {
+        author: "Sherm Pendley <sherm@example.com>, and subsequently updated by Dominic Dunlop <dom@example.com>".to_string(),
+        start_line: LineNumber::ONE,
+        end_line: LineNumber::new(2).expect("valid line"),
+    }];
+
+    repair_contact_author_before_new_attribution(&raw_lines, &mut authors);
+
+    assert!(authors[0].author.contains("Dominic Dunlop"));
+    assert_eq!(authors[0].end_line, LineNumber::new(2).expect("valid line"));
+}
+
+#[test]
 fn test_extract_comment_author_label_authors_detects_doxygen_author_tags() {
     let raw_lines = vec![
         "*> \\author Univ. of California Berkeley",
@@ -919,6 +1062,16 @@ fn test_detect_author() {
     assert_eq!(a[0].author, "John Doe");
     assert_eq!(a[0].start_line, LineNumber::ONE);
     assert_eq!(a[0].end_line, LineNumber::ONE);
+}
+
+#[test]
+fn test_written_by_author_stops_before_following_notice_sentence() {
+    let input = "Copyright (c) 1986 by University of Toronto.\n\
+                 Written by Henry Spencer. Not derived from licensed software.";
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert_eq!(authors.len(), 1, "authors: {authors:?}");
+    assert_eq!(authors[0].author, "Henry Spencer");
 }
 
 #[test]

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -397,6 +397,8 @@ pub fn detect_copyrights_from_text_with_deadline(
     if deadline_exceeded(deadline) {
         refine_final_copyrights(&mut copyrights);
         postprocess_transforms::refine_final_authors(&mut authors);
+        author_heuristics::repair_contact_author_before_new_attribution(&raw_lines, &mut authors);
+        author_heuristics::drop_shadowed_multiline_author_overruns(&raw_lines, &mut authors);
         dedupe_exact_span_copyrights(&mut copyrights);
         dedupe_exact_span_holders(&mut holders);
         dedupe_exact_span_authors(&mut authors);
@@ -429,6 +431,8 @@ pub fn detect_copyrights_from_text_with_deadline(
 
     refine_final_copyrights(&mut copyrights);
     postprocess_transforms::refine_final_authors(&mut authors);
+    author_heuristics::repair_contact_author_before_new_attribution(&raw_lines, &mut authors);
+    author_heuristics::drop_shadowed_multiline_author_overruns(&raw_lines, &mut authors);
     postprocess_transforms::drop_trademark_boilerplate_multiline_extensions(
         &raw_lines,
         &mut copyrights,

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -324,6 +324,9 @@ fn run_author_extraction_and_repairs(
     super::author_heuristics::drop_markup_declaration_authors(raw_lines, authors);
     super::author_heuristics::drop_authors_after_sentence_final_label(raw_lines, authors);
     super::author_heuristics::drop_weak_single_word_prose_authors(raw_lines, authors);
+    super::author_heuristics::repair_complete_by_line_author_boundaries(raw_lines, authors);
+    super::author_heuristics::repair_hyphenated_prose_tail_authors(raw_lines, authors);
+    super::author_heuristics::drop_embedded_authors_title_phrases(raw_lines, authors);
     seen.rebuild_authors_from(authors);
 }
 

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -16,6 +16,9 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = strip_trailing_parenthesized_email_contact(&a);
     a = strip_trailing_at_handle(&a);
     a = truncate_trailing_collective_contributors_prose(&a);
+    a = truncate_trailing_revision_metadata(&a);
+    a = truncate_trailing_contact_metadata(&a);
+    a = truncate_trailing_email_prose(&a);
     a = truncate_prose_sentence_after_name(&a);
     a = strip_leading_maintainers_label(&a);
     a = strip_trailing_javadoc_tags(&a);
@@ -34,6 +37,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = strip_trailing_comma_year(&a);
     a = strip_trailing_comma_month_year(&a);
     a = strip_trailing_on_date(&a);
+    a = truncate_trailing_revision_metadata(&a);
     a = strip_trailing_version(&a);
     a = strip_trailing_comma_email_matching_name(&a);
     a = truncate_trailing_from_clause_after_angle_contact(&a);
@@ -54,6 +58,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = strip_trailing_gnu_project_file_suffix(&a);
     a = normalize_comma_spacing(&a);
     a = normalize_angle_bracket_comma_spacing(&a);
+    a = strip_dangling_quote_before_contact(&a);
     a = strip_trailing_comma_and(&a);
     a = refine_names(&a, &AUTHORS_PREFIXES);
     a = a.trim().to_string();
@@ -195,6 +200,10 @@ fn looks_like_prose_fragment_author(s: &str) -> bool {
         return true;
     }
 
+    if looks_like_contact_instruction_author(trimmed) {
+        return true;
+    }
+
     let contains_email = contains_email_address(trimmed);
     if contains_email && trimmed.split_whitespace().count() <= 6 {
         return false;
@@ -309,6 +318,145 @@ fn looks_like_prose_fragment_author(s: &str) -> bool {
     }
 
     starts_lowercase || capitalized_word_count < 2
+}
+
+fn looks_like_contact_instruction_author(s: &str) -> bool {
+    let lower = s.trim().to_ascii_lowercase();
+    (lower.starts_with("at ") || lower.starts_with("via ")) && contains_email_address(s)
+}
+
+/// Stop an author at revision metadata. A delimited numeric date, a written
+/// date, or a year before a new attribution describes file history, not a name.
+fn truncate_trailing_revision_metadata(s: &str) -> String {
+    static REVISION_METADATA_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            ^(?P<name>.+?)
+            (?:
+                ,\s*(?:original(?:ly)?\s+)?
+                (?:
+                    \d{1,2}/(?:\d{1,2}/)?\d{2,4}
+                    |
+                    \d{1,2}\s+\p{L}{3,9}\s+\d{2,4}
+                )
+                |
+                \s+
+                (?:
+                    jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|
+                    jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?
+                )
+                \s+\d{1,2}(?:,\s+\d{4})?
+                |
+                \s+\d{4}\.\s+(?:maintained|modified|revised|updated)\s+by\b
+            )
+            \b.*$
+            ",
+        )
+        .expect("valid author revision metadata regex")
+    });
+
+    let trimmed = s.trim();
+    let Some(captures) = REVISION_METADATA_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let name = captures
+        .name("name")
+        .map(|matched| matched.as_str())
+        .unwrap_or("")
+        .trim();
+    if name.split_whitespace().count() < 2 {
+        return s.to_string();
+    }
+
+    name.to_string()
+}
+
+/// Stop after a complete email contact when the remaining text is a prose
+/// clause. Conjoined contacts remain intact as an author list.
+fn truncate_trailing_email_prose(s: &str) -> String {
+    static EMAIL_TAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            ^(?P<head>.*\b[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+\b\s*>?)
+            (?P<separator>\s*,\s+|\s*\.\s+|\s+)
+            (?P<tail>.+)$
+            ",
+        )
+        .expect("valid author email prose-tail regex")
+    });
+
+    let trimmed = s.trim();
+    let Some(captures) = EMAIL_TAIL_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let head = captures
+        .name("head")
+        .map(|matched| matched.as_str())
+        .unwrap_or("")
+        .trim();
+    let separator = captures
+        .name("separator")
+        .map(|matched| matched.as_str().trim())
+        .unwrap_or("");
+    let tail = captures
+        .name("tail")
+        .map(|matched| matched.as_str())
+        .unwrap_or("")
+        .trim();
+    let tail_lower = tail.to_ascii_lowercase();
+
+    if tail_lower.starts_with("and ")
+        || tail_lower.starts_with("or ")
+        || tail_lower == "et al"
+        || tail_lower.starts_with("et al.")
+    {
+        return s.to_string();
+    }
+    let tail_starts_lowercase = tail.chars().next().is_some_and(|ch| ch.is_lowercase());
+    let tail_word_count = tail.split_whitespace().count();
+    let tail_is_following_attribution = separator == "." && tail_lower.contains(" by ");
+    if tail_is_following_attribution
+        || (tail_starts_lowercase && tail_word_count >= 2 && looks_like_prose_fragment_author(tail))
+    {
+        return head.to_string();
+    }
+
+    s.to_string()
+}
+
+/// Stop a collected author at a following contact-field label. Email and URL
+/// detections retain the contact separately.
+fn truncate_trailing_contact_metadata(s: &str) -> String {
+    static CONTACT_METADATA_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^(?P<name>.+?)\.\s+(?:e-?mail|contact)\s*:?\s+.+$")
+            .expect("valid author contact metadata regex")
+    });
+
+    let trimmed = s.trim();
+    let Some(captures) = CONTACT_METADATA_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let name = captures
+        .name("name")
+        .map(|matched| matched.as_str())
+        .unwrap_or("")
+        .trim();
+    if name.split_whitespace().count() < 2 || looks_like_prose_fragment_author(name) {
+        return s.to_string();
+    }
+
+    name.to_string()
+}
+
+fn strip_dangling_quote_before_contact(s: &str) -> String {
+    static DANGLING_QUOTE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?P<name>\p{L})['`’]\s+(?P<contact><[^>]*@[^>]*>)")
+            .expect("valid dangling author quote regex")
+    });
+
+    DANGLING_QUOTE_RE
+        .replace_all(s, "${name} ${contact}")
+        .into_owned()
 }
 
 fn contains_windows_versioninfo_fragment(s: &str) -> bool {

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -2469,6 +2469,64 @@ fn test_refine_author_does_not_let_email_bypass_prose_evidence() {
 }
 
 #[test]
+fn test_refine_author_respects_revision_and_contact_metadata_boundaries() {
+    assert_eq!(
+        refine_author(
+            "Bill Davidsen, original 10/13/91, revised 23 Oct 1991. This program is public domain"
+        ),
+        Some("Bill Davidsen".to_string())
+    );
+    assert_eq!(
+        refine_author(
+            "George Petrov, 11 Apr 1995 (VMCOMPIL EXEC) Modified for IBM C V3R1 by Ian E. Gorman"
+        ),
+        Some("George Petrov".to_string())
+    );
+    assert_eq!(
+        refine_author("John Doe, 7/2000"),
+        Some("John Doe".to_string())
+    );
+    assert_eq!(
+        refine_author("Greg Hartwig. e-mail ghartwig@example.com"),
+        Some("Greg Hartwig".to_string())
+    );
+    assert_eq!(
+        refine_author("Andy Dougherty July 14, 1998"),
+        Some("Andy Dougherty".to_string())
+    );
+    assert_eq!(
+        refine_author("Yves Orton (demerphq) 2007. Maintained by Perl5 Porters"),
+        Some("Yves Orton (demerphq)".to_string())
+    );
+    assert_eq!(
+        refine_author("Andy Dougherty doughera@example.com, borrowing very"),
+        Some("Andy Dougherty doughera@example.com".to_string())
+    );
+    assert_eq!(
+        refine_author("Michael G Schwern schwern@example.com within the"),
+        Some("Michael G Schwern schwern@example.com".to_string())
+    );
+    assert_eq!(
+        refine_author("Russ Allbery <rra@example.com> . Subsequently updated by Russ Allbery"),
+        Some("Russ Allbery <rra@example.com>".to_string())
+    );
+    assert_eq!(
+        refine_author("Jane Doe <jane@example.com> and John Roe <john@example.com>"),
+        Some("Jane Doe <jane@example.com> and John Roe <john@example.com>".to_string())
+    );
+}
+
+#[test]
+fn test_refine_author_normalizes_contact_evidence_without_contact_instructions() {
+    assert_eq!(
+        refine_author("Francesco Potorti` <pot@example.com>"),
+        Some("Francesco Potorti <pot@example.com>".to_string())
+    );
+    assert_eq!(refine_author("at bugs@example.com or"), None);
+    assert_eq!(refine_author("via maintainers@example.com"), None);
+}
+
+#[test]
 fn test_refine_author_strips_author_prefix() {
     let result = refine_author("author John Doe");
     assert_eq!(result, Some("John Doe".to_string()));

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/edac/i82975x_edac.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/edac/i82975x_edac.c.yml
@@ -9,4 +9,4 @@ holders:
   - aCarLab (India) Pvt. Ltd.
   - jetzbroadband
 authors:
-  - Arvind R. Copied from
+  - Arvind R.


### PR DESCRIPTION
## Summary

- Stop author values at source-backed revision dates, contact-field labels, complete `by NAME` lines, and split hyphenated prose words.
- Normalize dangling quotes before email contacts and reject email contact instructions as authors.
- Drop `Upload Server` candidates when `Authors` is embedded in a title-cased product/service name, while preserving real `Authors:` labels and multi-author credits.

## Issues

- Covers: author-boundary defects found while validating #1391 on Info-ZIP 3.0 and Perl 5.38.4

## Scope and exclusions

- Included: generic source-statement and metadata boundaries for already detected author candidates.
- Explicit exclusions: passive `created by` product/version false positives and extraction of separate authors from consecutive attribution lines; unrelated scan deltas.

## How to verify

- Scan Info-ZIP 3.0 and confirm clean values for Bill Davidsen, Martin Minow, Steve Salisbury, Greg Hartwig, George Petrov, Darren Salt, and Francesco Potorti; confirm `at Zip-Bugs...` contacts are absent.
- Scan Perl 5.38.4 and confirm five `Upload Server` variants plus the absorbed `Recreate the` sentence are absent, while the wrapped Nick Ing-Simmons obfuscated contact remains intact.

## Intentional differences from Python

- The cleanup follows source statement structure and typed metadata boundaries. It keeps useful contact evidence and does not copy ScanCode output where that output also includes a product/service as an author.

## Follow-up work

- Created or intentionally deferred: a later stacked PR will address passive product creation separately from human authorship and then re-audit the real-world corpus.

## Expected-output fixture changes

- Files changed: `i82975x_edac.c.yml` in the copyright golden corpus.
- Why the new expected output is correct: `Arvind R.` is the complete credited name; `Copied from` begins the following prose and is not part of the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)