### PR TITLE
fix(copyright): extract JSON author arrays

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use std::sync::LazyLock;
 
 use regex::Regex;
+use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use super::super::token_utils::normalize_whitespace;
 use super::{
@@ -3136,6 +3137,147 @@ pub(in super::super) fn extract_json_author_object_authors(
     }
 
     authors
+}
+
+fn json_key_opens_code_or_schema_context(key: &str) -> bool {
+    key.starts_with('$')
+        || matches!(
+            key.to_ascii_lowercase().as_str(),
+            "example"
+                | "examples"
+                | "expectedstages"
+                | "filter"
+                | "pipeline"
+                | "pipelines"
+                | "properties"
+                | "query"
+                | "schema"
+        )
+}
+
+fn json_object_has_package_metadata(object: &JsonMap<String, JsonValue>) -> bool {
+    object.keys().any(|key| {
+        matches!(
+            key.to_ascii_lowercase().as_str(),
+            "abstract"
+                | "bomformat"
+                | "components"
+                | "description"
+                | "distribution_type"
+                | "homepage"
+                | "license"
+                | "licenses"
+                | "name"
+                | "package"
+                | "publisher"
+                | "purl"
+                | "release_status"
+                | "supplier"
+                | "url"
+                | "version"
+        )
+    })
+}
+
+fn collect_json_author_array_values(
+    value: &JsonValue,
+    is_root: bool,
+    in_code_or_schema_context: bool,
+    values: &mut Vec<String>,
+) {
+    match value {
+        JsonValue::Object(object) => {
+            let object_is_metadata = is_root || json_object_has_package_metadata(object);
+            for (key, child) in object {
+                let child_is_code_or_schema =
+                    in_code_or_schema_context || json_key_opens_code_or_schema_context(key);
+                let is_author_key =
+                    key.eq_ignore_ascii_case("author") || key.eq_ignore_ascii_case("authors");
+
+                if is_author_key
+                    && object_is_metadata
+                    && !child_is_code_or_schema
+                    && let JsonValue::Array(entries) = child
+                {
+                    for entry in entries {
+                        let candidate = match entry {
+                            JsonValue::String(candidate) => Some(candidate.as_str()),
+                            JsonValue::Object(author) => {
+                                author.get("name").and_then(JsonValue::as_str)
+                            }
+                            _ => None,
+                        };
+                        if let Some(candidate) = candidate {
+                            values.push(candidate.to_string());
+                        }
+                    }
+                }
+
+                collect_json_author_array_values(child, false, child_is_code_or_schema, values);
+            }
+        }
+        JsonValue::Array(entries) => {
+            for entry in entries {
+                collect_json_author_array_values(entry, false, in_code_or_schema_context, values);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Extract independently declared authors from validated JSON author arrays.
+///
+/// Array entries are kept separate because each item is an independent
+/// declaration. Nested query, example, and schema structures are excluded by
+/// their structural path rather than by candidate text.
+pub(in super::super) fn extract_json_author_array_authors(
+    raw_lines: &[&str],
+) -> Vec<AuthorDetection> {
+    if raw_lines.is_empty()
+        || !raw_lines
+            .iter()
+            .any(|line| line.contains("\"author\"") || line.contains("\"authors\""))
+    {
+        return Vec::new();
+    }
+
+    let content = raw_lines.join("\n");
+    let Ok(json) = serde_json::from_str::<JsonValue>(&content) else {
+        return Vec::new();
+    };
+
+    let mut candidates = Vec::new();
+    collect_json_author_array_values(&json, true, false, &mut candidates);
+
+    let mut used_source_lines = HashSet::new();
+    let fallback_source_index = raw_lines
+        .iter()
+        .position(|line| line.contains("\"author\"") || line.contains("\"authors\""))
+        .unwrap_or(0);
+    candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            let context = format!(
+                r#"{{"name":"metadata","author":{}}}"#,
+                serde_json::to_string(&candidate).ok()?
+            );
+            let author = refine_json_author_candidate(&candidate, &context)?;
+            let encoded = serde_json::to_string(&candidate).ok()?;
+            let source_index = raw_lines
+                .iter()
+                .enumerate()
+                .find(|(idx, line)| !used_source_lines.contains(idx) && line.contains(&encoded))
+                .map(|(idx, _)| idx)
+                .unwrap_or(fallback_source_index);
+            used_source_lines.insert(source_index);
+            let line = LineNumber::from_0_indexed(source_index);
+            Some(AuthorDetection {
+                author,
+                start_line: line,
+                end_line: line,
+            })
+        })
+        .collect()
 }
 
 pub(in super::super) fn extract_maintained_by_authors(

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -305,6 +305,10 @@ fn run_author_extraction_and_repairs(
     super::author_heuristics::normalize_json_blob_authors(raw_lines, authors);
     seen.authors = authors.iter().map(|a| a.author.clone()).collect();
 
+    let mut new_a = super::author_heuristics::extract_json_author_array_authors(raw_lines);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
     let mut new_a =
         super::postprocess_transforms::extract_following_authors_holders(raw_lines, prepared_cache);
     seen.dedup_new_authors(&mut new_a, 0);

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -208,6 +208,67 @@ fn test_plain_json_author_string_with_parenthesized_url_and_following_key_preser
 }
 
 #[test]
+fn test_json_author_array_emits_independent_authors() {
+    let input = r#"{
+  "name": "example-package",
+  "author": [
+    "Ada Lovelace <ada@example.com>",
+    "Example Toolchain Team"
+  ],
+  "version": "1.0.0"
+}"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert_eq!(
+        authors
+            .iter()
+            .map(|author| (author.author.as_str(), author.start_line.get()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("Ada Lovelace <ada@example.com>", 4),
+            ("Example Toolchain Team", 5),
+        ],
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_json_author_array_keeps_explicit_email_identity() {
+    let input = r#"{
+  "abstract": "An interpreter",
+  "author": ["language-porters@example.org"]
+}"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert_eq!(
+        authors
+            .iter()
+            .map(|author| author.author.as_str())
+            .collect::<Vec<_>>(),
+        vec!["language-porters@example.org"],
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_json_author_array_in_query_or_schema_is_not_file_authorship() {
+    let input = r#"{
+  "name": "query-fixtures",
+  "examples": [
+    {"$match": {"name": "novels", "author": ["Agatha Christie"]}}
+  ],
+  "schema": {
+    "properties": {
+      "author": {"examples": [["Example Person"]]}
+    }
+  }
+}"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_plain_json_author_string_machine_token_dropped_without_metadata_context() {
     let input = r#""author": "makeappicon", "images": []"#;
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);


### PR DESCRIPTION
## Summary

- Parse validated JSON structurally to recover explicit `author` and `authors` arrays.
- Emit each declared array item as an independent author with its source line.
- Exclude query, example, pipeline, and schema subtrees by structural context.

## Issues

- Covers: follow-up findings from #1391

## Scope and exclusions

- Included: JSON author arrays containing strings or `{ "name": ... }` objects in package/metadata objects.
- Explicit exclusions: YAML author arrays, contributor-specific metadata fields, and unrelated prose attribution gaps.

## How to verify

- Scan Perl 5.38.4 with `provenant --copyright --json out.json perl-5.38.4`. Relative to #1405, this adds 35 declared author records across 20 JSON metadata files with no removals and no copyright/holder changes. The InfoZIP 3.0 control scan is unchanged in all three fields.
- Inspect `cpan/CPAN-Meta/t/data-valid/META-2.json`: Provenant emits Ken Williams and the Module-Build List independently, preserving the array's semantics.

## Intentional differences from Python

- ScanCode joins multiple JSON array entries into one author value. Provenant emits one author record per declaration, which preserves the structured source model and is easier to consume.

## Follow-up work

- Created or intentionally deferred: YAML and contributor metadata coverage, explicit prose author sections, and cleanup of pre-existing malformed/template authors remain in later stacked branches.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: existing golden fixtures do not contain validated JSON author arrays; focused tests and the real-corpus comparison cover the new contract.

---

Generated with [Claude Code](https://claude.ai/code)
