### PR TITLE
fix(copyright): preserve attribution structure

### DIFF
--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -528,38 +528,56 @@ pub(in super::super) fn drop_authors_after_sentence_final_label(
     });
 }
 
-/// Drop a weak, single-word author when it was harvested from surrounding
-/// prose rather than from an explicit attribution. Lowercase mononyms remain
-/// valid when the source gives them strong local evidence such as `Author:` or
-/// `written by`.
-pub(in super::super) fn drop_weak_single_word_prose_authors(
+/// Drop a weak compact author phrase when it was harvested without a bounded
+/// label or attribution. Lowercase names remain valid with explicit evidence.
+pub(in super::super) fn drop_weak_prose_authors(
     raw_lines: &[&str],
     authors: &mut Vec<AuthorDetection>,
 ) {
     authors.retain(|author| {
         let candidate = author.author.trim();
-        if candidate.split_whitespace().count() != 1
-            || !candidate.chars().all(|ch| ch.is_alphabetic())
-            || !candidate.chars().all(char::is_lowercase)
-        {
+        let normalized = candidate
+            .trim_matches(|ch: char| !ch.is_alphabetic() && !ch.is_whitespace())
+            .trim();
+        let words: Vec<&str> = normalized.split_whitespace().collect();
+        let is_weak_compact_phrase = !words.is_empty()
+            && words.len() <= 2
+            && normalized
+                .chars()
+                .all(|ch| ch.is_alphabetic() || ch.is_whitespace())
+            && normalized
+                .chars()
+                .find(|ch| ch.is_alphabetic())
+                .is_some_and(|ch| ch.is_lowercase());
+        if !is_weak_compact_phrase {
             return true;
         }
 
         let Some(raw_line) = raw_lines.get(author.start_line.get().saturating_sub(1)) else {
             return true;
         };
-        if raw_line.split_whitespace().count() <= 2 {
-            return true;
-        }
-
         let lower = raw_line.to_lowercase();
-        let candidate_lower = candidate.to_lowercase();
-        let has_explicit_label = ["author:", "author :", "authors:", "authors :"]
+        let candidate_lower = normalized.to_lowercase();
+        let has_explicit_label = ["author:", "author :", "authors:", "authors :", "@author"]
             .iter()
             .any(|label| lower.contains(&format!("{label} {candidate_lower}")));
-        let has_by_attribution = lower.contains(&format!("by {candidate_lower}"));
+        let has_structured_author_field = lower.find(&candidate_lower).is_some_and(|index| {
+            let prefix = &lower[..index];
+            prefix
+                .rfind("author")
+                .is_some_and(|label_index| prefix[label_index + "author".len()..].contains(':'))
+        });
+        let attribution = format!("by {candidate_lower}");
+        let has_bounded_by_attribution = lower.match_indices(&attribution).any(|(index, _)| {
+            let tail = lower[index + attribution.len()..].trim_start();
+            tail.is_empty()
+                || tail
+                    .chars()
+                    .next()
+                    .is_some_and(|ch| matches!(ch, '.' | ',' | ';' | ':' | ')' | ']' | '>'))
+        });
 
-        has_explicit_label || has_by_attribution
+        has_explicit_label || has_structured_author_field || has_bounded_by_attribution
     });
 }
 

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -369,6 +369,101 @@ fn extract_written_by_subject(line: &str) -> Option<String> {
         .and_then(|cap| cap.name("who").map(|m| m.as_str().trim().to_string()))
 }
 
+fn extract_line_local_attribution_author(
+    line: &str,
+    allow_without_contact: bool,
+) -> Option<String> {
+    static ACTION_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:written|authored|revised|overhauled|updated|modified|implemented)\s+by\s+(?P<who>.+)$",
+        )
+        .unwrap()
+    });
+    static CONTACT_CONTRIBUTION_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^(?:code|driver|kernel|stuff|support|work|patch(?:es)?|implementation|maintenance|module|program|software)\b.*\s+by\s+(?P<who>.+(?:@|\s+at\s+.+\s+dot\s+).*)$",
+        )
+        .unwrap()
+    });
+    static COPYRIGHT_TAIL_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)\s*(?:,\s*copyright\b|\(c\)\s*\d{4})\b.*$").unwrap());
+    static CONTACT_SENTENCE_TAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^(?P<head>.*\b[\w.+-]+@[\w.-]+\.[a-z]{2,})(?:\.\s+|;\s+)[A-Z].*$").unwrap()
+    });
+
+    let normalized = strip_leading_dash_bullet(line);
+    let captures = ACTION_BY_RE
+        .captures(normalized)
+        .or_else(|| CONTACT_CONTRIBUTION_BY_RE.captures(normalized))?;
+    let who = captures.name("who")?.as_str().trim();
+    let has_contact = who.contains('@')
+        || who.contains('<')
+        || (who.to_ascii_lowercase().contains(" at ")
+            && who.to_ascii_lowercase().contains(" dot "));
+    if !allow_without_contact && !has_contact {
+        return None;
+    }
+    let who = trim_following_sentence_clause(who);
+    let who = COPYRIGHT_TAIL_RE.replace(&who, "");
+    let who = CONTACT_SENTENCE_TAIL_RE
+        .captures(&who)
+        .and_then(|captures| captures.name("head").map(|head| head.as_str().to_string()))
+        .unwrap_or_else(|| who.into_owned());
+    let who = trim_attribution_tail(&who);
+    let who = who.find('>').map_or(who.as_str(), |contact_end| {
+        let tail = who[contact_end + 1..].trim_start();
+        if tail.starts_with('.') || tail.starts_with(';') {
+            &who[..=contact_end]
+        } else {
+            who.as_str()
+        }
+    });
+    let who = who.trim_end_matches('.').trim();
+    let who_lower = who.to_ascii_lowercase();
+    if who_lower.ends_with(" and") || who_lower.ends_with(" or") {
+        return None;
+    }
+    refine_author(who)
+}
+
+pub(in super::super) fn extract_line_local_attribution_authors(
+    prepared_cache: &PreparedLines<'_>,
+) -> Vec<AuthorDetection> {
+    prepared_cache
+        .iter_non_empty()
+        .filter_map(|line| {
+            let author =
+                extract_line_local_attribution_author(line.prepared, false).or_else(|| {
+                    let normalized = strip_leading_dash_bullet(line.prepared);
+                    let lower = normalized.to_ascii_lowercase();
+                    let could_be_action_attribution = lower.contains(" by ")
+                        && [
+                            "written",
+                            "authored",
+                            "revised",
+                            "overhauled",
+                            "updated",
+                            "modified",
+                            "implemented",
+                            "originally",
+                            "original driver",
+                        ]
+                        .iter()
+                        .any(|prefix| lower.starts_with(prefix));
+                    (could_be_action_attribution
+                        && has_adjacent_copyright_hint(prepared_cache, line.line_number))
+                    .then(|| extract_line_local_attribution_author(line.prepared, true))
+                    .flatten()
+                })?;
+            Some(AuthorDetection {
+                author,
+                start_line: line.line_number,
+                end_line: line.line_number,
+            })
+        })
+        .collect()
+}
+
 fn has_adjacent_copyright_hint(
     prepared_cache: &PreparedLines<'_>,
     line_number: LineNumber,
@@ -641,14 +736,7 @@ pub(in super::super) fn extract_changes_by_authors(
             .map(|matched| matched.as_str())
             .unwrap_or("")
             .trim();
-        if who
-            .chars()
-            .filter(|ch| ch.is_alphabetic())
-            .all(|ch| ch.is_uppercase())
-        {
-            continue;
-        }
-        if let Some(author) = refine_author(who) {
+        if let Some(author) = refine_changes_by_party(who) {
             authors.push(AuthorDetection {
                 author,
                 start_line: line.line_number,
@@ -674,14 +762,7 @@ pub(in super::super) fn extract_changes_by_authors(
             .map(|matched| matched.as_str())
             .unwrap_or("")
             .trim();
-        if who
-            .chars()
-            .filter(|ch| ch.is_alphabetic())
-            .all(|ch| ch.is_uppercase())
-        {
-            continue;
-        }
-        if let Some(author) = refine_author(who) {
+        if let Some(author) = refine_changes_by_party(who) {
             authors.push(AuthorDetection {
                 author,
                 start_line: line.line_number,
@@ -691,6 +772,31 @@ pub(in super::super) fn extract_changes_by_authors(
     }
 
     authors
+}
+
+fn refine_changes_by_party(who: &str) -> Option<String> {
+    let party = who
+        .split_once(':')
+        .map(|(head, _)| head)
+        .unwrap_or(who)
+        .trim();
+    if party.is_empty()
+        || party
+            .chars()
+            .filter(|ch| ch.is_alphabetic())
+            .all(|ch| ch.is_uppercase())
+    {
+        return None;
+    }
+
+    refine_author(party).or_else(|| {
+        let mut letters = party.chars().filter(|ch| ch.is_alphabetic());
+        let first = letters.next()?;
+        (party.split_whitespace().count() == 1
+            && first.is_uppercase()
+            && letters.all(|ch| ch.is_lowercase()))
+        .then(|| party.to_string())
+    })
 }
 
 fn looks_like_contributed_person_name_token(word: &str) -> bool {
@@ -975,6 +1081,24 @@ pub(in super::super) fn extract_multiline_written_by_author_blocks(
                 || lower.starts_with("implemented ")
                 || lower.starts_with("copied from ")
         });
+
+        let line_local_authors: Vec<AuthorDetection> = block_lines
+            .iter()
+            .filter_map(|(line_number, raw_line)| {
+                let author = extract_line_local_attribution_author(raw_line, true)?;
+                Some(AuthorDetection {
+                    author,
+                    start_line: *line_number,
+                    end_line: *line_number,
+                })
+            })
+            .collect();
+        if line_local_authors.len() >= 2 {
+            authors.retain(|author| author.start_line < start_line || author.end_line > end_line);
+            authors.extend(line_local_authors);
+            line_number = next_line_number;
+            continue;
+        }
 
         if prefer_combined_block {
             let combined_raw = block_lines

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -135,11 +135,15 @@ fn test_comment_author_after_year_only_copyright_remains_holder_only() {
 }
 
 #[test]
-fn test_drop_weak_single_word_authors_uses_local_attribution_evidence() {
+fn test_drop_weak_authors_uses_bounded_local_attribution_evidence() {
     let raw_lines = vec![
         "Contributors, please see AUTHORS",
         "let the script author decide",
         "Written by chunchu",
+        "re-indented in 2006 by commit 95b2444",
+        "there are no missing authors in AUTHORS",
+        "The one maintained by the Perl development team",
+        "Changes by Gisle: optree dump",
     ];
     let mut authors = vec![
         AuthorDetection {
@@ -157,12 +161,33 @@ fn test_drop_weak_single_word_authors_uses_local_attribution_evidence() {
             start_line: LineNumber::new(3).expect("valid line"),
             end_line: LineNumber::new(3).expect("valid line"),
         },
+        AuthorDetection {
+            author: "commit".to_string(),
+            start_line: LineNumber::new(4).expect("valid line"),
+            end_line: LineNumber::new(4).expect("valid line"),
+        },
+        AuthorDetection {
+            author: "in AUTHORS".to_string(),
+            start_line: LineNumber::new(5).expect("valid line"),
+            end_line: LineNumber::new(5).expect("valid line"),
+        },
+        AuthorDetection {
+            author: "the Perl".to_string(),
+            start_line: LineNumber::new(6).expect("valid line"),
+            end_line: LineNumber::new(6).expect("valid line"),
+        },
+        AuthorDetection {
+            author: "Gisle".to_string(),
+            start_line: LineNumber::new(7).expect("valid line"),
+            end_line: LineNumber::new(7).expect("valid line"),
+        },
     ];
 
-    drop_weak_single_word_prose_authors(&raw_lines, &mut authors);
+    drop_weak_prose_authors(&raw_lines, &mut authors);
 
-    assert_eq!(authors.len(), 1, "authors: {authors:?}");
+    assert_eq!(authors.len(), 2, "authors: {authors:?}");
     assert_eq!(authors[0].author, "chunchu");
+    assert_eq!(authors[1].author, "Gisle");
 }
 
 #[test]
@@ -1283,6 +1308,7 @@ fn test_changes_by_attribution_is_detected_inline_and_across_lines() {
         "This platform file is based on unix.c; changes by Ruslan Nickolaev (nruslan@hotbox.ru)\n",
         "This other port is based on unix.c; changes\n",
         " by Chris Herborth (chrish@pobox.com).\n",
+        "Changes by Gisle: optree dump.\n",
     );
     let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
     let values: Vec<&str> = authors
@@ -1298,6 +1324,56 @@ fn test_changes_by_attribution_is_detected_inline_and_across_lines() {
         values.contains(&"Chris Herborth (chrish@pobox.com)"),
         "authors: {values:?}"
     );
+    assert!(values.contains(&"Gisle"), "authors: {values:?}");
+    assert!(
+        values.iter().all(|author| !author.contains("optree dump")),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_consecutive_line_local_attributions_remain_distinct() {
+    let input = concat!(
+        "Copyright (C) 2004 Example Corp.\n",
+        "Written by Ralph Metzler\n",
+        "Overhauled by Holger Waechtler\n",
+        "Driver support by Michael Hunold <hunold@example.com>\n",
+        "Support by Charles Bailey bailey@example.edu. OS/2 support\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(values.contains(&"Ralph Metzler"), "authors: {values:?}");
+    assert!(values.contains(&"Holger Waechtler"), "authors: {values:?}");
+    assert!(
+        values.contains(&"Michael Hunold <hunold@example.com>"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Charles Bailey bailey@example.edu"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values
+            .iter()
+            .all(|author| !author.contains("Overhauled by")),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_line_local_attribution_does_not_match_passive_prose() {
+    let input = concat!(
+        "The implementation was revised by adding one check.\n",
+        "The default support is maintained by the package manager.\n",
+        "Changes were introduced by default.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
 }
 
 #[test]

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -400,6 +400,7 @@ pub fn detect_copyrights_from_text_with_deadline(
         author_heuristics::repair_contact_author_before_new_attribution(&raw_lines, &mut authors);
         author_heuristics::drop_shadowed_multiline_author_overruns(&raw_lines, &mut authors);
         author_heuristics::drop_passive_product_creation_authors(&raw_lines, &mut authors);
+        author_heuristics::drop_weak_prose_authors(&raw_lines, &mut authors);
         dedupe_exact_span_copyrights(&mut copyrights);
         dedupe_exact_span_holders(&mut holders);
         dedupe_exact_span_authors(&mut authors);
@@ -435,6 +436,7 @@ pub fn detect_copyrights_from_text_with_deadline(
     author_heuristics::repair_contact_author_before_new_attribution(&raw_lines, &mut authors);
     author_heuristics::drop_shadowed_multiline_author_overruns(&raw_lines, &mut authors);
     author_heuristics::drop_passive_product_creation_authors(&raw_lines, &mut authors);
+    author_heuristics::drop_weak_prose_authors(&raw_lines, &mut authors);
     postprocess_transforms::drop_trademark_boilerplate_multiline_extensions(
         &raw_lines,
         &mut copyrights,
@@ -472,6 +474,15 @@ pub fn detect_copyrights_from_text_with_deadline(
     ));
     holders
         .extend(postprocess_transforms::add_missing_holders_for_iso_date_copyrights(&copyrights));
+
+    let mut final_line_local_authors =
+        author_heuristics::extract_line_local_attribution_authors(&prepared_lines);
+    final_line_local_authors.retain(|candidate| {
+        !authors
+            .iter()
+            .any(|author| author.author == candidate.author)
+    });
+    authors.extend(final_line_local_authors);
 
     dedupe_exact_span_holders(&mut holders);
 

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -148,6 +148,11 @@ fn run_author_extraction_and_repairs(
     seen.dedup_new_authors(authors, a_before);
     seen.rebuild_authors_from(authors);
 
+    let mut new_a =
+        super::author_heuristics::extract_line_local_attribution_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
     let a_before = authors.len();
     super::author_heuristics::extract_multiline_written_by_author_blocks(prepared_cache, authors);
     seen.dedup_new_authors(authors, a_before);
@@ -323,7 +328,7 @@ fn run_author_extraction_and_repairs(
     super::author_heuristics::drop_markup_element_value_authors(raw_lines, authors);
     super::author_heuristics::drop_markup_declaration_authors(raw_lines, authors);
     super::author_heuristics::drop_authors_after_sentence_final_label(raw_lines, authors);
-    super::author_heuristics::drop_weak_single_word_prose_authors(raw_lines, authors);
+    super::author_heuristics::drop_weak_prose_authors(raw_lines, authors);
     super::author_heuristics::repair_complete_by_line_author_boundaries(raw_lines, authors);
     super::author_heuristics::repair_hyphenated_prose_tail_authors(raw_lines, authors);
     super::author_heuristics::drop_embedded_authors_title_phrases(raw_lines, authors);

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/Documentation/bpf/bpf_devel_QA.rst.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/Documentation/bpf/bpf_devel_QA.rst.yml
@@ -2,7 +2,6 @@ what:
   - copyrights
   - holders
   - authors
-authors:
-  - in Cc
+authors: []
 copyrights: []
 holders: []

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/Documentation/driver-api/soundwire/stream.rst.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/Documentation/driver-api/soundwire/stream.rst.yml
@@ -2,7 +2,6 @@ what:
   - copyrights
   - holders
   - authors
-authors:
-  - the Bus
+authors: []
 copyrights: []
 holders: []

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/arch/nios2/include/asm/uaccess.h.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/arch/nios2/include/asm/uaccess.h.yml
@@ -8,4 +8,5 @@ copyrights:
 holders:
   - Tobias Klauser
   - Wind River Systems Inc Implemented by
-authors: []
+authors:
+  - fredrik.markstrom@gmail.com and ivarholmqvist@gmail.com

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/staging/rtlwifi/halmac/halmac_88xx/halmac_api_88xx.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/staging/rtlwifi/halmac/halmac_88xx/halmac_api_88xx.c.yml
@@ -17,4 +17,3 @@ authors:
   - Soar Return
   - Soar/Ivan Lin
   - chunchu
-  - chunchu Return

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/fs/nilfs2/sufile.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/fs/nilfs2/sufile.c.yml
@@ -7,4 +7,5 @@ copyrights:
 holders:
   - Nippon Telegraph and Telephone Corporation
 authors:
-  - Koji Sato. Revised by Ryusuke Konishi
+  - Koji Sato
+  - Ryusuke Konishi

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/include/media/dvb_frontend.h.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/include/media/dvb_frontend.h.yml
@@ -9,4 +9,6 @@ holders:
   - convergence GmbH
   - convergence integrated media GmbH
 authors:
-  - Ralph Metzler Overhauled by Holger Waechtler Kernel I2C stuff by Michael Hunold <hunold@convergence.de>
+  - Holger Waechtler
+  - Michael Hunold <hunold@convergence.de>
+  - Ralph Metzler

--- a/testdata/copyright-golden/copyrights/misco4/linux3/pre-name.txt.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux3/pre-name.txt.yml
@@ -8,4 +8,6 @@ copyrights:
 holders:
   - Paul Mundt
   - Vladimir Oleynik
-authors: []
+authors:
+  - Paul Mundt <lethal@linux-sh.org>
+  - Vladimir Oleynik <dzo@simtreas.ru>


### PR DESCRIPTION
## Summary

- Reject compact prose fragments unless a bounded author label, attribution, or structured field supports them.
- Preserve line-local authors across consecutive attribution lines instead of flattening the block into one malformed value.
- Bound contact-backed and `changes by` credits at their source evidence while retaining real names, handles, and metadata fields.

## Issues

- Covers: #1391

## Scope and exclusions

- Included: author evidence filtering, line-local attribution extraction, attribution-tail cleanup, and intentional copyright golden updates.
- Explicit exclusions: broader copyright and holder cleanup, and same-line multi-credit sentence splitting.

## How to verify

- Scan Perl 5.38.4 with `--copyright` and inspect the exact author-record delta against the parent: prose values such as `commit`, `notified`, `provides`, `actually...`, and `in AUTHORS` disappear, while contact-backed contributor credits are recovered or made more complete.
- Scan Info-ZIP 3.0 with `--copyright`; its exact author records remain unchanged from the parent.

## Intentional differences from Python

- Consecutive explicit credit lines are emitted as distinct authors rather than one ScanCode-compatible flattened string.
- Provenant keeps contact-backed `Modified by`, `Implemented by`, patch, support, and contribution credits when the source establishes authorship, even when historical ScanCode expectations omitted them.

## Follow-up work

- Created or intentionally deferred: split independently attributable credits that share one prose line.

## Expected-output fixture changes

- Files changed: seven copyright golden YAML fixtures covering weak prose, malformed tails, contact-backed credits, and consecutive attribution lines.
- Why the new expected output is correct: every retained author is bounded by an explicit source attribution; values copied from surrounding prose are removed, and independent credit lines no longer bleed into one another.

---

Generated with [Claude Code](https://claude.com/claude-code)
