### PR TITLE
fix(copyright): recover contact-backed change credits

### DIFF
--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -335,9 +335,7 @@ pub(in super::super) fn drop_same_span_contact_sentence_overruns(
     });
 }
 
-pub(in super::super) fn drop_shadowed_contribution_author_prefixes(
-    authors: &mut Vec<AuthorDetection>,
-) {
+pub(in super::super) fn drop_shadowed_author_prefixes(authors: &mut Vec<AuthorDetection>) {
     if authors.len() < 2 {
         return;
     }
@@ -354,12 +352,17 @@ pub(in super::super) fn drop_shadowed_contribution_author_prefixes(
             let Some(tail) = other.author.trim().strip_prefix(candidate) else {
                 return false;
             };
-            let tail = tail
+            let tail = tail.trim_start();
+            let normalized_tail = tail
                 .trim_start_matches([',', ';'])
                 .trim_start()
                 .to_ascii_lowercase();
-            tail.starts_with("with contributions from ")
-                || tail.starts_with("and contributions from ")
+            (other.end_line == author.end_line
+                && (tail.starts_with(',')
+                    || tail.starts_with(';')
+                    || normalized_tail.starts_with("and ")))
+                || normalized_tail.starts_with("with contributions from ")
+                || normalized_tail.starts_with("and contributions from ")
         })
     });
 }

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -238,6 +238,26 @@ fn trim_attribution_tail(who: &str) -> String {
     }
 }
 
+fn trim_contact_attribution_suffix(who: &str) -> String {
+    static CONTACT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)(?:<[^>\s]+@[^>\s]+>|\b[\w.+-]+@[\w.-]+\.[a-z]{2,})").unwrap()
+    });
+    static NON_AUTHOR_SUFFIX_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^(?:(?:on\s+)?\d|in\s+\d{4}\b|for\s+\p{L})").unwrap());
+
+    let Some(contact) = CONTACT_RE.find_iter(who).last() else {
+        return who.to_string();
+    };
+    let tail = who[contact.end()..]
+        .trim_start_matches([',', ';'])
+        .trim_start();
+    if !tail.is_empty() && NON_AUTHOR_SUFFIX_RE.is_match(tail) {
+        who[..contact.end()].trim().to_string()
+    } else {
+        who.to_string()
+    }
+}
+
 fn trim_following_sentence_clause(who: &str) -> String {
     static FOLLOWING_SENTENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?is)^(?P<head>.+?)\.\s+(?:it|this|these|those|the|a|an|no)\b.*$").unwrap()
@@ -385,6 +405,12 @@ fn extract_line_local_attribution_author(
         )
         .unwrap()
     });
+    static CONTACT_CHANGE_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)\b(?:backport(?:ed)?|changes?|fix(?:ed)?|reported|suggested|added|updated|modified|revised|overhauled|implemented|futzed|tweaked|threaded|enabled|done)\b[^\r\n]{0,120}?\bby\s+(?P<who>.+(?:@|\s+at\s+.+\s+dot\s+).*)$",
+        )
+        .unwrap()
+    });
     static COPYRIGHT_TAIL_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\s*(?:,\s*copyright\b|\(c\)\s*\d{4})\b.*$").unwrap());
     static CONTACT_SENTENCE_TAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -401,7 +427,8 @@ fn extract_line_local_attribution_author(
     }
     let captures = ACTION_BY_RE
         .captures(normalized)
-        .or_else(|| CONTACT_CONTRIBUTION_BY_RE.captures(normalized))?;
+        .or_else(|| CONTACT_CONTRIBUTION_BY_RE.captures(normalized))
+        .or_else(|| CONTACT_CHANGE_BY_RE.captures(normalized))?;
     let who = captures.name("who")?.as_str().trim();
     let has_contact = who.contains('@')
         || who.contains('<')
