### PR TITLE
fix(copyright): decode POD attribution markup

### DIFF
--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -303,6 +303,38 @@ pub(in super::super) fn drop_shadowed_prefix_authors(authors: &mut Vec<AuthorDet
     });
 }
 
+pub(in super::super) fn drop_same_span_contact_sentence_overruns(
+    authors: &mut Vec<AuthorDetection>,
+) {
+    if authors.len() < 2 {
+        return;
+    }
+    let originals = authors.clone();
+    authors.retain(|author| {
+        let candidate = author.author.trim();
+        !originals.iter().any(|other| {
+            if other.start_line != author.start_line || other.end_line != author.end_line {
+                return false;
+            }
+            let clean = other.author.trim();
+            if clean.len() >= candidate.len() || !clean.contains('@') {
+                return false;
+            }
+            let Some(tail) = candidate.strip_prefix(clean) else {
+                return false;
+            };
+            let tail = tail.trim_start();
+            matches!(tail.chars().next(), Some('.' | ';'))
+                && tail
+                    .trim_start_matches(['.', ';'])
+                    .trim_start()
+                    .chars()
+                    .next()
+                    .is_some_and(char::is_uppercase)
+        })
+    });
+}
+
 pub(in super::super) fn drop_shadowed_compound_email_authors(authors: &mut Vec<AuthorDetection>) {
     if authors.is_empty() {
         return;
@@ -790,38 +822,47 @@ pub(in super::super) fn repair_contact_author_before_new_attribution(
         if author.end_line <= author.start_line {
             continue;
         }
-        let Some(first_raw) = raw_lines.get(author.start_line.get().saturating_sub(1)) else {
-            continue;
-        };
-        let Some(next_raw) = raw_lines.get(author.start_line.get()) else {
-            continue;
-        };
-        let first = prepare_text_line(first_raw);
-        let first_lower = first.to_ascii_lowercase();
-        let next = prepare_text_line(next_raw).to_ascii_lowercase();
-        let has_contact =
-            first.contains('@') || (first_lower.contains(" at ") && first_lower.contains(" dot "));
-        if !has_contact
-            || !next.contains(" by ")
-            || next.starts_with("and ")
-            || next.starts_with("or ")
+        let start_index = author.start_line.get().saturating_sub(1);
+        let end_index = author.end_line.get().min(raw_lines.len());
+        let mut prefix = Vec::new();
+
+        for (index, raw_line) in raw_lines
+            .iter()
+            .enumerate()
+            .take(end_index)
+            .skip(start_index)
         {
-            continue;
-        }
-        let Some(captures) = TRAILING_BY_RE.captures(&first) else {
-            continue;
-        };
-        let who = captures
-            .name("who")
-            .map(|matched| matched.as_str())
-            .unwrap_or("")
-            .trim();
-        let Some(refined) = refine_author(who) else {
-            continue;
-        };
-        if author.author.starts_with(&refined) {
-            author.author = refined;
-            author.end_line = author.start_line;
+            let prepared = prepare_text_line(raw_line);
+            if index > start_index {
+                let lower = prepared.to_ascii_lowercase();
+                let opens_new_attribution = lower.contains(" by ")
+                    && !lower.starts_with("and ")
+                    && !lower.starts_with("or ");
+                let joined = prefix.join(" ");
+                let joined_lower = joined.to_ascii_lowercase();
+                let has_contact = joined.contains('@')
+                    || joined.contains('<')
+                    || (joined_lower.contains(" at ") && joined_lower.contains(" dot "));
+                if opens_new_attribution && has_contact {
+                    let Some(captures) = TRAILING_BY_RE.captures(&joined) else {
+                        break;
+                    };
+                    let who = captures
+                        .name("who")
+                        .map(|matched| matched.as_str())
+                        .unwrap_or("")
+                        .trim();
+                    let Some(refined) = refine_author(who) else {
+                        break;
+                    };
+                    if author.author.starts_with(&refined) {
+                        author.author = refined;
+                        author.end_line = LineNumber::new(index).expect("valid source line");
+                    }
+                    break;
+                }
+            }
+            prefix.push(prepared);
         }
     }
 }

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -381,7 +381,7 @@ fn extract_line_local_attribution_author(
     });
     static CONTACT_CONTRIBUTION_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)^(?:code|driver|kernel|stuff|support|work|patch(?:es)?|implementation|maintenance|module|program|software)\b.*\s+by\s+(?P<who>.+(?:@|\s+at\s+.+\s+dot\s+).*)$",
