### PR TITLE
fix(copyright): split chained author credits

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -375,7 +375,7 @@ fn extract_line_local_attribution_author(
 ) -> Option<String> {
     static ACTION_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)^(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:written|authored|revised|overhauled|updated|modified|implemented)\s+by\s+(?P<who>.+)$",
+            r"(?i)^(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:(?:written|authored|revised|overhauled|implemented)\s+by|(?:updated|modified|ported|adapted)(?:\s+to\s+.*?)?\s+by)\s+(?P<who>.+)$",
         )
         .unwrap()
     });
@@ -392,6 +392,13 @@ fn extract_line_local_attribution_author(
     });
 
     let normalized = strip_leading_dash_bullet(line);
+    let normalized_lower = normalized.to_ascii_lowercase();
+    if normalized_lower.find(" by ").is_some_and(|by_index| {
+        let prefix = &normalized_lower[..by_index];
+        prefix.contains("copyright") || prefix.contains("(c)")
+    }) {
+        return None;
+    }
     let captures = ACTION_BY_RE
         .captures(normalized)
         .or_else(|| CONTACT_CONTRIBUTION_BY_RE.captures(normalized))?;
@@ -462,6 +469,97 @@ pub(in super::super) fn extract_line_local_attribution_authors(
             })
         })
         .collect()