@@ -416,6 +443,7 @@ fn extract_line_local_attribution_author(
         .captures(&who)
         .and_then(|captures| captures.name("head").map(|head| head.as_str().to_string()))
         .unwrap_or_else(|| who.into_owned());
+    let who = trim_contact_attribution_suffix(&who);
     let who = trim_attribution_tail(&who);
     let who = who.find('>').map_or(who.as_str(), |contact_end| {
         let tail = who[contact_end + 1..].trim_start();
@@ -436,7 +464,7 @@ fn extract_line_local_attribution_author(
 pub(in super::super) fn extract_line_local_attribution_authors(
     prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
-    prepared_cache
+    let mut authors: Vec<AuthorDetection> = prepared_cache
         .iter_non_empty()
         .filter_map(|line| {
             let author =
@@ -468,7 +496,61 @@ pub(in super::super) fn extract_line_local_attribution_authors(
                 end_line: line.line_number,
             })
         })
-        .collect()
+        .collect();
+
+    for (line, next_line) in prepared_cache.adjacent_pairs() {
+        let first = line.prepared.trim_end();
+        let next = next_line.prepared.trim();
+        let first_lower = first.to_ascii_lowercase();
+        let has_by_boundary = first_lower.contains(" by ") || first_lower.ends_with(" by");
+        if first.contains('@') || !next.contains('@') || !has_by_boundary {
+            continue;
+        }
+        let attributed_party = if first_lower.ends_with(" by") {
+            ""
+        } else {
+            let Some((_, attributed_party)) = first_lower.rsplit_once(" by ") else {
+                continue;
+            };
+            attributed_party
+        };
+        if attributed_party.split_whitespace().count() > 6 {
+            continue;
+        }
+        let next = if next.starts_with('<') {
+            next.find('>').map_or(next, |end| &next[..=end])
+        } else {
+            next
+        };
+        if next
+            .split_whitespace()
+            .filter(|word| word.chars().any(|ch| ch.is_alphanumeric()))
+            .count()
+            > 3
+        {
+            continue;
+        }
+        let bare_contact = next.trim_end_matches('.');
+        let joined = if bare_contact.contains('@') && !bare_contact.contains(char::is_whitespace) {
+            if bare_contact.starts_with('<') && bare_contact.ends_with('>') {
+                format!("{first} {bare_contact}")
+            } else {
+                format!("{first} <{bare_contact}>")
+            }
+        } else {
+            format!("{first} {next}")
+        };
+        let Some(author) = extract_line_local_attribution_author(&joined, false) else {
+            continue;
+        };
+        authors.push(AuthorDetection {
+            author,
+            start_line: line.line_number,
+            end_line: next_line.line_number,
+        });
+    }
+
+    authors
 }
 
 pub(in super::super) fn extract_subject_attribution_authors(

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -435,6 +435,111 @@ fn test_subject_attribution_uses_bounded_pod_author_section() {
 }
 
 #[test]
+fn test_contact_backed_change_attributions_cover_varied_actions() {
+    let input = concat!(
+        "- Updated backport to 5.6.1 by Steffen Mueller <smueller@cpan.org>.\n",
+        "- Fix suggested by Joel C. Maslak <jmaslak@example.net>.\n",
+        "# Threaded by Jarkko Hietaniemi <jhi@example.net> on 11/18/97\n",
+        "sdbm_exists added to the library by Russ Allbery <rra@example.net>.\n",
+        "Float and double added by gnb@example.net 22/11/89\n",
+        "This fix provided by akt@example.net for Japanese.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    for expected in [
+        "Steffen Mueller <smueller@cpan.org>",
+        "Joel C. Maslak <jmaslak@example.net>",
+        "Jarkko Hietaniemi <jhi@example.net>",
+        "Russ Allbery <rra@example.net>",
+        "gnb@example.net",
+        "akt@example.net",
+    ] {
+        assert!(values.contains(&expected), "missing {expected}: {values:?}");
+    }
+}
+
+#[test]
+fn test_contact_backed_change_attribution_wraps_onto_next_line() {
+    let input = concat!(
+        "Additional portability changes by Andy Dougherty\n",
+        "doughera@example.net.\n",
+        "This work was all done by Roderick Schertler\n",
+        "<roderick@example.net>. If you run Linux, thank him.\n",
+        "Fix suggested by\n",
+        "Slaven Rezic <slaven@example.net>.\n",
+    );
+    let raw_lines: Vec<&str> = input.lines().collect();
+    let prepared = PreparedLineCache::new(&raw_lines).materialize();
+    let extracted = extract_line_local_attribution_authors(&prepared);
+    assert!(
+        extracted
+            .iter()
+            .any(|author| author.author == "Andy Dougherty <doughera@example.net>"),
+        "direct authors: {extracted:?}"
+    );
+    assert!(
+        extracted
+            .iter()
+            .any(|author| author.author == "Slaven Rezic <slaven@example.net>"),
+        "prepared: {:?}; direct authors: {extracted:?}",
+        prepared
+            .iter()
+            .map(|line| line.prepared.to_string())
+            .collect::<Vec<_>>()
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(
+        values.contains(&"Andy Dougherty <doughera@example.net>"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Roderick Schertler <roderick@example.net>"),
+        "authors: {values:?}"
+    );
+    assert!(
+        values.contains(&"Slaven Rezic <slaven@example.net>"),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_contact_backed_non_author_by_phrases_are_not_authors() {
+    let input = concat!(
+        "This package is distributed by Example Support <support@example.net>.\n",
+        "The service is owned by Example Corp <legal@example.net>.\n",
+        "Send reports by email to bugs@example.net.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_wrapped_affiliation_contact_does_not_extend_author() {
+    let input = concat!(
+        "Written by Joe Meadows Jr, at the Fred Hutchinson Cancer Research Center\n",
+        "BITNET: JOE@FHCRCVAX\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(
+        authors
+            .iter()
+            .all(|author| !author.author.contains("Cancer Research Center")),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
 fn test_extract_comment_author_label_authors_detects_doxygen_author_tags() {
     let raw_lines = vec![
         "*> \\author Univ. of California Berkeley",
@@ -1572,6 +1677,31 @@ fn test_contribution_author_chain_drops_shadowed_prefix() {
             .all(|author| *author != "John SJ Anderson genehack@genehack.org"),
         "authors: {values:?}"
     );
+}
+
+#[test]
+fn test_same_span_author_list_drops_shadowed_prefix() {
+    let mut authors = vec![
+        AuthorDetection {
+            author: "Ken Williams <ken@example.net>".to_string(),
+            start_line: LineNumber::new(3).expect("line"),
+            end_line: LineNumber::new(4).expect("line"),
+        },
+        AuthorDetection {
+            author: concat!(
+                "Ken Williams <ken@example.net>, ",
+                "Randy Sims <randy@example.net>"
+            )
+            .to_string(),
+            start_line: LineNumber::new(3).expect("line"),
+            end_line: LineNumber::new(4).expect("line"),
+        },
+    ];
+
+    drop_shadowed_author_prefixes(&mut authors);
+
+    assert_eq!(authors.len(), 1, "authors: {authors:?}");
+    assert!(authors[0].author.contains("Randy Sims"));
 }
 
 #[test]

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -485,7 +485,7 @@ pub fn detect_copyrights_from_text_with_deadline(
     authors.extend(final_line_local_authors);
     author_heuristics::repair_chained_attribution_authors(&prepared_lines, &mut authors);
     author_heuristics::drop_same_span_contact_sentence_overruns(&mut authors);
-    author_heuristics::drop_shadowed_contribution_author_prefixes(&mut authors);
+    author_heuristics::drop_shadowed_author_prefixes(&mut authors);
 
     dedupe_exact_span_holders(&mut holders);
 

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -1471,7 +1471,7 @@ fn truncate_trailing_clause_after_contact(s: &str) -> String {
     let tail_lower = prose_tail.to_ascii_lowercase();
     let prose_like_tail = [
         "the ", "a ", "an ", "i ", "since ", "this ", "these ", "those ", "is ", "was ", "visit ",
-        "for ", "from ",
+        "for ", "from ", "in ", "on ",
     ]
     .iter()
     .any(|prefix_text| tail_lower.starts_with(prefix_text));

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -246,6 +246,10 @@ fn test_refine_author_truncates_trailing_prose_after_contact() {
         refine_author("Jean-Loup Gailly <gzip@prep.ai.mit.edu> . Since this"),
         Some("Jean-Loup Gailly <gzip@prep.ai.mit.edu>".to_string())
     );
+    assert_eq!(
+        refine_author("Charles Bailey <bailey@example.net> in 1996"),
+        Some("Charles Bailey <bailey@example.net>".to_string())
+    );
 }
 
 #[test]

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/net/ethernet/dec/tulip/de4x5.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/net/ethernet/dec/tulip/de4x5.c.yml
@@ -9,6 +9,7 @@ holders:
 authors:
   - <Austin.Donnelly@cl.cam.ac.uk>
   - <Matt_Domsch@dell.com>
+  - <Piete.Brooks@cl.cam.ac.uk>
   - <belliott@accessone.com>
   - <bhat@mundook.cs.mu.OZ.AU>
   - <bkm@star.rl.ac.uk>

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/staging/rtl8192e/rtllib.h.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/staging/rtl8192e/rtllib.h.yml
@@ -12,4 +12,5 @@ holders:
   - Jouni Malinen
   - SSH Communications Security Corp and Jouni Malinen
   - the original
-authors: []
+authors:
+  - Andrea Merello <andrea.merello@gmail.com>

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/staging/rtl8192u/ieee80211/ieee80211.h.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/staging/rtl8192u/ieee80211/ieee80211.h.yml
@@ -12,4 +12,5 @@ holders:
   - Jouni Malinen
   - SSH Communications Security Corp and Jouni Malinen
   - the original
-authors: []
+authors:
+  - Andrea Merello <andrea.merello@gmail.com>

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/usb/serial/spcp8x5.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/drivers/usb/serial/spcp8x5.c.yml
@@ -10,4 +10,5 @@ holders:
   - Johan Hovold
   - Linxb
   - S1 Corp.
-authors: []
+authors:
+  - Harald Klein hari@vt100.at

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/net/sunrpc/xprtsock.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/net/sunrpc/xprtsock.c.yml
@@ -13,4 +13,5 @@ holders:
   - Red Hat TCP
   - Red Hat TCP NFS related read
   - Trond Myklebust
-authors: []
+authors:
+  - Gilles Quillard, Bull Open Source, 2005. <gilles.quillard@bull.net>


### PR DESCRIPTION
## Summary

- Recover contact-backed change credits across changelogs, README prose, POD, and source comments for actions such as fixes, backports, modifications, and reported/suggested work.
- Join a short attributed name with a contact on the following line while bounding affiliation and sentence tails.
- Prefer complete same-span author lists and retain clean contact/date boundaries.

## Issues

- Covers: follow-up findings from #1391

## Scope and exclusions

- Included: explicit `... by ...` change/contribution evidence with a contact on the same or immediately following line.
- Explicit exclusions: structured metadata author gaps and cleanup of unrelated pre-existing malformed/template authors.

## How to verify

- Scan Perl 5.38.4 with `provenant --copyright --json out.json perl-5.38.4`. Relative to #1404, this adds 50 source-backed author records and replaces three bare-name/contact records with more complete contact-backed values. It recovers all missing benchmark credits in `dist/Data-Dumper/Changes`, `dist/Time-HiRes/Changes`, `ext/SDBM_File/README.too`, and `hints/irix_6.sh`. Copyrights and holders are unchanged; the InfoZIP 3.0 control scan is unchanged in all three fields.

## Intentional differences from Python

- The extractor requires a bounded contribution/change action plus contact evidence. It does not inherit ScanCode's unrelated prose, filenames, URLs, and code-token author false positives found in the same comparison.

## Follow-up work

- Created or intentionally deferred: structured metadata author coverage and remaining malformed/template author cleanup remain in later stacked branches.

## Expected-output fixture changes

- Files changed: five Linux copyright golden YAML files for `de4x5.c`, two Realtek `ieee80211` headers, `spcp8x5.c`, and `xprtsock.c`.
- Why the new expected output is correct: each fixture contains the newly reported person/contact in an explicit `reported by`, `Modified ... by`, `Changes ... by`, or `contributed by` source attribution.

---

Generated with [Claude Code](https://claude.ai/code)