+            r"(?i)^(?:.{1,80}\s+)?(?:code|driver|kernel|stuff|support|work|patch(?:es)?|implementation|maintenance|module|program|software)\b.*\s+by\s+(?P<who>.+(?:@|\s+at\s+.+\s+dot\s+).*)$",
         )
         .unwrap()
     });
@@ -489,6 +489,18 @@ pub(in super::super) fn repair_chained_attribution_authors(
     });
     static LEADING_BY_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^by\s+(?P<who>.+)$").unwrap());
+    static CONJOINED_CONTACT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)\b(?:support|implementation|code|patch(?:es)?|maintenance|maintainership|documentation)\s+by\s+(?P<who>.+?),?\s+and\s*$",
+        )
+        .unwrap()
+    });
+    static TRAILING_SECOND_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)\b(?:expanded|updated|modified|integrated|supplemented|maintained|ported|adapted)\s+by\s+(?P<head>[\p{L}][\p{L}'’.-]*(?:\s+[\p{L}][\p{L}'’.-]*){0,4})\s*$",
+        )
+        .unwrap()
+    });
 
     let mut recovered = Vec::new();
     for line in prepared_cache.iter_non_empty() {
@@ -547,6 +559,67 @@ pub(in super::super) fn repair_chained_attribution_authors(
         let Some(author) = refine_author(&who) else {
             continue;
         };
+        recovered.push(AuthorDetection {
+            author,
+            start_line: previous.line_number,
+            end_line: next.line_number,
+        });
+    }
+
+    for (previous, next) in prepared_cache.adjacent_pairs() {
+        let Some(captures) = CONJOINED_CONTACT_RE.captures(previous.prepared.trim()) else {
+            continue;
+        };
+        let Some(first) = captures.name("who").map(|matched| matched.as_str().trim()) else {
+            continue;
+        };
+        let second = next.prepared.trim().trim_end_matches('.').trim();
+        if (!first.contains('@') && !first.contains('<'))
+            || (!second.contains('@') && !second.contains('<'))
+        {
+            continue;
+        }
+        let Some(author) = refine_author(&format!("{first}, and {second}")) else {
+            continue;
+        };
+        authors.retain(|existing| {
+            !(existing.start_line == previous.line_number && author.starts_with(&existing.author))
+        });
+        recovered.push(AuthorDetection {
+            author,
+            start_line: previous.line_number,
+            end_line: next.line_number,
+        });
+    }
+
+    for (previous, next) in prepared_cache.adjacent_pairs() {
+        let Some(captures) = TRAILING_SECOND_BY_RE.captures(previous.prepared.trim()) else {
+            continue;
+        };
+        let Some(head) = captures.name("head").map(|matched| matched.as_str().trim()) else {
+            continue;
+        };
+        let tail = next.prepared.trim().trim_end_matches('.').trim();
+        let tail_words: Vec<&str> = tail.split_whitespace().collect();
+        if tail_words.is_empty()
+            || tail_words.len() > 3
+            || !tail_words.iter().all(|word| {
+                word.chars()
+                    .find(|ch| ch.is_alphabetic())
+                    .is_some_and(|ch| ch.is_uppercase())
+                    && word
+                        .chars()
+                        .all(|ch| ch.is_alphabetic() || matches!(ch, '\'' | '’' | '-' | '.'))
+            })
+        {
+            continue;
+        }
+        let Some(author) = refine_author(&format!("{head} {tail}")) else {
+            continue;
+        };
+        authors.retain(|existing| {
+            !(existing.start_line == previous.line_number && author.starts_with(&existing.author))
+        });
         recovered.push(AuthorDetection {
             author,
             start_line: previous.line_number,

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -1429,6 +1429,107 @@ fn test_wrapped_contribution_role_supports_leading_by_author() {
 }
 
 #[test]
+fn test_contact_backed_conjoined_attribution_continues_on_next_line() {
+    let input = concat!(
+        "AUTHORS\n",
+        "Mac support by Paul Schinder C<< <paul@example.com> >>, and\n",
+        "Thomas Wegner C<< <thomas@example.com> >>.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(
+        values
+            .contains(&"Paul Schinder <paul@example.com>, and Thomas Wegner <thomas@example.com>"),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_second_by_author_name_continues_across_pod_lines() {
+    let input = concat!(
+        "AUTHORS\n",
+        "Originally written by Yves Orton, expanded by E<AElig>var ArnfjE<ouml>rE<eth>\n",
+        "Bjarmason.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(values.contains(&"Yves Orton"), "authors: {values:?}");
+    assert!(
+        values.contains(&"Ævar Arnfjörð Bjarmason"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.iter().all(|author| author != &"Ævar Arnfjörð"),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_pod_contact_author_stops_at_following_sentence() {
+    let input = concat!(
+        "This project was maintained by Dan Kogai I<< <dankogai@cpan.org> >>.  ",
+        "See AUTHORS for everyone involved.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert_eq!(values, vec!["Dan Kogai <dankogai@cpan.org>"]);
+}
+
+#[test]
+fn test_wrapped_contact_author_stops_before_new_attribution() {
+    let input = concat!(
+        "Widget was written by Raphael Manfredi\n",
+        "F<E<lt>Raphael_Manfredi@pobox.comE<gt>>\n",
+        "Maintenance is now done by the Widget team.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(
+        values.contains(&"Raphael Manfredi <Raphael_Manfredi@pobox.com>"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.iter().all(|author| !author.contains("Maintenance")),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_pod_copyright_heading_does_not_duplicate_final_line() {
+    let input = concat!(
+        "=head1 COPYRIGHT\n",
+        "\n",
+        "Copyright 2002-2014 Dan Kogai I<< <dankogai@cpan.org> >>.\n",
+    );
+    let (copyrights, _holders, _authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = copyrights
+        .iter()
+        .map(|copyright| copyright.copyright.as_str())
+        .collect();
+
+    assert_eq!(
+        values,
+        vec!["Copyright 2002-2014 Dan Kogai <dankogai@cpan.org>"]
+    );
+}
+
+#[test]
 fn test_changes_by_prose_does_not_create_an_author() {
     let input = concat!(
         "The value changes by adding one to the previous result.\n",

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -483,6 +483,8 @@ pub fn detect_copyrights_from_text_with_deadline(
             .any(|author| author.author == candidate.author)
     });
     authors.extend(final_line_local_authors);
+    author_heuristics::repair_chained_attribution_authors(&prepared_lines, &mut authors);
+    author_heuristics::drop_same_span_contact_sentence_overruns(&mut authors);
 
     dedupe_exact_span_holders(&mut holders);
 

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -272,6 +272,7 @@ fn run_author_extraction_and_repairs(
     );
     super::author_heuristics::drop_shadowed_compound_email_authors(authors);
     super::author_heuristics::drop_shadowed_prefix_authors(authors);
+    super::author_heuristics::drop_same_span_contact_sentence_overruns(authors);
     seen.rebuild_authors_from(authors);
 
     super::postprocess_transforms::merge_implemented_by_lines(
@@ -984,6 +985,9 @@ fn run_final_variant_and_cleanup_repairs(
     );
     super::postprocess_transforms::drop_markup_declaration_and_versioninfo_copyrights_and_holders(
         raw_lines, copyrights, holders,
+    );
+    super::postprocess_transforms::drop_section_heading_multiline_copyrights_shadowed_by_final_line(
+        raw_lines, copyrights,
     );
     super::postprocess_transforms::drop_copyright_like_holders(holders);
     drop_placeholder_and_code_junk_by_raw_line(raw_lines, copyrights, holders);

--- a/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
+++ b/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::copyright::prepare::prepare_text_line;
 
 pub fn strip_trailing_license_tail(s: &str) -> Option<String> {
     let lower = s.to_ascii_lowercase();
@@ -352,7 +353,6 @@ pub fn drop_single_line_copyrights_shadowed_by_multiline_same_start(
     if copyrights.len() < 2 {
         return;
     }
-
     static YEARS_EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
             r"(?ix)^copyright\s*\(c\)\s*(?P<years>[0-9\s,\-–]{4,32})\s+(?P<email>[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,15})\b",
@@ -607,6 +607,71 @@ pub fn drop_shadowed_multiline_prefix_copyrights(copyrights: &mut Vec<CopyrightD
                         .get(short.len())
                         .is_some_and(|b| b.is_ascii_whitespace() || b.is_ascii_punctuation())
             })
+        })
+    });
+}
+
+fn looks_like_copyright_section_heading(prefix: &str) -> bool {
+    let mut saw_subject = false;
+    let mut saw_pod_directive = false;
+    prefix.split_whitespace().all(|raw_token| {
+        let token = raw_token
+            .trim_matches(|ch: char| !ch.is_alphanumeric() && ch != '=')
+            .to_ascii_lowercase();
+        if token.starts_with("=head")
+            && token.strip_prefix("=head").is_some_and(|level| {
+                !level.is_empty() && level.chars().all(|ch| ch.is_ascii_digit())
+            })
+        {
+            saw_pod_directive = true;
+            return true;
+        }
+        if matches!(token.as_str(), "copyright" | "license" | "licence") {
+            saw_subject = true;
+            return true;
+        }
+        matches!(token.as_str(), "and" | "legal" | "notice" | "notices")
+    }) && saw_subject
+        && saw_pod_directive
+}
+
+/// Drop a multi-line extraction that consists only of a section heading plus
+/// a complete copyright already extracted on the final line.
+pub fn drop_section_heading_multiline_copyrights_shadowed_by_final_line(
+    raw_lines: &[&str],
+    copyrights: &mut Vec<CopyrightDetection>,
+) {
+    if copyrights.len() < 2 {
+        return;
+    }
+    let originals = copyrights.clone();
+    copyrights.retain(|candidate| {
+        if candidate.start_line == candidate.end_line {
+            return true;
+        }
+        !originals.iter().any(|single| {
+            if single.start_line != candidate.end_line || single.end_line != candidate.end_line {
+                return false;
+            }
+            let candidate_text = prepare_text_line(&candidate.copyright);
+            let single_text = prepare_text_line(&single.copyright);
+            if candidate_text == single_text {
+                let heading_start = candidate.start_line.get().saturating_sub(1);
+                let heading_end = candidate.end_line.get().saturating_sub(1);
+                return raw_lines
+                    .get(heading_start..heading_end)
+                    .is_some_and(|lines| {
+                        lines.iter().all(|line| {
+                            let prepared = prepare_text_line(line);
+                            prepared.trim().is_empty()
+                                || looks_like_copyright_section_heading(&prepared)
+                        })
+                    });
+            }
+            candidate_text
+                .strip_suffix(&single_text)
+                .map(str::trim)
+                .is_some_and(looks_like_copyright_section_heading)
         })
     });
 }

--- a/src/copyright/prepare.rs
+++ b/src/copyright/prepare.rs
@@ -424,20 +424,173 @@ fn should_keep_angle_bracket_content(m: &str) -> bool {
 }
 
 fn unwrap_simple_pod_formatting(text: &str) -> String {
+    static POD_DOUBLE_FORMATTING_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\b[BCFILS]<<\s+(?P<text>.*?)\s+>>")
+            .expect("valid double-angle POD formatting regex")
+    });
     static POD_FORMATTING_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"\b[BCFILS]<(?P<text>[^/<>][^<>]*)>").expect("valid POD formatting regex")
+        Regex::new(r"\b[BCFILS]<(?P<text>(?:E<[^<>]+>|[^/<>])(?:E<[^<>]+>|[^<>])*)>")
+            .expect("valid POD formatting regex")
     });
 
     let mut unwrapped = text.to_string();
     for _ in 0..3 {
-        if !POD_FORMATTING_RE.is_match(&unwrapped) {
+        let has_double = POD_DOUBLE_FORMATTING_RE.is_match(&unwrapped);
+        let has_single = POD_FORMATTING_RE.is_match(&unwrapped);
+        if !has_double && !has_single {
             break;
         }
+        unwrapped = POD_DOUBLE_FORMATTING_RE
+            .replace_all(&unwrapped, "$text")
+            .into_owned();
         unwrapped = POD_FORMATTING_RE
             .replace_all(&unwrapped, "$text")
             .into_owned();
     }
     unwrapped
+}
+
+fn decode_pod_character_escapes(text: &str) -> String {
+    static POD_ESCAPE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"E<(?P<name>[A-Za-z][A-Za-z0-9]*|0x[0-9A-Fa-f]+|\d+)>")
+            .expect("valid POD character escape regex")
+    });
+
+    POD_ESCAPE_RE
+        .replace_all(text, |captures: &regex::Captures| {
+            let whole = captures
+                .get(0)
+                .map(|matched| matched.as_str())
+                .unwrap_or("");
+            let name = captures
+                .name("name")
+                .map(|matched| matched.as_str())
+                .unwrap_or("");
+            let decoded = if let Some(hex) = name.strip_prefix("0x") {
+                u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)
+            } else if name.chars().all(|ch| ch.is_ascii_digit()) {
+                name.parse::<u32>().ok().and_then(char::from_u32)
+            } else {
+                decode_named_pod_character(name)
+            };
+            decoded
+                .map(|ch| ch.to_string())
+                .unwrap_or_else(|| whole.to_string())
+        })
+        .into_owned()
+}
+
+fn decode_named_pod_character(name: &str) -> Option<char> {
+    Some(match name {
+        "lt" => '<',
+        "gt" => '>',
+        "amp" => '&',
+        "quot" => '"',
+        "apos" => '\'',
+        "sol" => '/',
+        "verbar" => '|',
+        "lchevron" | "laquo" => '«',
+        "rchevron" | "raquo" => '»',
+        "nbsp" => '\u{00A0}',
+        "iexcl" => '¡',
+        "cent" => '¢',
+        "pound" => '£',
+        "curren" => '¤',
+        "yen" => '¥',
+        "brvbar" => '¦',
+        "sect" => '§',
+        "uml" => '¨',
+        "copy" => '©',
+        "ordf" => 'ª',
+        "not" => '¬',
+        "shy" => '\u{00AD}',
+        "reg" => '®',
+        "macr" => '¯',
+        "deg" => '°',
+        "plusmn" => '±',
+        "sup2" => '²',
+        "sup3" => '³',
+        "acute" => '´',
+        "micro" => 'µ',
+        "para" => '¶',
+        "middot" => '·',
+        "cedil" => '¸',
+        "sup1" => '¹',
+        "ordm" => 'º',
+        "frac14" => '¼',
+        "frac12" => '½',
+        "frac34" => '¾',
+        "iquest" => '¿',
+        "Agrave" => 'À',
+        "Aacute" => 'Á',
+        "Acirc" => 'Â',
+        "Atilde" => 'Ã',
+        "Auml" => 'Ä',
+        "Aring" => 'Å',
+        "AElig" => 'Æ',
+        "Ccedil" => 'Ç',
+        "Egrave" => 'È',
+        "Eacute" => 'É',
+        "Ecirc" => 'Ê',
+        "Euml" => 'Ë',
+        "Igrave" => 'Ì',
+        "Iacute" => 'Í',
+        "Icirc" => 'Î',
+        "Iuml" => 'Ï',
+        "ETH" => 'Ð',
+        "Ntilde" => 'Ñ',
+        "Ograve" => 'Ò',
+        "Oacute" => 'Ó',
+        "Ocirc" => 'Ô',
+        "Otilde" => 'Õ',
+        "Ouml" => 'Ö',
+        "times" => '×',
+        "Oslash" => 'Ø',
+        "Ugrave" => 'Ù',
+        "Uacute" => 'Ú',
+        "Ucirc" => 'Û',
+        "Uuml" => 'Ü',
+        "Yacute" => 'Ý',
+        "THORN" => 'Þ',
+        "szlig" => 'ß',
+        "agrave" => 'à',
+        "aacute" => 'á',
+        "acirc" => 'â',
+        "atilde" => 'ã',
+        "auml" => 'ä',
+        "aring" => 'å',
+        "aelig" => 'æ',
+        "ccedil" => 'ç',
+        "egrave" => 'è',
+        "eacute" => 'é',
+        "ecirc" => 'ê',
+        "euml" => 'ë',
+        "igrave" => 'ì',
+        "iacute" => 'í',
+        "icirc" => 'î',
+        "iuml" => 'ï',
+        "eth" => 'ð',
+        "ntilde" => 'ñ',
+        "ograve" => 'ò',
+        "oacute" => 'ó',
+        "ocirc" => 'ô',
+        "otilde" => 'õ',
+        "ouml" => 'ö',
+        "divide" => '÷',
+        "oslash" => 'ø',
+        "ugrave" => 'ù',
+        "uacute" => 'ú',
+        "ucirc" => 'û',
+        "uuml" => 'ü',
+        "yacute" => 'ý',
+        "thorn" => 'þ',
+        "yuml" => 'ÿ',
+        "euro" => '€',
+        "infin" => '∞',
+        "zwnj" => '\u{200C}',
+        "zwj" => '\u{200D}',
+        _ => return None,
+    })
 }
 
 /// Prepare a text `line` for copyright detection.
@@ -446,8 +599,8 @@ fn unwrap_simple_pod_formatting(text: &str) -> String {
 /// copyright/author detection. This mirrors the Python `prepare_text_line()`
 /// function from ScanCode Toolkit.
 pub fn prepare_text_line(line: &str) -> String {
-    let mut s = line.replace("E<lt>", "<").replace("E<gt>", ">");
-    s = unwrap_simple_pod_formatting(&s);
+    let mut s = unwrap_simple_pod_formatting(line);
+    s = decode_pod_character_escapes(&s);
 
     s.retain(|ch| ch != '\0');
 
@@ -1059,6 +1212,29 @@ mod tests {
         assert_eq!(
             prepare_text_line("The C<$buffer> is modified by C<inflate>. On completion"),
             "The $buffer is modified by inflate. On completion"
+        );
+    }
+
+    #[test]
+    fn test_perl_pod_named_and_numeric_character_escapes_are_decoded() {
+        assert_eq!(
+            decode_pod_character_escapes(
+                "E<AElig>var Bjarnason, JE<ouml>rg, E<0x00D8>ystein, E<47>, E<copy>, E<euro>"
+            ),
+            "Ævar Bjarnason, Jörg, Øystein, /, ©, €"
+        );
+        assert_eq!(decode_pod_character_escapes("E<unknown>"), "E<unknown>");
+        assert_eq!(
+            prepare_text_line("E<AElig>var Bjarnason, JE<ouml>rg, E<0x00D8>ystein"),
+            "Ævar Bjarnason, Jörg, Øystein"
+        );
+    }
+
+    #[test]
+    fn test_perl_pod_double_angle_formatting_is_unwrapped() {
+        assert_eq!(
+            prepare_text_line("Charles Bailey C<< <bailey@example.com> >>"),
+            "Charles Bailey <bailey@example.com>"
         );
     }
 

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/ata/pata_ali.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/ata/pata_ali.c.yml
@@ -17,4 +17,5 @@ holders:
   - CJ, cjtsai@ali.com.tw, Maintainer
   - Michel Aubry, Maintainer
   - Red Hat Inc
-authors: []
+authors:
+  - Clear Zhang <Clear.Zhang@ali.com.tw>

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/ide/alim15x3.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/ide/alim15x3.c.yml
@@ -19,4 +19,5 @@ holders:
   - CJ, cjtsai@ali.com.tw, Maintainer
   - Michel Aubry, Maintainer
   - MontaVista Software, Inc.
-authors: []
+authors:
+  - Clear Zhang <Clear.Zhang@ali.com.tw>

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/staging/comedi/drivers/ni_atmio.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/staging/comedi/drivers/ni_atmio.c.yml
@@ -6,4 +6,5 @@ copyrights:
   - Copyright (c) 1997-2001 David A. Schleef <ds@schleef.org>
 holders:
   - David A. Schleef
-authors: []
+authors:
+  - Truxton Fulton <trux@truxton.com>


### PR DESCRIPTION
## Summary

- Decode standard POD formatting and character escapes before copyright and author detection, preserving unknown escapes instead of guessing.
- Keep decoded contact-backed attributions within sentence and attribution boundaries, including wrapped and conjoined credits.
- Drop POD section-heading copyright variants when the same complete notice is already represented on its source line.

## Issues

- Covers: #1391 follow-up hardening from the Perl and Info-ZIP benchmark audit.

## Scope and exclusions

- Included: copyright text preparation, author evidence extraction/cleanup, POD heading deduplication, focused detector tests, and three source-backed golden author additions.
- Explicit exclusions: package/license parity differences and unrelated author patterns identified by the broader Perl comparison; those are handled in later stacked changes.

## How to verify

- Run `cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --target-path <perl-5.38.4> --profile common` and inspect the generated ScanCode-favored queue. POD identities should be decoded (`Ævar`, `König`, clean angle-email contacts), while ScanCode retains malformed `E`/`C` fragments.
- Scan Perl 5.38.4 and verify that POD section headings no longer produce wider duplicate copyright records; Info-ZIP 3.0 should have no author, copyright, or holder delta from the parent branch.

## Intentional differences from Python

- Provenant decodes standard POD character escapes and double-angle formatting that ScanCode leaves as malformed name/contact fragments.
- Provenant removes redundant POD heading-spanning copyright variants when the final source line already supplies the complete notice.

## Follow-up work

- Created or intentionally deferred: additional generic missing-author and placeholder cleanup patterns found by the full common-profile Perl comparison are being handled in subsequent stacked PRs.

## Expected-output fixture changes

- Files changed: `pata_ali.c.yml`, `alim15x3.c.yml`, and `ni_atmio.c.yml` copyright goldens.
- Why the new expected output is correct: each source contains an explicit contact-backed contribution credit (`support by` or `added by`) that is now retained as author evidence.

## Benchmark evidence

- Perl 5.38.4 common-profile compare run: `.provenant/compare-runs/20260902T233209Z-perl-5.38.4-23143` (6,493 files; Provenant 27.46s, ScanCode 1,041.32s; zero scanner errors).
- Against the parent branch's copyright scan, Provenant removes 119 old copyright records and adds three corrected decoded records; 116 removals are malformed POD renderings or redundant heading/wider-span records. Holder changes are three corrected values plus one malformed duplicate removal.
- The same before/after scan adds or enriches source-backed Perl authors, including `Ævar Arnfjörð Bjarmason`, `Andreas König`, POD contact identities, and wrapped attribution chains. Info-ZIP 3.0 is unchanged across authors, copyrights, and holders.

---

🤖 Generated with [Claude Code](https://claude.ai/code)
