### PR TITLE
fix(copyright): preserve explicit subject authors

### DIFF
--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -335,6 +335,35 @@ pub(in super::super) fn drop_same_span_contact_sentence_overruns(
     });
 }
 
+pub(in super::super) fn drop_shadowed_contribution_author_prefixes(
+    authors: &mut Vec<AuthorDetection>,
+) {
+    if authors.len() < 2 {
+        return;
+    }
+    let originals = authors.clone();
+    authors.retain(|author| {
+        let candidate = author.author.trim();
+        !originals.iter().any(|other| {
+            if other.start_line != author.start_line
+                || other.end_line.get() < author.end_line.get()
+                || other.author.len() <= candidate.len()
+            {
+                return false;
+            }
+            let Some(tail) = other.author.trim().strip_prefix(candidate) else {
+                return false;
+            };
+            let tail = tail
+                .trim_start_matches([',', ';'])
+                .trim_start()
+                .to_ascii_lowercase();
+            tail.starts_with("with contributions from ")
+                || tail.starts_with("and contributions from ")
+        })
+    });
+}
+
 pub(in super::super) fn drop_shadowed_compound_email_authors(authors: &mut Vec<AuthorDetection>) {
     if authors.is_empty() {
         return;

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -471,6 +471,72 @@ pub(in super::super) fn extract_line_local_attribution_authors(
         .collect()
 }
 
+pub(in super::super) fn extract_subject_attribution_authors(
+    prepared_cache: &PreparedLines<'_>,
+) -> Vec<AuthorDetection> {
+    static SUBJECT_ATTRIBUTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)\b(?:was|were|is|are|has\s+been|have\s+been)\s+(?:originally\s+)?(?:written|created|authored|developed|maintained)\s+by\s+(?P<who>.+)$",
+        )
+        .unwrap()
+    });
+    static POD_AUTHOR_HEADING_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^=head\d+\s+authors?\s*$").unwrap());
+    static POD_HEADING_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^=head\d+\b").unwrap());
+    static NON_AUTHOR_CLAUSE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)\s+and\s+(?:on|upon|for)\s+(?:which|whom)\b.*$").unwrap()
+    });
+    static BARE_EMAIL_SENTENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^(?P<head>.*\b[\w.+-]+@[\w.-]+\.[a-z]{2,})(?:\.\s+|;\s+).*$").unwrap()
+    });
+
+    let mut authors = Vec::new();
+    let mut in_pod_author_section = false;
+    for line in prepared_cache.iter_non_empty() {
+        let prepared = line.prepared.trim();
+        if POD_HEADING_RE.is_match(prepared) {
+            in_pod_author_section = POD_AUTHOR_HEADING_RE.is_match(prepared);
+            continue;
+        }
+        let Some(captures) = SUBJECT_ATTRIBUTION_RE.captures(prepared) else {
+            continue;
+        };
+        let Some(raw_who) = captures.name("who").map(|matched| matched.as_str().trim()) else {
+            continue;
+        };
+        let lower = raw_who.to_ascii_lowercase();
+        let has_contact = raw_who.contains('@')
+            || raw_who.contains('<')
+            || (lower.contains(" at ") && lower.contains(" dot "));
+        if !has_contact && !in_pod_author_section {
+            continue;
+        }
+
+        let mut who = NON_AUTHOR_CLAUSE_RE.replace(raw_who, "").into_owned();
+        if let Some(contact_end) = who.find('>') {
+            let tail = who[contact_end + 1..].trim_start();
+            if tail.starts_with('.') || tail.starts_with(';') {
+                who.truncate(contact_end + 1);
+            }
+        } else if let Some(captures) = BARE_EMAIL_SENTENCE_RE.captures(&who)
+            && let Some(head) = captures.name("head")
+        {
+            who = head.as_str().to_string();
+        }
+        let who = trim_attribution_tail(&who);
+        let Some(author) = refine_author(&who) else {
+            continue;
+        };
+        authors.push(AuthorDetection {
+            author,
+            start_line: line.line_number,
+            end_line: line.line_number,
+        });
+    }
+    authors
+}
+
 pub(in super::super) fn repair_chained_attribution_authors(
     prepared_cache: &PreparedLines<'_>,
     authors: &mut Vec<AuthorDetection>,

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -377,6 +377,64 @@ fn test_passive_creation_keeps_person_and_contact_backed_authors() {
 }
 
 #[test]
+fn test_subject_attribution_keeps_contact_backed_people() {
+    let input = concat!(
+        "under the same terms as Perl itself.\n",
+        "\n",
+        "This program is distributed in the hope that it will be useful, but\n",
+        "without any warranty; without even the implied warranty of\n",
+        "merchantability or fitness for a particular purpose.\n",
+        "\n",
+        "=head1 AUTHOR\n",
+        "\n",
+        "Pod::Simple was created by Sean M. Burke <sburke@cpan.org>.\n",
+        "But don't bother him, he's retired.\n",
+        "\n",
+        "Pod::Simple is maintained by:\n",
+        "\n",
+        "=over\n",
+        "\n",
+        "=item * Allison Randal C<allison@perl.org>\n",
+        "\n",
+        "=back\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(
+        values.contains(&"Sean M. Burke <sburke@cpan.org>"),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_subject_attribution_uses_bounded_pod_author_section() {
+    let input = concat!(
+        "=head1 AUTHORS\n",
+        "\n",
+        "Test::Harness 2.64 is maintained by Andy Lester and on which this module is based.\n",
+        "\n",
+        "=head1 DESCRIPTION\n",
+        "\n",
+        "Archives were created by Release Tool 2.0.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(values.contains(&"Andy Lester"), "authors: {values:?}");
+    assert!(
+        values.iter().all(|author| !author.contains("Release Tool")),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
 fn test_extract_comment_author_label_authors_detects_doxygen_author_tags() {
     let raw_lines = vec![
         "*> \\author Univ. of California Berkeley",
@@ -1485,6 +1543,35 @@ fn test_pod_contact_author_stops_at_following_sentence() {
         .collect();
 
     assert_eq!(values, vec!["Dan Kogai <dankogai@cpan.org>"]);
+}
+
+#[test]
+fn test_contribution_author_chain_drops_shadowed_prefix() {
+    let input = concat!(
+        "=head1 AUTHOR\n",
+        "\n",
+        "Pod::Simple::JustPod was developed by John SJ Anderson\n",
+        "C<genehack@genehack.org>, with contributions from Karl Williamson\n",
+        "C<khw@cpan.org>.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(
+        values.contains(
+            &"John SJ Anderson genehack@genehack.org, with contributions from Karl Williamson khw@cpan.org"
+        ),
+        "authors: {values:?}"
+    );
+    assert!(
+        values
+            .iter()
+            .all(|author| *author != "John SJ Anderson genehack@genehack.org"),
+        "authors: {values:?}"
+    );
 }
 
 #[test]

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -485,6 +485,7 @@ pub fn detect_copyrights_from_text_with_deadline(
     authors.extend(final_line_local_authors);
     author_heuristics::repair_chained_attribution_authors(&prepared_lines, &mut authors);
     author_heuristics::drop_same_span_contact_sentence_overruns(&mut authors);
+    author_heuristics::drop_shadowed_contribution_author_prefixes(&mut authors);
 
     dedupe_exact_span_holders(&mut holders);
 

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -153,6 +153,10 @@ fn run_author_extraction_and_repairs(
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
 
+    let mut new_a = super::author_heuristics::extract_subject_attribution_authors(prepared_cache);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
     let a_before = authors.len();
     super::author_heuristics::extract_multiline_written_by_author_blocks(prepared_cache, authors);
     seen.dedup_new_authors(authors, a_before);

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -33,6 +33,7 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = truncate_omap_dual_mode_clause(&a);
     a = strip_initials_before_angle_email(&a);
     a = normalize_obfuscated_angle_contact(&a);
+    a = collapse_repeated_angle_contact(&a);
     a = strip_trailing_year_after_angle_email(&a);
     a = strip_trailing_comma_year(&a);
     a = strip_trailing_comma_month_year(&a);
@@ -121,6 +122,29 @@ fn contains_obfuscated_angle_contact(s: &str) -> bool {
         LazyLock::new(|| Regex::new(r"(?i)<\s*(?P<inner>[^<>]*\bat\b[^<>]*)\s*>").unwrap());
 
     OBFUSCATED_ANGLE_CONTACT_RE.is_match(s)
+}
+
+fn collapse_repeated_angle_contact(s: &str) -> String {
+    static ANGLE_CONTACT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<([^<>]+)>").unwrap());
+
+    ANGLE_CONTACT_RE
+        .replace_all(s, |captures: &regex::Captures<'_>| {
+            let body = captures.get(1).map_or("", |matched| matched.as_str());
+            let contacts: Vec<&str> = body.split_whitespace().collect();
+            if contacts.len() > 1
+                && contacts.iter().all(|contact| contact.contains('@'))
+                && contacts
+                    .windows(2)
+                    .all(|pair| pair[0].eq_ignore_ascii_case(pair[1]))
+            {
+                format!("<{}>", contacts[0])
+            } else {
+                captures
+                    .get(0)
+                    .map_or_else(String::new, |matched| matched.as_str().to_string())
+            }
+        })
+        .into_owned()
 }
 
 /// Strip a trailing parenthesized angle-bracketed email contact from an author

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -261,6 +261,14 @@ fn test_refine_author_keeps_conjoined_name_after_contact() {
 }
 
 #[test]
+fn test_refine_author_collapses_repeated_angle_contact() {
+    assert_eq!(
+        refine_author("David Sundstrom <sunds@example.com sunds@example.com>"),
+        Some("David Sundstrom <sunds@example.com>".to_string())
+    );
+}
+
+#[test]
 fn test_refine_author_truncates_prose_sentence_after_a_name() {
     assert_eq!(
         refine_author(

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -136,7 +136,10 @@ pub(super) fn extract_copyright_information(
     authors.retain(|author| {
         let raw_span = render_raw_span(&raw_lines, author.start_line, author.end_line);
         !is_binary_garbage_party_value(&author.author)
-            && !detection_is_source_code(&author.author, &raw_span)
+            && !looks_like_source_code(&author.author)
+            && (!looks_like_source_code(&raw_span)
+                || (has_author_contact_evidence(&author.author)
+                    && raw_span_has_author_attribution(&raw_span)))
             && seen_authors.insert((author.author.clone(), author.start_line, author.end_line))
     });
 
@@ -399,6 +402,19 @@ fn render_raw_span(raw_lines: &[&str], start_line: LineNumber, end_line: LineNum
 /// obviously source code, so it should be dropped from output.
 fn detection_is_source_code(value: &str, raw_span: &str) -> bool {
     looks_like_source_code(value) || looks_like_source_code(raw_span)
+}
+
+pub(super) fn has_author_contact_evidence(author: &str) -> bool {
+    if author.contains('@') {
+        return true;
+    }
+    let lower = author.to_ascii_lowercase();
+    lower.contains(" at ") && lower.contains(" dot ")
+}
+
+fn raw_span_has_author_attribution(raw_span: &str) -> bool {
+    static BY_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)\bby\b").unwrap());
+    BY_RE.is_match(raw_span)
 }
 
 fn project_wrapped_copyright_value(rendered: &str, fallback: &str) -> Option<String> {

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1164,6 +1164,27 @@ fn test_extract_copyright_information_keeps_real_notice_and_name_with_email() {
 }
 
 #[test]
+fn test_extract_copyright_information_keeps_attributed_author_after_namespace() {
+    let text = "Pod::Simple was created by Sean M. Burke <sburke@cpan.org>.\n";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("Simple.pm"), text, 120.0, false);
+
+    let file = build_single_file(builder);
+    assert_eq!(file.authors.len(), 1, "authors: {:?}", file.authors);
+    assert_eq!(file.authors[0].author, "Sean M. Burke <sburke@cpan.org>");
+}
+
+#[test]
+fn test_extract_copyright_information_rejects_author_in_source_container() {
+    let text = "$is_list->( authors => [ q{Michael G Schwern <schwern@pobox.com>} ] );\n";
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("basic.t"), text, 120.0, false);
+
+    let file = build_single_file(builder);
+    assert!(file.authors.is_empty(), "authors: {:?}", file.authors);
+}
+
+#[test]
 fn test_extract_copyright_information_drops_code_line_with_embedded_email_literal() {
     // A C++ source line whose argument list embeds an email literal must still be
     // rejected: the namespace/address-of code signals are not bypassed by the

--- a/src/scanner/process/license_region_filter.rs
+++ b/src/scanner/process/license_region_filter.rs
@@ -22,15 +22,16 @@
 //!    merely mentions the word mid-sentence (`at the Copyright Holders option
 //!    either a return of any price paid or`) does not, so the marker/year guard
 //!    keeps real notices that sit at the top of (or inside) a LICENSE file.
-//! 2. Holders and authors are bare entity names with no notice marker of their
-//!    own, so they cannot be classified directly. Instead they are anchored to
-//!    the copyrights that survived step 1: a holder/author whose span overlaps a
-//!    preserved copyright is a real attribution and is kept; one that falls in a
-//!    license region with no co-located preserved copyright is license prose
-//!    (`MAKE NO REPRESENTATIONS`, `...and its contributors`) and is dropped.
+//! 2. Holders and authors are normally anchored to the copyrights that survived
+//!    step 1. Contact-backed authors are also kept: an explicit email is bounded
+//!    authorship evidence and avoids dropping an `AUTHOR` section that happens to
+//!    sit inside a coarse license match. Unanchored bare fragments such as `MAKE
+//!    NO REPRESENTATIONS` or `...and its contributors` are still dropped.
 
 use crate::copyright::has_copyright_year;
 use crate::models::FileInfo;
+
+use super::copyright::has_author_contact_evidence;
 
 /// Minimum matched token count for a license match to count as a full
 /// license-text region. Substantial license bodies match well above this
@@ -86,12 +87,13 @@ pub(super) fn suppress_license_text_region_parties(file_info: &mut FileInfo) {
         )
     });
     file_info.authors.retain(|a| {
-        !is_unanchored_party_in_region(
-            &regions,
-            &preserved_copyright_ranges,
-            a.start_line.get(),
-            a.end_line.get(),
-        )
+        has_author_contact_evidence(&a.author)
+            || !is_unanchored_party_in_region(
+                &regions,
+                &preserved_copyright_ranges,
+                a.start_line.get(),
+                a.end_line.get(),
+            )
     });
 }
 

--- a/src/scanner/process/license_region_filter_test.rs
+++ b/src/scanner/process/license_region_filter_test.rs
@@ -108,6 +108,24 @@ fn drops_year_free_party_inside_license_body_region() {
 }
 
 #[test]
+fn keeps_contact_backed_author_inside_license_body_region() {
+    let mut file_info = file_info_with_region(107);
+    file_info.authors = vec![Author {
+        author: "Sean M. Burke <sburke@cpan.org>".to_string(),
+        start_line: line(8),
+        end_line: line(8),
+    }];
+
+    suppress_license_text_region_parties(&mut file_info);
+
+    assert_eq!(
+        file_info.authors.len(),
+        1,
+        "contact-backed attribution must survive a coarse license region"
+    );
+}
+
+#[test]
 fn keeps_real_notice_and_its_bare_name_party_inside_license_body_region() {
     let mut file_info = file_info_with_region(107);
     // A genuine embedded copyright notice with a year, inside the region. The

--- a/src/scanner/process/pipeline_test.rs
+++ b/src/scanner/process/pipeline_test.rs
@@ -546,3 +546,57 @@ fn test_process_file_drops_license_prose_parties_but_keeps_real_notice() {
         file_info.authors,
     );
 }
+
+#[test]
+fn test_process_file_keeps_contact_backed_author_inside_license_region() {
+    use crate::license_detection::LicenseDetectionEngine;
+    use std::sync::Arc;
+
+    let fixture = Path::new("testdata/license-golden/datadriven/lic2/bsd-original_1.txt");
+    let source = fs::read_to_string(fixture).expect("read BSD fixture");
+    let source = source.replacen(
+        " * 4. Neither",
+        concat!(
+            " * Pod::Simple was created by Sean M. Burke <sburke@cpan.org>.\n",
+            " *\n",
+            " * 4. Neither",
+        ),
+        1,
+    );
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("license-region-author.c");
+    fs::write(&path, source).expect("write synthetic source");
+
+    let engine =
+        Arc::new(LicenseDetectionEngine::from_embedded().expect("embedded engine should load"));
+    let metadata = fs::metadata(&path).expect("metadata");
+    let progress = ScanProgress::new(ProgressMode::Quiet);
+    let file_info = process_file(
+        &path,
+        &metadata,
+        &progress,
+        Some(engine),
+        LicenseScanOptions::default(),
+        &TextDetectionOptions::default(),
+    );
+
+    assert!(
+        file_info.license_detections.iter().any(|detection| {
+            detection.matches.iter().any(|matched| {
+                matched.start_line.get() <= 22
+                    && matched.end_line.get() >= 22
+                    && matched.matched_length.unwrap_or(0) >= 80
+            })
+        }),
+        "synthetic attribution must overlap a license-body region: {:?}",
+        file_info.license_detections,
+    );
+    assert!(
+        file_info
+            .authors
+            .iter()
+            .any(|author| author.author == "Sean M. Burke <sburke@cpan.org>"),
+        "contact-backed author dropped: {:?}",
+        file_info.authors,
+    );
+}


### PR DESCRIPTION
## Summary

- Extract passive subject attributions such as `Widget was created by Person` when bounded by contact evidence or a POD author section.
- Preserve contact-backed author detections through coarse license-region and source-code filters without allowing source metadata containers through.
- Collapse repeated POD contacts and shadowed contribution-prefix variants exposed by the broader evidence flow.

## Issues

- Covers: follow-up findings from #1391

## Scope and exclusions

- Included: author extraction and downstream evidence filters for explicit passive attributions.
- Explicit exclusions: unrelated changelog attribution gaps and remaining malformed/template author cleanup, which are being handled in later stacked branches.

## How to verify

- Scan Perl 5.38.4 with `provenant --copyright --json out.json perl-5.38.4` and inspect `cpan/Pod-Simple`: 23 source-backed Sean M. Burke creator records and the Allison Randal XHTML creator record should be present. Across the full tree, the branch adds 37 source-backed authors with no copyright or holder changes. The InfoZIP 3.0 control scan remains unchanged in all three fields.

## Intentional differences from Python

- ScanCode is used as a discovery signal, but the implementation requires bounded attribution/contact evidence and continues to reject source containers such as Perl `authors => [ q{...} ]` metadata.

## Follow-up work

- Created or intentionally deferred: additional generic changelog/contribution attribution coverage and cleanup of pre-existing malformed/template author values remain in the stack.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: no expected-output fixtures require updates; detector, scanner pipeline, golden, and real-repository comparisons cover the behavior.

---

Generated with [Claude Code](https://claude.ai/code)