+}
+
+pub(in super::super) fn repair_chained_attribution_authors(
+    prepared_cache: &PreparedLines<'_>,
+    authors: &mut Vec<AuthorDetection>,
+) {
+    static ACTIVE_SENTENCE_CHAIN_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)\b(?:written|authored|developed|created)\s+by\s+(?P<first>[^.]{2,100})\.\s+(?P<second>[\p{L}][\p{L}'’-]*(?:\s+[\p{L}][\p{L}'’-]*){1,4})\s+(?:created|authored|wrote|developed|implemented|updated|modified|refactored)\b",
+        )
+        .unwrap()
+    });
+    static WRAPPED_ROLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)\b(?:support|implementation|code|patch(?:es)?|maintenance|maintainership|documentation)\s*$",
+        )
+        .unwrap()
+    });
+    static LEADING_BY_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^by\s+(?P<who>.+)$").unwrap());
+
+    let mut recovered = Vec::new();
+    for line in prepared_cache.iter_non_empty() {
+        let Some(captures) = ACTIVE_SENTENCE_CHAIN_RE.captures(line.prepared) else {
+            continue;
+        };
+        let Some(first) = captures
+            .name("first")
+            .and_then(|matched| refine_author(matched.as_str().trim_matches(&[' ', ',', ';'][..])))
+        else {
+            continue;
+        };
+        let Some(second) = captures
+            .name("second")
+            .and_then(|matched| refine_author(matched.as_str()))
+        else {
+            continue;
+        };
+
+        authors.retain(|author| {
+            !(author.start_line <= line.line_number
+                && author.end_line >= line.line_number
+                && author.author.contains(&first)
+                && author.author.contains(&second))
+        });
+        recovered.push(AuthorDetection {
+            author: first,
+            start_line: line.line_number,
+            end_line: line.line_number,
+        });
+        recovered.push(AuthorDetection {
+            author: second,
+            start_line: line.line_number,
+            end_line: line.line_number,
+        });
+    }
+
+    for (previous, next) in prepared_cache.adjacent_pairs() {
+        if !WRAPPED_ROLE_RE.is_match(previous.prepared.trim()) {
+            continue;
+        }
+        let Some(captures) = LEADING_BY_RE.captures(next.prepared.trim()) else {
+            continue;
+        };
+        let Some(who) = captures.name("who").map(|matched| matched.as_str()) else {
+            continue;
+        };
+        let lower = who.to_ascii_lowercase();
+        let has_contact = who.contains('@')
+            || who.contains('<')
+            || (lower.contains(" at ") && lower.contains(" dot "));
+        if !has_contact {
+            continue;
+        }
+        let who = trim_attribution_tail(who);
+        let Some(author) = refine_author(&who) else {
+            continue;
+        };
+        recovered.push(AuthorDetection {
+            author,
+            start_line: previous.line_number,
+            end_line: next.line_number,
+        });
+    }
+
+    recovered.retain(|candidate| {
+        !authors
+            .iter()
+            .any(|author| author.author == candidate.author)
+    });
+    authors.extend(recovered);
 }
 
 fn has_adjacent_copyright_hint(

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -1339,6 +1339,7 @@ fn test_consecutive_line_local_attributions_remain_distinct() {
         "Overhauled by Holger Waechtler\n",
         "Driver support by Michael Hunold <hunold@example.com>\n",
         "Support by Charles Bailey bailey@example.edu. OS/2 support\n",
+        "Ported to HID by Benjamin Tissoires <benjamin@example.com>\n",
     );
     let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
     let values: Vec<&str> = authors
@@ -1357,6 +1358,10 @@ fn test_consecutive_line_local_attributions_remain_distinct() {
         "authors: {values:?}"
     );
     assert!(
+        values.contains(&"Benjamin Tissoires <benjamin@example.com>"),
+        "authors: {values:?}"
+    );
+    assert!(
         values
             .iter()
             .all(|author| !author.contains("Overhauled by")),
@@ -1370,10 +1375,57 @@ fn test_line_local_attribution_does_not_match_passive_prose() {
         "The implementation was revised by adding one check.\n",
         "The default support is maintained by the package manager.\n",
         "Changes were introduced by default.\n",
+        "DTMF code (c) 1996 by Christian Mock (cm@example.com).\n",
     );
     let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
 
     assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_chained_active_attributions_are_distinct_authors() {
+    let input = concat!(
+        "AUTHORS\n",
+        "The implementation was written by Brandon L Black. ",
+        "Nicholas Clark created the pluggable interface.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(values.contains(&"Brandon L Black"), "authors: {values:?}");
+    assert!(values.contains(&"Nicholas Clark"), "authors: {values:?}");
+    assert!(
+        values
+            .iter()
+            .all(|author| !author.contains("Black. Nicholas")),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_wrapped_contribution_role_supports_leading_by_author() {
+    let input = concat!(
+        "AUTHORS\n",
+        "Support by Charles Bailey <charles@example.com>. OS/2 support\n",
+        "by Ilya Zakharevich <ilya@example.com>.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(
+        values.contains(&"Charles Bailey <charles@example.com>"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Ilya Zakharevich <ilya@example.com>"),
+        "authors: {values:?}"
+    );
 }
 
 #[test]

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -317,6 +317,9 @@ fn run_author_extraction_and_repairs(
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
 
+    super::author_heuristics::repair_chained_attribution_authors(prepared_cache, authors);
+    seen.rebuild_authors_from(authors);
+
     let mut new_a = super::author_heuristics::extract_comment_author_label_authors(raw_lines);
     new_a.retain(|candidate| {
         !authors

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/hid/hid-appleir.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/hid/hid-appleir.c.yml
@@ -17,4 +17,7 @@ holders:
   - Novell Inc.
   - Red Hat Inc.
 authors:
-  - James McKenzie Ported to recent 2.6 kernel versions by Greg Kroah-Hartman <gregkh@suse.de> Updated to support newer remotes by Bastien Nocera <hadess@hadess.net> Ported to HID subsystem by Benjamin Tissoires <benjamin.tissoires@gmail.com>
+  - Bastien Nocera <hadess@hadess.net>
+  - Benjamin Tissoires <benjamin.tissoires@gmail.com>
+  - Greg Kroah-Hartman <gregkh@suse.de>
+  - James McKenzie


### PR DESCRIPTION
## Summary

- Split independent active credits that share one sentence instead of retaining a merged author value.
- Treat adjacent attribution lines as separate records for `ported`, `adapted`, `updated`, and similar contribution actions.
- Recover a contact-backed author when a contribution role wraps immediately before a leading `by NAME` line.

## Issues

- Covers: chained-attribution defects found while validating #1391 on Perl 5.38.4 and the Linux copyright corpus

## Scope and exclusions

- Included: structurally independent author clauses and one-line-wrapped contribution roles.
- Explicit exclusions: general POD escape decoding and broader contact-role extraction, which require their own output audit.

## How to verify

- Scan Perl 5.38.4 with `--copyright`: `Brandon L Black. Nicholas Clark` becomes two authors, and the wrapped `OS/2 support` / `by Ilya Zakharevich` credit is recovered.
- Scan Info-ZIP 3.0 with `--copyright`; its exact author records remain unchanged from the parent.

## Intentional differences from Python

- Provenant emits one record per independently attributable clause or line rather than preserving a flattened compatibility value across multiple credits.

## Follow-up work

- Created or intentionally deferred: normalize standard POD character and double-angle formatting before enabling broader contact-backed role recovery.

## Expected-output fixture changes

- Files changed: `drivers/hid/hid-appleir.c.yml`.
- Why the new expected output is correct: four adjacent, explicit source credits now produce four authors rather than one string containing all four lines.

---

Generated with [Claude Code](https://claude.com/claude-code)
