### PR TITLE
fix(copyright): extract YAML author arrays

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -9,6 +9,7 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 use serde_json::{Map as JsonMap, Value as JsonValue};
+use yaml_serde::Value as YamlValue;
 
 use super::super::token_utils::normalize_whitespace;
 use super::{
@@ -3139,7 +3140,7 @@ pub(in super::super) fn extract_json_author_object_authors(
     authors
 }
 
-fn json_key_opens_code_or_schema_context(key: &str) -> bool {
+fn structured_key_opens_code_or_schema_context(key: &str) -> bool {
     key.starts_with('$')
         || matches!(
             key.to_ascii_lowercase().as_str(),
@@ -3155,34 +3156,47 @@ fn json_key_opens_code_or_schema_context(key: &str) -> bool {
         )
 }
 
-fn json_object_has_package_metadata(object: &JsonMap<String, JsonValue>) -> bool {
-    object.keys().any(|key| {
-        matches!(
-            key.to_ascii_lowercase().as_str(),
-            "abstract"
-                | "bomformat"
-                | "components"
-                | "description"
-                | "distribution_type"
-                | "homepage"
-                | "license"
-                | "licenses"
-                | "name"
-                | "package"
-                | "publisher"
-                | "purl"
-                | "release_status"
-                | "supplier"
-                | "url"
-                | "version"
-        )
-    })
+fn structured_key_is_package_metadata(key: &str) -> bool {
+    matches!(
+        key.to_ascii_lowercase().as_str(),
+        "abstract"
+            | "bomformat"
+            | "components"
+            | "description"
+            | "distribution_type"
+            | "homepage"
+            | "license"
+            | "licenses"
+            | "name"
+            | "package"
+            | "publisher"
+            | "purl"
+            | "release_status"
+            | "supplier"
+            | "url"
+            | "version"
+    )
 }
 
-fn collect_json_author_array_values(
+fn json_object_has_package_metadata(object: &JsonMap<String, JsonValue>) -> bool {
+    object
+        .keys()
+        .any(|key| structured_key_is_package_metadata(key))
+}
+
+fn refine_structured_metadata_author(candidate: &str) -> Option<String> {
+    let context = format!(
+        r#"{{"name":"metadata","author":{}}}"#,
+        serde_json::to_string(candidate).ok()?
+    );
+    refine_json_author_candidate(candidate, &context)
+}
+
+fn collect_structured_author_values(
     value: &JsonValue,
     is_root: bool,
     in_code_or_schema_context: bool,
+    allow_scalar_value: bool,
     values: &mut Vec<String>,
 ) {
     match value {
@@ -3190,35 +3204,57 @@ fn collect_json_author_array_values(
             let object_is_metadata = is_root || json_object_has_package_metadata(object);
             for (key, child) in object {
                 let child_is_code_or_schema =
-                    in_code_or_schema_context || json_key_opens_code_or_schema_context(key);
+                    in_code_or_schema_context || structured_key_opens_code_or_schema_context(key);
                 let is_author_key =
                     key.eq_ignore_ascii_case("author") || key.eq_ignore_ascii_case("authors");
 
-                if is_author_key
-                    && object_is_metadata
-                    && !child_is_code_or_schema
-                    && let JsonValue::Array(entries) = child
-                {
-                    for entry in entries {
-                        let candidate = match entry {
-                            JsonValue::String(candidate) => Some(candidate.as_str()),
-                            JsonValue::Object(author) => {
-                                author.get("name").and_then(JsonValue::as_str)
+                if is_author_key && object_is_metadata && !child_is_code_or_schema {
+                    match child {
+                        JsonValue::Array(entries) => {
+                            for entry in entries {
+                                let candidate = match entry {
+                                    JsonValue::String(candidate) => Some(candidate.as_str()),
+                                    JsonValue::Object(author) => {
+                                        author.get("name").and_then(JsonValue::as_str)
+                                    }
+                                    _ => None,
+                                };
+                                if let Some(candidate) = candidate {
+                                    values.push(candidate.to_string());
+                                }
                             }
-                            _ => None,
-                        };
-                        if let Some(candidate) = candidate {
+                        }
+                        JsonValue::String(candidate) if allow_scalar_value => {
                             values.push(candidate.to_string());
                         }
+                        JsonValue::Object(author) if allow_scalar_value => {
+                            if let Some(candidate) = author.get("name").and_then(JsonValue::as_str)
+                            {
+                                values.push(candidate.to_string());
+                            }
+                        }
+                        _ => {}
                     }
                 }
 
-                collect_json_author_array_values(child, false, child_is_code_or_schema, values);
+                collect_structured_author_values(
+                    child,
+                    false,
+                    child_is_code_or_schema,
+                    allow_scalar_value,
+                    values,
+                );
             }
         }
         JsonValue::Array(entries) => {
             for entry in entries {
-                collect_json_author_array_values(entry, false, in_code_or_schema_context, values);
+                collect_structured_author_values(
+                    entry,
+                    false,
+                    in_code_or_schema_context,
+                    allow_scalar_value,
+                    values,
+                );
             }
         }
         _ => {}
@@ -3247,7 +3283,7 @@ pub(in super::super) fn extract_json_author_array_authors(
     };
 
     let mut candidates = Vec::new();
-    collect_json_author_array_values(&json, true, false, &mut candidates);
+    collect_structured_author_values(&json, true, false, false, &mut candidates);
 
     let mut used_source_lines = HashSet::new();
     let fallback_source_index = raw_lines
@@ -3257,16 +3293,63 @@ pub(in super::super) fn extract_json_author_array_authors(
     candidates
         .into_iter()
         .filter_map(|candidate| {
-            let context = format!(
-                r#"{{"name":"metadata","author":{}}}"#,
-                serde_json::to_string(&candidate).ok()?
-            );
-            let author = refine_json_author_candidate(&candidate, &context)?;
+            let author = refine_structured_metadata_author(&candidate)?;
             let encoded = serde_json::to_string(&candidate).ok()?;
             let source_index = raw_lines
                 .iter()
                 .enumerate()
                 .find(|(idx, line)| !used_source_lines.contains(idx) && line.contains(&encoded))
+                .map(|(idx, _)| idx)
+                .unwrap_or(fallback_source_index);
+            used_source_lines.insert(source_index);
+            let line = LineNumber::from_0_indexed(source_index);
+            Some(AuthorDetection {
+                author,
+                start_line: line,
+                end_line: line,
+            })
+        })
+        .collect()
+}
+
+fn line_has_yaml_author_key(line: &str) -> bool {
+    let Some((key, _value)) = line.trim_start().split_once(':') else {
+        return false;
+    };
+    key.trim().eq_ignore_ascii_case("author") || key.trim().eq_ignore_ascii_case("authors")
+}
+
+/// Extract independently declared authors from validated YAML author arrays.
+pub(in super::super) fn extract_yaml_metadata_authors(raw_lines: &[&str]) -> Vec<AuthorDetection> {
+    let Some(fallback_source_index) = raw_lines
+        .iter()
+        .position(|line| line_has_yaml_author_key(line))
+    else {
+        return Vec::new();
+    };
+
+    let content = raw_lines.join("\n");
+    let Ok(yaml) = yaml_serde::from_str::<YamlValue>(&content) else {
+        return Vec::new();
+    };
+    let Ok(yaml_as_json) = serde_json::to_value(yaml) else {
+        return Vec::new();
+    };
+
+    let mut candidates = Vec::new();
+    collect_structured_author_values(&yaml_as_json, true, false, false, &mut candidates);
+
+    let mut used_source_lines = HashSet::new();
+    candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            let author = refine_structured_metadata_author(&candidate)?;
+            let source_index = raw_lines
+                .iter()
+                .enumerate()
+                .find(|(idx, line)| {
+                    !used_source_lines.contains(idx) && line.contains(candidate.as_str())
+                })
                 .map(|(idx, _)| idx)
                 .unwrap_or(fallback_source_index);
             used_source_lines.insert(source_index);

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -309,6 +309,10 @@ fn run_author_extraction_and_repairs(
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
 
+    let mut new_a = super::author_heuristics::extract_yaml_metadata_authors(raw_lines);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
+
     let mut new_a =
         super::postprocess_transforms::extract_following_authors_holders(raw_lines, prepared_cache);
     seen.dedup_new_authors(&mut new_a, 0);

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -269,6 +269,46 @@ fn test_json_author_array_in_query_or_schema_is_not_file_authorship() {
 }
 
 #[test]
+fn test_yaml_author_list_emits_independent_authors() {
+    let input = r#"---
+name: example-package
+author:
+  - 'Ada Lovelace <ada@example.com>'
+  - Example Toolchain Team
+version: 1.0.0
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert_eq!(
+        authors
+            .iter()
+            .map(|author| author.author.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Ada Lovelace <ada@example.com>", "Example Toolchain Team"],
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_yaml_author_values_in_examples_are_not_file_authorship() {
+    let input = r#"---
+name: query-fixtures
+examples:
+  - name: novels
+    author:
+      - Agatha Christie
+schema:
+  properties:
+    author:
+      examples:
+        - Example Person
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_plain_json_author_string_machine_token_dropped_without_metadata_context() {
     let input = r#""author": "makeappicon", "images": []"#;
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);


### PR DESCRIPTION
## Summary

- Parse validated YAML metadata structurally and recover independent entries from `author` and `authors` arrays.
- Reuse the JSON structured-author traversal so metadata evidence and code/schema exclusions stay consistent across formats.
- Keep scalar YAML handling on the existing path, avoiding collisions with wheel/RFC822 `Author` fields that permissive YAML parsers also accept.

## Issues

- Covers: follow-up findings from #1391

## Scope and exclusions

- Included: YAML author arrays containing strings or `{ name: ... }` objects in package/metadata mappings.
- Explicit exclusions: scalar author fields already handled by the existing detector, embedded multi-document test formats, and contributor-specific metadata fields.

## How to verify

- Scan Perl 5.38.4 with `provenant --copyright --json out.json perl-5.38.4`. Relative to #1406, this adds 11 declared author records across seven YAML metadata files with no removals and no copyright/holder changes. The InfoZIP 3.0 control scan is unchanged in all three fields.
- Inspect `cpan/CPAN-Meta/t/data-valid/META-1_4.yml`: Provenant emits Ken Williams and the Module-Build List as two independent authors.

## Intentional differences from Python

- ScanCode joins YAML list entries and can absorb the following `abstract` key into a single author. Provenant uses the parsed list boundary and emits one record per declaration.

## Follow-up work

- Created or intentionally deferred: contributor metadata, embedded YAML test documents, explicit prose author sections, and malformed/template author cleanup remain in later stacked branches.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: existing golden fixtures do not contain validated YAML author arrays; focused structural tests and the real-corpus comparison cover the new contract.

---

Generated with [Claude Code](https://claude.ai/code)
