### PR TITLE
fix(copyright): distinguish product creation from authorship

### DIFF
--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -808,6 +808,75 @@ pub(in super::super) fn repair_contact_author_before_new_attribution(
     }
 }
 
+/// Drop product provenance mistaken for human authorship in passive creation
+/// sentences, such as plural artifacts created by a versioned application.
+pub(in super::super) fn drop_passive_product_creation_authors(
+    raw_lines: &[&str],
+    authors: &mut Vec<AuthorDetection>,
+) {
+    authors.retain(|author| {
+        if author.author.contains('@') {
+            return true;
+        }
+        let author_lower = author.author.to_ascii_lowercase();
+        if author_lower.contains(" at ") && author_lower.contains(" dot ") {
+            return true;
+        }
+
+        let window = (author.start_line.get()..=author.end_line.get())
+            .filter_map(|line_number| raw_lines.get(line_number.saturating_sub(1)))
+            .map(|line| prepare_text_line(line))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let window_lower = window.to_ascii_lowercase();
+        let Some(created_index) = window_lower.find("created by") else {
+            return true;
+        };
+        let subject = window_lower[..created_index]
+            .split_whitespace()
+            .rev()
+            .map(|word| word.trim_matches(|ch: char| !ch.is_alphanumeric()))
+            .find(|word| {
+                !word.is_empty()
+                    && !matches!(
+                        *word,
+                        "be" | "been" | "being" | "is" | "are" | "was" | "were"
+                    )
+            })
+            .unwrap_or("");
+        let plural_artifact = matches!(subject, "those" | "these" | "them")
+            || (subject.len() > 2 && subject.ends_with('s') && subject != "this");
+        if !plural_artifact {
+            return true;
+        }
+
+        let tokens: Vec<&str> = author
+            .author
+            .split_whitespace()
+            .map(|word| {
+                word.trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '\'' && ch != '’')
+            })
+            .filter(|word| !word.is_empty())
+            .collect();
+        let has_version_token = tokens.iter().any(|word| {
+            let lower = word.to_ascii_lowercase();
+            (word.contains('.') && word.chars().any(|ch| ch.is_ascii_digit()))
+                || lower
+                    .strip_prefix('v')
+                    .is_some_and(|rest| rest.chars().next().is_some_and(|ch| ch.is_ascii_digit()))
+        });
+        let has_possessive = tokens
+            .iter()
+            .any(|word| word.ends_with("'s") || word.ends_with("’s"));
+        let has_acronym = tokens.iter().any(|word| {
+            let letters: Vec<char> = word.chars().filter(|ch| ch.is_alphabetic()).collect();
+            letters.len() >= 3 && letters.iter().all(|ch| ch.is_uppercase())
+        });
+
+        !(has_version_token || (has_possessive && has_acronym))
+    });
+}
+
 fn window_contains_markup_element_author_value(window: &str, author: &str) -> bool {
     let normalized = normalize_whitespace(window);
     if !(normalized.contains('<') && normalized.contains('>')) {

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -309,6 +309,49 @@ fn test_conjoined_contact_attribution_continuation_is_preserved() {
 }
 
 #[test]
+fn test_passive_product_creation_is_not_human_authorship() {
+    let input = "Archive entry names behave like those created by ZipTool's MSDOS port.\n\
+                 Therefore archives created by MacTool 1.0 (March 1999) need conversion.";
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_passive_creation_keeps_person_and_contact_backed_authors() {
+    let raw_lines = vec![
+        "Files were created by Jane Doe.",
+        "Archives were created by Release Tool 2.0.",
+        "Files were created by maintainer@example.com.",
+    ];
+    let mut authors = vec![
+        AuthorDetection {
+            author: "Jane Doe".to_string(),
+            start_line: LineNumber::ONE,
+            end_line: LineNumber::ONE,
+        },
+        AuthorDetection {
+            author: "Release Tool 2.0".to_string(),
+            start_line: LineNumber::new(2).expect("valid line"),
+            end_line: LineNumber::new(2).expect("valid line"),
+        },
+        AuthorDetection {
+            author: "maintainer@example.com".to_string(),
+            start_line: LineNumber::new(3).expect("valid line"),
+            end_line: LineNumber::new(3).expect("valid line"),
+        },
+    ];
+
+    drop_passive_product_creation_authors(&raw_lines, &mut authors);
+
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+    assert_eq!(values, vec!["Jane Doe", "maintainer@example.com"]);
+}
+
+#[test]
 fn test_extract_comment_author_label_authors_detects_doxygen_author_tags() {
     let raw_lines = vec![
         "*> \\author Univ. of California Berkeley",

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -399,6 +399,7 @@ pub fn detect_copyrights_from_text_with_deadline(
         postprocess_transforms::refine_final_authors(&mut authors);
         author_heuristics::repair_contact_author_before_new_attribution(&raw_lines, &mut authors);
         author_heuristics::drop_shadowed_multiline_author_overruns(&raw_lines, &mut authors);
+        author_heuristics::drop_passive_product_creation_authors(&raw_lines, &mut authors);
         dedupe_exact_span_copyrights(&mut copyrights);
         dedupe_exact_span_holders(&mut holders);
         dedupe_exact_span_authors(&mut authors);
@@ -433,6 +434,7 @@ pub fn detect_copyrights_from_text_with_deadline(
     postprocess_transforms::refine_final_authors(&mut authors);
     author_heuristics::repair_contact_author_before_new_attribution(&raw_lines, &mut authors);
     author_heuristics::drop_shadowed_multiline_author_overruns(&raw_lines, &mut authors);
+    author_heuristics::drop_passive_product_creation_authors(&raw_lines, &mut authors);
     postprocess_transforms::drop_trademark_boilerplate_multiline_extensions(
         &raw_lines,
         &mut copyrights,


### PR DESCRIPTION
## Summary

- Reject passive `created by` detections when the grammatical subject is a plural artifact and the attributed party has product/version evidence.
- Preserve real people, collectives, and contact-backed authors under the same syntax.
- Keep the rule semantic and source-local instead of suppressing named products with a corpus-specific list.

## Issues

- Covers: author false positives found while validating #1391 on Info-ZIP 3.0

## Scope and exclusions

- Included: post-refinement classification of passive product-creation statements.
- Explicit exclusions: active `Created by NAME` credits, generic author boundary repair, and package metadata.

## How to verify

- Scan Info-ZIP 3.0 with `--copyright` and confirm `MacZip 1.0 March` and `Zip's MSDOS` are no longer authors.
- Scan Perl 5.38.4 with `--copyright` and confirm its 1,755 exact author records are unchanged from the parent.

## Intentional differences from Python

- Provenant distinguishes product provenance from human authorship using the sentence role and candidate shape even when a compatibility-oriented parser would emit both as authors.

## Follow-up work

- Created or intentionally deferred: attribution structure and weak prose evidence are handled by the next stacked PR.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: existing focused tests cover versioned and possessive/acronym product creators alongside positive human and contact-backed controls.

---

Generated with [Claude Code](https://claude.com/claude-code)
