### PR TITLE
fix(copyright): extract structured contributor credits

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -3178,6 +3178,26 @@ fn structured_key_is_package_metadata(key: &str) -> bool {
     )
 }
 
+fn structured_key_declares_authorship(key: &str) -> bool {
+    matches!(
+        key.to_ascii_lowercase().as_str(),
+        "author" | "authors" | "contributor" | "contributors" | "x_contributors"
+    )
+}
+
+fn structured_key_opens_package_inventory_context(key: &str) -> bool {
+    matches!(
+        key.to_ascii_lowercase().as_str(),
+        "bundledependencies"
+            | "bundleddependencies"
+            | "dependencies"
+            | "devdependencies"
+            | "optionaldependencies"
+            | "packages"
+            | "peerdependencies"
+    )
+}
+
 fn json_object_has_package_metadata(object: &JsonMap<String, JsonValue>) -> bool {
     object
         .keys()
@@ -3196,7 +3216,9 @@ fn collect_structured_author_values(
     value: &JsonValue,
     is_root: bool,
     in_code_or_schema_context: bool,
+    in_package_inventory_context: bool,
     allow_scalar_value: bool,
+    collect_excluded_values: bool,
     values: &mut Vec<String>,
 ) {
     match value {
@@ -3205,10 +3227,16 @@ fn collect_structured_author_values(
             for (key, child) in object {
                 let child_is_code_or_schema =
                     in_code_or_schema_context || structured_key_opens_code_or_schema_context(key);
-                let is_author_key =
-                    key.eq_ignore_ascii_case("author") || key.eq_ignore_ascii_case("authors");
+                let child_is_package_inventory = in_package_inventory_context
+                    || structured_key_opens_package_inventory_context(key);
+                let is_credit_key = structured_key_declares_authorship(key);
 
-                if is_author_key && object_is_metadata && !child_is_code_or_schema {
+                let should_collect = if collect_excluded_values {
+                    child_is_code_or_schema || in_package_inventory_context
+                } else {
+                    object_is_metadata && !child_is_code_or_schema && !in_package_inventory_context
+                };
+                if is_credit_key && should_collect {
                     match child {
                         JsonValue::Array(entries) => {
                             for entry in entries {
@@ -3241,7 +3269,9 @@ fn collect_structured_author_values(
                     child,
                     false,
                     child_is_code_or_schema,
+                    child_is_package_inventory,
                     allow_scalar_value,
+                    collect_excluded_values,
                     values,
                 );
             }
@@ -3252,7 +3282,9 @@ fn collect_structured_author_values(
                     entry,
                     false,
                     in_code_or_schema_context,
+                    in_package_inventory_context,
                     allow_scalar_value,
+                    collect_excluded_values,
                     values,
                 );
             }
@@ -3261,18 +3293,22 @@ fn collect_structured_author_values(
     }
 }
 
-/// Extract independently declared authors from validated JSON author arrays.
+/// Extract independent author and contributor credits from validated JSON arrays.
 ///
 /// Array entries are kept separate because each item is an independent
 /// declaration. Nested query, example, and schema structures are excluded by
 /// their structural path rather than by candidate text.
-pub(in super::super) fn extract_json_author_array_authors(
+pub(in super::super) fn extract_json_credit_array_authors(
     raw_lines: &[&str],
 ) -> Vec<AuthorDetection> {
     if raw_lines.is_empty()
-        || !raw_lines
-            .iter()
-            .any(|line| line.contains("\"author\"") || line.contains("\"authors\""))
+        || !raw_lines.iter().any(|line| {
+            line.contains("\"author\"")
+                || line.contains("\"authors\"")
+                || line.contains("\"contributor\"")
+                || line.contains("\"contributors\"")
+                || line.contains("\"x_contributors\"")
+        })
     {
         return Vec::new();
     }
@@ -3283,12 +3319,18 @@ pub(in super::super) fn extract_json_author_array_authors(
     };
 
     let mut candidates = Vec::new();
-    collect_structured_author_values(&json, true, false, false, &mut candidates);
+    collect_structured_author_values(&json, true, false, false, false, false, &mut candidates);
 
     let mut used_source_lines = HashSet::new();
     let fallback_source_index = raw_lines
         .iter()
-        .position(|line| line.contains("\"author\"") || line.contains("\"authors\""))
+        .position(|line| {
+            line.contains("\"author\"")
+                || line.contains("\"authors\"")
+                || line.contains("\"contributor\"")
+                || line.contains("\"contributors\"")
+                || line.contains("\"x_contributors\"")
+        })
         .unwrap_or(0);
     candidates
         .into_iter()
@@ -3312,18 +3354,20 @@ pub(in super::super) fn extract_json_author_array_authors(
         .collect()
 }
 
-fn line_has_yaml_author_key(line: &str) -> bool {
+fn line_has_structured_credit_key(line: &str) -> bool {
     let Some((key, _value)) = line.trim_start().split_once(':') else {
         return false;
     };
-    key.trim().eq_ignore_ascii_case("author") || key.trim().eq_ignore_ascii_case("authors")
+    structured_key_declares_authorship(key.trim().trim_matches(&['\'', '"'][..]))
 }
 
-/// Extract independently declared authors from validated YAML author arrays.
-pub(in super::super) fn extract_yaml_metadata_authors(raw_lines: &[&str]) -> Vec<AuthorDetection> {
+/// Extract independent author and contributor credits from validated YAML arrays.
+pub(in super::super) fn extract_yaml_credit_array_authors(
+    raw_lines: &[&str],
+) -> Vec<AuthorDetection> {
     let Some(fallback_source_index) = raw_lines
         .iter()
-        .position(|line| line_has_yaml_author_key(line))
+        .position(|line| line_has_structured_credit_key(line))
     else {
         return Vec::new();
     };
@@ -3337,7 +3381,15 @@ pub(in super::super) fn extract_yaml_metadata_authors(raw_lines: &[&str]) -> Vec
     };
 
     let mut candidates = Vec::new();
-    collect_structured_author_values(&yaml_as_json, true, false, false, &mut candidates);
+    collect_structured_author_values(
+        &yaml_as_json,
+        true,
+        false,
+        false,
+        false,
+        false,
+        &mut candidates,
+    );
 
     let mut used_source_lines = HashSet::new();
     candidates
@@ -3361,6 +3413,74 @@ pub(in super::super) fn extract_yaml_metadata_authors(raw_lines: &[&str]) -> Vec
             })
         })
         .collect()
+}
+
+/// Drop line-based detections that parsed JSON or YAML places in code/schema
+/// contexts or nested package inventories rather than document-level credits.
+pub(in super::super) fn drop_out_of_scope_structured_credit_authors(
+    raw_lines: &[&str],
+    authors: &mut Vec<AuthorDetection>,
+) {
+    if authors.is_empty()
+        || !raw_lines
+            .iter()
+            .any(|line| line_has_structured_credit_key(line))
+    {
+        return;
+    }
+
+    let content = raw_lines.join("\n");
+    let Ok(yaml) = yaml_serde::from_str::<YamlValue>(&content) else {
+        return;
+    };
+    let Ok(yaml_as_json) = serde_json::to_value(yaml) else {
+        return;
+    };
+
+    let mut excluded_candidates = Vec::new();
+    collect_structured_author_values(
+        &yaml_as_json,
+        true,
+        false,
+        false,
+        true,
+        true,
+        &mut excluded_candidates,
+    );
+    let mut included_candidates = Vec::new();
+    collect_structured_author_values(
+        &yaml_as_json,
+        true,
+        false,
+        false,
+        true,
+        false,
+        &mut included_candidates,
+    );
+    let included: HashSet<String> = included_candidates
+        .into_iter()
+        .filter_map(|candidate| refine_structured_metadata_author(&candidate))
+        .collect();
+    let excluded: Vec<(String, LineNumber)> = excluded_candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            let author = refine_structured_metadata_author(&candidate)?;
+            if included.contains(&author) {
+                return None;
+            }
+            let source_index = raw_lines
+                .iter()
+                .position(|line| line.contains(candidate.as_str()))?;
+            Some((author, LineNumber::from_0_indexed(source_index)))
+        })
+        .collect();
+
+    authors.retain(|author| {
+        !excluded.iter().any(|(excluded_author, source_line)| {
+            author.author == *excluded_author
+                && author.start_line.get().abs_diff(source_line.get()) <= 1
+        })
+    });
 }
 
 pub(in super::super) fn extract_maintained_by_authors(

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -305,13 +305,15 @@ fn run_author_extraction_and_repairs(
     super::author_heuristics::normalize_json_blob_authors(raw_lines, authors);
     seen.authors = authors.iter().map(|a| a.author.clone()).collect();
 
-    let mut new_a = super::author_heuristics::extract_json_author_array_authors(raw_lines);
+    let mut new_a = super::author_heuristics::extract_json_credit_array_authors(raw_lines);
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
 
-    let mut new_a = super::author_heuristics::extract_yaml_metadata_authors(raw_lines);
+    let mut new_a = super::author_heuristics::extract_yaml_credit_array_authors(raw_lines);
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
+    super::author_heuristics::drop_out_of_scope_structured_credit_authors(raw_lines, authors);
+    seen.rebuild_authors_from(authors);
 
     let mut new_a =
         super::postprocess_transforms::extract_following_authors_holders(raw_lines, prepared_cache);

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -309,6 +309,122 @@ schema:
 }
 
 #[test]
+fn test_json_contributor_array_emits_independent_authors() {
+    let input = r#"{
+  "name": "example-package",
+  "contributors": [
+    "Ada Lovelace <ada@example.com>",
+    {"name": "Grace Hopper"}
+  ],
+  "version": "1.0.0"
+}"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert_eq!(
+        authors
+            .iter()
+            .map(|author| author.author.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Ada Lovelace <ada@example.com>", "Grace Hopper"],
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_yaml_extension_contributor_array_emits_independent_authors() {
+    let input = r#"---
+name: example-package
+version: 1.0.0
+x_contributors:
+  - 'Olivier Mengue <olivier@example.com>'
+  - 'Shlomi Fish <shlomi@example.com>'
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert_eq!(
+        authors
+            .iter()
+            .map(|author| author.author.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "Olivier Mengue <olivier@example.com>",
+            "Shlomi Fish <shlomi@example.com>",
+        ],
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_structured_contributor_arrays_in_examples_are_not_file_authorship() {
+    let json = r#"{
+  "name": "fixture-package",
+  "examples": [{"name": "sample", "contributors": ["Example Person"]}]
+}"#;
+    let yaml = r#"---
+name: fixture-package
+examples:
+  - name: sample
+    contributors:
+      - Example Person
+"#;
+
+    for input in [json, yaml] {
+        let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+        assert!(authors.is_empty(), "authors: {authors:?}");
+    }
+}
+
+#[test]
+fn test_nested_package_contributors_are_not_document_authors() {
+    let json = r#"{
+  "name": "lockfile",
+  "packages": {
+    "node_modules/dependency": {
+      "name": "dependency",
+      "version": "1.0.0",
+      "author": "Dependency Author",
+      "contributors": ["Dependency Contributor"]
+    }
+  }
+}"#;
+    let yaml = r#"---
+name: package-inventory
+packages:
+  dependency:
+    name: dependency
+    version: 1.0.0
+    author: Dependency Author
+    contributors:
+      - Dependency Contributor
+"#;
+
+    for input in [json, yaml] {
+        let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+        assert!(authors.is_empty(), "authors: {authors:?}");
+    }
+}
+
+#[test]
+fn test_nested_document_metadata_contributors_are_authors() {
+    let input = r#"{
+  "metadata": {
+    "name": "document-metadata",
+    "contributors": ["Document Contributor"]
+  }
+}"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert_eq!(
+        authors
+            .iter()
+            .map(|author| author.author.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Document Contributor"],
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
 fn test_plain_json_author_string_machine_token_dropped_without_metadata_context() {
     let input = r#""author": "makeappicon", "images": []"#;
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);

--- a/testdata/summarycode-golden/tallies/full_tallies/tallies.expected.json
+++ b/testdata/summarycode-golden/tallies/full_tallies/tallies.expected.json
@@ -161,7 +161,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Toma\u017e Muraus",
+          "name": "Tomaž Muraus",
           "email": "kami@k5-storitve.net",
           "url": null
         },
@@ -287,7 +287,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Felix Geisendo\u0308rfer",
+          "name": "Felix Geisendörfer",
           "email": "felix@debuggable.com",
           "url": null
         },
@@ -350,7 +350,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Maciej Ma\u0142ecki",
+          "name": "Maciej Małecki",
           "email": "me@mmalecki.com",
           "url": null
         },
@@ -679,7 +679,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Johan Sk\u00f6ld",
+          "name": "Johan Sköld",
           "email": "johan@skold.cc",
           "url": null
         },
@@ -840,7 +840,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Franc\u0327ois Frisch",
+          "name": "François Frisch",
           "email": "francoisfrisch@gmail.com",
           "url": null
         },
@@ -1015,7 +1015,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "S\u00e9bastien Santoro",
+          "name": "Sébastien Santoro",
           "email": "dereckson@espace-win.org",
           "url": null
         },
@@ -1232,7 +1232,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Miroslav Bajto\u0161",
+          "name": "Miroslav Bajtoš",
           "email": "miroslav@strongloop.com",
           "url": null
         },
@@ -1386,7 +1386,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "\u4e0d\u56db",
+          "name": "不四",
           "email": "busi.hyy@taobao.com",
           "url": null
         },
@@ -1449,7 +1449,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Timo Wei\u00df",
+          "name": "Timo Weiß",
           "email": "timoweiss@Timo-MBP.local",
           "url": null
         },
@@ -1463,7 +1463,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "J\u00e9r\u00e9my Lal",
+          "name": "Jérémy Lal",
           "email": "kapouer@melix.org",
           "url": null
         },
@@ -1750,7 +1750,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Gu\u00f0laugur Stef\u00e1n Egilsson",
+          "name": "Guðlaugur Stefán Egilsson",
           "email": "gulli@kolibri.is",
           "url": null
         },
@@ -2023,7 +2023,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Kat March\u00e1n",
+          "name": "Kat Marchán",
           "email": "kzm@sykosomatic.org",
           "url": null
         },
@@ -2128,7 +2128,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Stephan B\u00f6nnemann",
+          "name": "Stephan Bönnemann",
           "email": "stephan@excellenteasy.com",
           "url": null
         },
@@ -3836,11 +3836,1171 @@
         "count": 4
       },
       {
+        "value": "Aaron Blohowiak",
+        "count": 1
+      },
+      {
+        "value": "Aaron Stacy",
+        "count": 1
+      },
+      {
+        "value": "Adam Blackburn",
+        "count": 1
+      },
+      {
+        "value": "Adam Meadows",
+        "count": 1
+      },
+      {
+        "value": "Adrian Lynch",
+        "count": 1
+      },
+      {
+        "value": "Alain Kalker",
+        "count": 1
+      },
+      {
+        "value": "Alan Shaw",
+        "count": 1
+      },
+      {
+        "value": "Aleksey Smolenchuk",
+        "count": 1
+      },
+      {
+        "value": "Alex Ford",
+        "count": 1
+      },
+      {
+        "value": "Alex Gorbatchev",
+        "count": 1
+      },
+      {
+        "value": "Alex K. Wolfe",
+        "count": 1
+      },
+      {
+        "value": "Alex Kocharin",
+        "count": 1
+      },
+      {
+        "value": "Alex Rodionov",
+        "count": 1
+      },
+      {
+        "value": "Alexej Yaroshevich",
+        "count": 1
+      },
+      {
+        "value": "Alexey Kreschuk",
+        "count": 1
+      },
+      {
+        "value": "Anders Janmyr",
+        "count": 1
+      },
+      {
+        "value": "Andreas",
+        "count": 1
+      },
+      {
+        "value": "Andrew",
+        "count": 1
+      },
+      {
+        "value": "Andrew Bradley",
+        "count": 1
+      },
+      {
+        "value": "Andrew Horton",
+        "count": 1
+      },
+      {
+        "value": "Andrew Lunny",
+        "count": 1
+      },
+      {
+        "value": "Andrew Murray",
+        "count": 1
+      },
+      {
+        "value": "Andrew Terris",
+        "count": 1
+      },
+      {
+        "value": "Andrey Fedorov",
+        "count": 1
+      },
+      {
+        "value": "Andrey Kislyuk",
+        "count": 1
+      },
+      {
+        "value": "Anthony Zotti",
+        "count": 1
+      },
+      {
+        "value": "Antti Mattila",
+        "count": 1
+      },
+      {
+        "value": "Aria Stewart",
+        "count": 1
+      },
+      {
+        "value": "Arlo Breault",
+        "count": 1
+      },
+      {
+        "value": "Arnaud Rinquin",
+        "count": 1
+      },
+      {
+        "value": "Bart Teeuwisse",
+        "count": 1
+      },
+      {
+        "value": "Ben Evans",
+        "count": 1
+      },
+      {
+        "value": "Ben Noordhuis",
+        "count": 1
+      },
+      {
+        "value": "Ben Page",
+        "count": 1
+      },
+      {
+        "value": "Benjamin Coe",
+        "count": 1
+      },
+      {
+        "value": "Blaine Bublitz",
+        "count": 1
+      },
+      {
+        "value": "Bradley Meck",
+        "count": 1
+      },
+      {
+        "value": "Brian White",
+        "count": 1
+      },
+      {
+        "value": "Bryan Burgers",
+        "count": 1
+      },
+      {
+        "value": "Bryan English",
+        "count": 1
+      },
+      {
+        "value": "Bryant Williams",
+        "count": 1
+      },
+      {
+        "value": "C J Silverio",
+        "count": 1
+      },
+      {
+        "value": "CamilleM",
+        "count": 1
+      },
+      {
+        "value": "Carl Lange",
+        "count": 1
+      },
+      {
+        "value": "Cedric Nelson",
+        "count": 1
+      },
+      {
+        "value": "Charlie Robbins",
+        "count": 1
+      },
+      {
+        "value": "Charlie Rudolph",
+        "count": 1
+      },
+      {
+        "value": "Charmander",
+        "count": 1
+      },
+      {
+        "value": "Chris Dickinson",
+        "count": 1
+      },
+      {
+        "value": "Chris Meyers",
+        "count": 1
+      },
+      {
+        "value": "Chris Williams",
+        "count": 1
+      },
+      {
+        "value": "Chris Wong",
+        "count": 1
+      },
+      {
+        "value": "Christian Eager",
+        "count": 1
+      },
+      {
+        "value": "Christian Howe",
+        "count": 1
+      },
+      {
+        "value": "Christopher Hiller",
+        "count": 1
+      },
+      {
+        "value": "Chulki Lee",
+        "count": 1
+      },
+      {
+        "value": "Clay Carpenter",
+        "count": 1
+      },
+      {
+        "value": "Cliffano Subagio",
+        "count": 1
+      },
+      {
+        "value": "Conny Brunnkvist",
+        "count": 1
+      },
+      {
+        "value": "Daijiro Wachi",
+        "count": 1
+      },
+      {
+        "value": "Dalmais Maxence",
+        "count": 1
+      },
+      {
+        "value": "Daniel Santiago",
+        "count": 1
+      },
+      {
+        "value": "Danila Gerasimov",
+        "count": 1
+      },
+      {
+        "value": "Danny Fritz",
+        "count": 1
+      },
+      {
+        "value": "Dav Glass",
+        "count": 1
+      },
+      {
+        "value": "Dave Pacheco",
+        "count": 1
+      },
+      {
+        "value": "David Beitey",
+        "count": 1
+      },
+      {
+        "value": "David Glasser",
+        "count": 1
+      },
+      {
+        "value": "David Marr",
+        "count": 1
+      },
+      {
+        "value": "David Trejo",
+        "count": 1
+      },
+      {
+        "value": "David Volm",
+        "count": 1
+      },
+      {
+        "value": "Dean Landolt",
+        "count": 1
+      },
+      {
+        "value": "Denis Gladkikh",
+        "count": 1
+      },
+      {
+        "value": "Derek Peterson",
+        "count": 1
+      },
+      {
+        "value": "Di Wu",
+        "count": 1
+      },
+      {
+        "value": "Domenic Denicola",
+        "count": 1
+      },
+      {
+        "value": "Don Park",
+        "count": 1
+      },
+      {
+        "value": "Dylan Greene",
+        "count": 1
+      },
+      {
+        "value": "Ed Morley",
+        "count": 1
+      },
+      {
+        "value": "Eduardo Pinho",
+        "count": 1
+      },
+      {
+        "value": "Einar Otto Stangvik",
+        "count": 1
+      },
+      {
+        "value": "Elan Shanker",
+        "count": 1
+      },
+      {
+        "value": "Eric Mill",
+        "count": 1
+      },
+      {
+        "value": "Erik Wienhold",
+        "count": 1
+      },
+      {
+        "value": "Eugene Sharygin",
+        "count": 1
+      },
+      {
+        "value": "Evan Lucas",
+        "count": 1
+      },
+      {
+        "value": "Evan Meagher",
+        "count": 1
+      },
+      {
+        "value": "Evan You",
+        "count": 1
+      },
+      {
+        "value": "Faiq Raza",
+        "count": 1
+      },
+      {
+        "value": "Federico Romero",
+        "count": 1
+      },
+      {
+        "value": "Felix Geisendörfer",
+        "count": 1
+      },
+      {
+        "value": "Felix Rabe",
+        "count": 1
+      },
+      {
+        "value": "Filip Weiss",
+        "count": 1
+      },
+      {
+        "value": "Florian Margaine",
+        "count": 1
+      },
+      {
+        "value": "Forbes Lindesay",
+        "count": 1
+      },
+      {
+        "value": "Forrest L Norvell",
+        "count": 1
+      },
+      {
+        "value": "Francisco Treacy",
+        "count": 1
+      },
+      {
+        "value": "Franck Cuny",
+        "count": 1
+      },
+      {
+        "value": "François Frisch",
+        "count": 1
+      },
+      {
+        "value": "Gabriel Barros",
+        "count": 1
+      },
+      {
+        "value": "Gabriel Falkenberg",
+        "count": 1
+      },
+      {
+        "value": "Gautham Pai",
+        "count": 1
+      },
+      {
+        "value": "Geoff Flarity",
+        "count": 1
+      },
+      {
+        "value": "George Miroshnykov",
+        "count": 1
+      },
+      {
+        "value": "George Ornbo",
+        "count": 1
+      },
+      {
+        "value": "Gianluca Casati",
+        "count": 1
+      },
+      {
         "value": "Gilles Vollant",
         "count": 1
       },
       {
+        "value": "Greg Whiteley",
+        "count": 1
+      },
+      {
+        "value": "Guðlaugur Stefán Egilsson",
+        "count": 1
+      },
+      {
+        "value": "Helge Skogly Holm",
+        "count": 1
+      },
+      {
+        "value": "Henrik Hodne",
+        "count": 1
+      },
+      {
+        "value": "Hunter Loftis",
+        "count": 1
+      },
+      {
+        "value": "Iain Sproat",
+        "count": 1
+      },
+      {
+        "value": "Ian Babrou",
+        "count": 1
+      },
+      {
+        "value": "Ian Livingstone",
+        "count": 1
+      },
+      {
+        "value": "Irakli Gozalishvili",
+        "count": 1
+      },
+      {
+        "value": "Isaac Murchie",
+        "count": 1
+      },
+      {
         "value": "Isaac Z. Schlueter",
+        "count": 1
+      },
+      {
+        "value": "J. Tangelder",
+        "count": 1
+      },
+      {
+        "value": "Jaakko Manninen",
+        "count": 1
+      },
+      {
+        "value": "Jake Verbaten",
+        "count": 1
+      },
+      {
+        "value": "Jakob Krigovsky",
+        "count": 1
+      },
+      {
+        "value": "James Butler",
+        "count": 1
+      },
+      {
+        "value": "James Halliday",
+        "count": 1
+      },
+      {
+        "value": "James Sanders",
+        "count": 1
+      },
+      {
+        "value": "James Talmage",
+        "count": 1
+      },
+      {
+        "value": "Jameson Little",
+        "count": 1
+      },
+      {
+        "value": "Jan Lehnardt",
+        "count": 1
+      },
+      {
+        "value": "Jann Horn",
+        "count": 1
+      },
+      {
+        "value": "Jason Diamond",
+        "count": 1
+      },
+      {
+        "value": "Jason Smith",
+        "count": 1
+      },
+      {
+        "value": "Jean Lauliac",
+        "count": 1
+      },
+      {
+        "value": "Jed Schmidt",
+        "count": 1
+      },
+      {
+        "value": "Jeff Barczewski",
+        "count": 1
+      },
+      {
+        "value": "Jeff Jo",
+        "count": 1
+      },
+      {
+        "value": "Jens Grunert",
+        "count": 1
+      },
+      {
+        "value": "Jeremiah Senkpiel",
+        "count": 1
+      },
+      {
+        "value": "Jeremy Cantrell",
+        "count": 1
+      },
+      {
+        "value": "Jess Martin",
+        "count": 1
+      },
+      {
+        "value": "Johan Nordberg",
+        "count": 1
+      },
+      {
+        "value": "Johan Sköld",
+        "count": 1
+      },
+      {
+        "value": "Jon Spencer",
+        "count": 1
+      },
+      {
+        "value": "Jonas Weber",
+        "count": 1
+      },
+      {
+        "value": "Joost-Wim Boekesteijn",
+        "count": 1
+      },
+      {
+        "value": "Jordan Harband",
+        "count": 1
+      },
+      {
+        "value": "Joseph Dykstra",
+        "count": 1
+      },
+      {
+        "value": "Joshua Egan",
+        "count": 1
+      },
+      {
+        "value": "Julian Gruber",
+        "count": 1
+      },
+      {
+        "value": "Julien Meddah",
+        "count": 1
+      },
+      {
+        "value": "Jussi Kalliokoski",
+        "count": 1
+      },
+      {
+        "value": "Jérémy Lal",
+        "count": 1
+      },
+      {
+        "value": "Kai Chen",
+        "count": 1
+      },
+      {
+        "value": "Karl Horky",
+        "count": 1
+      },
+      {
+        "value": "Karolis Narkevicius",
+        "count": 1
+      },
+      {
+        "value": "Karsten Tinnefeld",
+        "count": 1
+      },
+      {
+        "value": "Kat Marchán",
+        "count": 1
+      },
+      {
+        "value": "Kazuhito Hokamura",
+        "count": 1
+      },
+      {
+        "value": "Kei Son",
+        "count": 1
+      },
+      {
+        "value": "Kenan Yildirim",
+        "count": 1
+      },
+      {
+        "value": "Kevin Kragenbrink",
+        "count": 1
+      },
+      {
+        "value": "KevinSheedy",
+        "count": 1
+      },
+      {
+        "value": "Kris Kowal",
+        "count": 1
+      },
+      {
+        "value": "Kris Windham",
+        "count": 1
+      },
+      {
+        "value": "Kyle M. Tarplee",
+        "count": 1
+      },
+      {
+        "value": "Kyle Mitchell",
+        "count": 1
+      },
+      {
+        "value": "Larz Conwell",
+        "count": 1
+      },
+      {
+        "value": "Laurie Harper",
+        "count": 1
+      },
+      {
+        "value": "Laurie Voss",
+        "count": 1
+      },
+      {
+        "value": "Lin Clark",
+        "count": 1
+      },
+      {
+        "value": "Luc Thevenard",
+        "count": 1
+      },
+      {
+        "value": "Ludwig Magnusson",
+        "count": 1
+      },
+      {
+        "value": "Luke Arduini",
+        "count": 1
+      },
+      {
+        "value": "Maciej Małecki",
+        "count": 1
+      },
+      {
+        "value": "Marcel Klehr",
+        "count": 1
+      },
+      {
+        "value": "Marcin Wosinek",
+        "count": 1
+      },
+      {
+        "value": "Marcus Ekwall",
+        "count": 1
+      },
+      {
+        "value": "Mark Cahill",
+        "count": 1
+      },
+      {
+        "value": "Mark Dube",
+        "count": 1
+      },
+      {
+        "value": "Mark J. Titorenko",
+        "count": 1
+      },
+      {
+        "value": "Martin Cooper",
+        "count": 1
+      },
+      {
+        "value": "Martyn Smith",
+        "count": 1
+      },
+      {
+        "value": "Mat Tyndall",
+        "count": 1
+      },
+      {
+        "value": "Mathias Bynens",
+        "count": 1
+      },
+      {
+        "value": "Matt Brennan",
+        "count": 1
+      },
+      {
+        "value": "Matt Colyer",
+        "count": 1
+      },
+      {
+        "value": "Matt Hickford",
+        "count": 1
+      },
+      {
+        "value": "Matt Lunn",
+        "count": 1
+      },
+      {
+        "value": "Matt McClure",
+        "count": 1
+      },
+      {
+        "value": "Matt Zorn",
+        "count": 1
+      },
+      {
+        "value": "Max Goodman",
+        "count": 1
+      },
+      {
+        "value": "Maxim Bogushevich",
+        "count": 1
+      },
+      {
+        "value": "Maximilian Antoni",
+        "count": 1
+      },
+      {
+        "value": "Meaglin",
+        "count": 1
+      },
+      {
+        "value": "Michael Budde",
+        "count": 1
+      },
+      {
+        "value": "Michael Hayes",
+        "count": 1
+      },
+      {
+        "value": "Michael Klein",
+        "count": 1
+      },
+      {
+        "value": "Michael Nisi",
+        "count": 1
+      },
+      {
+        "value": "Michiel Sikma",
+        "count": 1
+      },
+      {
+        "value": "Mick Thompson",
+        "count": 1
+      },
+      {
+        "value": "Mike MacCana",
+        "count": 1
+      },
+      {
+        "value": "Mikeal Rogers",
+        "count": 1
+      },
+      {
+        "value": "Mikola Lysenko",
+        "count": 1
+      },
+      {
+        "value": "Miroslav Bajtoš",
+        "count": 1
+      },
+      {
+        "value": "Nathan Rajlich",
+        "count": 1
+      },
+      {
+        "value": "Nathan Zadoks",
+        "count": 1
+      },
+      {
+        "value": "Neil Gentleman",
+        "count": 1
+      },
+      {
+        "value": "Nicholas Kinsey",
+        "count": 1
+      },
+      {
+        "value": "Nick Heiner",
+        "count": 1
+      },
+      {
+        "value": "Nick Malaguti",
+        "count": 1
+      },
+      {
+        "value": "Nick Santos",
+        "count": 1
+      },
+      {
+        "value": "Nicolas Morel",
+        "count": 1
+      },
+      {
+        "value": "Niggler",
+        "count": 1
+      },
+      {
+        "value": "Oddur Sigurdsson",
+        "count": 1
+      },
+      {
+        "value": "Oleg Efimov",
+        "count": 1
+      },
+      {
+        "value": "Oli Evans",
+        "count": 1
+      },
+      {
+        "value": "Olivier Melcher",
+        "count": 1
+      },
+      {
+        "value": "Orlando Vazquez",
+        "count": 1
+      },
+      {
+        "value": "Paolo Fragomeni",
+        "count": 1
+      },
+      {
+        "value": "Patrick Pfeiffer",
+        "count": 1
+      },
+      {
+        "value": "Paul Miller",
+        "count": 1
+      },
+      {
+        "value": "Paul Vorbach",
+        "count": 1
+      },
+      {
+        "value": "Paulo Cesar",
+        "count": 1
+      },
+      {
+        "value": "Pete Kruckenberg",
+        "count": 1
+      },
+      {
+        "value": "Peter A. Shevtsov",
+        "count": 1
+      },
+      {
+        "value": "Peter Richardson",
+        "count": 1
+      },
+      {
+        "value": "Phillip Howell",
+        "count": 1
+      },
+      {
+        "value": "Quim Calpe",
+        "count": 1
+      },
+      {
+        "value": "Quinn Slack",
+        "count": 1
+      },
+      {
+        "value": "Ra'Shaun Stovall",
+        "count": 1
+      },
+      {
+        "value": "Rachel Hutchison",
+        "count": 1
+      },
+      {
+        "value": "Rafael de Oleza",
+        "count": 1
+      },
+      {
+        "value": "Rebecca Turner",
+        "count": 1
+      },
+      {
+        "value": "Reid Burke",
+        "count": 1
+      },
+      {
+        "value": "Ribettes",
+        "count": 1
+      },
+      {
+        "value": "Richard Littauer",
+        "count": 1
+      },
+      {
+        "value": "Robert Gieseke",
+        "count": 1
+      },
+      {
+        "value": "Robert Kowalski",
+        "count": 1
+      },
+      {
+        "value": "Robin Tweedie",
+        "count": 1
+      },
+      {
+        "value": "Rod Vagg",
+        "count": 1
+      },
+      {
+        "value": "Ron Martinez",
+        "count": 1
+      },
+      {
+        "value": "Ryan Emery",
+        "count": 1
+      },
+      {
+        "value": "Ryan Temple",
+        "count": 1
+      },
+      {
+        "value": "Sam Mikes",
+        "count": 1
+      },
+      {
+        "value": "Schabse Laks",
+        "count": 1
+      },
+      {
+        "value": "Scott Bronson",
+        "count": 1
+      },
+      {
+        "value": "Sean McGivern",
+        "count": 1
+      },
+      {
+        "value": "Sergey Belov",
+        "count": 1
+      },
+      {
+        "value": "Shawn Wildermuth",
+        "count": 1
+      },
+      {
+        "value": "Simen Bekkhus",
+        "count": 1
+      },
+      {
+        "value": "Spain Train",
+        "count": 1
+      },
+      {
+        "value": "Stephan Bönnemann",
+        "count": 1
+      },
+      {
+        "value": "Stephen Sugden",
+        "count": 1
+      },
+      {
+        "value": "Steve Klabnik",
+        "count": 1
+      },
+      {
+        "value": "Steve Mason",
+        "count": 1
+      },
+      {
+        "value": "Steve Steiner",
+        "count": 1
+      },
+      {
+        "value": "Stuart Knightley",
+        "count": 1
+      },
+      {
+        "value": "Stuart P. Bentley",
+        "count": 1
+      },
+      {
+        "value": "Sébastien Santoro",
+        "count": 1
+      },
+      {
+        "value": "TJ Holowaychuk",
+        "count": 1
+      },
+      {
+        "value": "Takaya Kobayashi",
+        "count": 1
+      },
+      {
+        "value": "Tauren Mills",
+        "count": 1
+      },
+      {
+        "value": "Terin Stock",
+        "count": 1
+      },
+      {
+        "value": "Thaddee Tyl",
+        "count": 1
+      },
+      {
+        "value": "Thom Blake",
+        "count": 1
+      },
+      {
+        "value": "Thomas Cort",
+        "count": 1
+      },
+      {
+        "value": "Thomas Torp",
+        "count": 1
+      },
+      {
+        "value": "Thorsten Lorenz",
+        "count": 1
+      },
+      {
+        "value": "Tim Oxley",
+        "count": 1
+      },
+      {
+        "value": "Tim Whidden",
+        "count": 1
+      },
+      {
+        "value": "Timo Derstappen",
+        "count": 1
+      },
+      {
+        "value": "Timo Weiß",
+        "count": 1
+      },
+      {
+        "value": "Tom Huang",
+        "count": 1
+      },
+      {
+        "value": "Tomaž Muraus",
+        "count": 1
+      },
+      {
+        "value": "Tony",
+        "count": 1
+      },
+      {
+        "value": "Tor Valamo",
+        "count": 1
+      },
+      {
+        "value": "Trent Mick",
+        "count": 1
+      },
+      {
+        "value": "Trevor Burnham",
+        "count": 1
+      },
+      {
+        "value": "Tristan Davies",
+        "count": 1
+      },
+      {
+        "value": "Tyler Green",
+        "count": 1
+      },
+      {
+        "value": "Vaz Allen",
+        "count": 1
+      },
+      {
+        "value": "Victor",
+        "count": 1
+      },
+      {
+        "value": "Visnu Pitiyanuvath",
+        "count": 1
+      },
+      {
+        "value": "Vladimir Rutsky",
+        "count": 1
+      },
+      {
+        "value": "Wesley de Souza",
+        "count": 1
+      },
+      {
+        "value": "Whyme.Lyu",
+        "count": 1
+      },
+      {
+        "value": "Wil Moore III",
+        "count": 1
+      },
+      {
+        "value": "Will Elwood",
+        "count": 1
+      },
+      {
+        "value": "Wout Mertens",
+        "count": 1
+      },
+      {
+        "value": "Yazhong Liu",
+        "count": 1
+      },
+      {
+        "value": "Yeonghoon Park",
+        "count": 1
+      },
+      {
+        "value": "Zach Pomerantz",
+        "count": 1
+      },
+      {
+        "value": "Zeke Sikelianos",
         "count": 1
       }
     ],
@@ -4920,7 +6080,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Toma\u017e Muraus",
+              "name": "Tomaž Muraus",
               "email": "kami@k5-storitve.net",
               "url": null
             },
@@ -5046,7 +6206,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Felix Geisendo\u0308rfer",
+              "name": "Felix Geisendörfer",
               "email": "felix@debuggable.com",
               "url": null
             },
@@ -5109,7 +6269,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Maciej Ma\u0142ecki",
+              "name": "Maciej Małecki",
               "email": "me@mmalecki.com",
               "url": null
             },
@@ -5438,7 +6598,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Johan Sk\u00f6ld",
+              "name": "Johan Sköld",
               "email": "johan@skold.cc",
               "url": null
             },
@@ -5599,7 +6759,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Franc\u0327ois Frisch",
+              "name": "François Frisch",
               "email": "francoisfrisch@gmail.com",
               "url": null
             },
@@ -5774,7 +6934,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "S\u00e9bastien Santoro",
+              "name": "Sébastien Santoro",
               "email": "dereckson@espace-win.org",
               "url": null
             },
@@ -5991,7 +7151,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Miroslav Bajto\u0161",
+              "name": "Miroslav Bajtoš",
               "email": "miroslav@strongloop.com",
               "url": null
             },
@@ -6145,7 +7305,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "\u4e0d\u56db",
+              "name": "不四",
               "email": "busi.hyy@taobao.com",
               "url": null
             },
@@ -6208,7 +7368,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Timo Wei\u00df",
+              "name": "Timo Weiß",
               "email": "timoweiss@Timo-MBP.local",
               "url": null
             },
@@ -6222,7 +7382,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "J\u00e9r\u00e9my Lal",
+              "name": "Jérémy Lal",
               "email": "kapouer@melix.org",
               "url": null
             },
@@ -6509,7 +7669,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Gu\u00f0laugur Stef\u00e1n Egilsson",
+              "name": "Guðlaugur Stefán Egilsson",
               "email": "gulli@kolibri.is",
               "url": null
             },
@@ -6782,7 +7942,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Kat March\u00e1n",
+              "name": "Kat Marchán",
               "email": "kzm@sykosomatic.org",
               "url": null
             },
@@ -6887,7 +8047,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Stephan B\u00f6nnemann",
+              "name": "Stephan Bönnemann",
               "email": "stephan@excellenteasy.com",
               "url": null
             },
@@ -7887,7 +9047,1457 @@
         {
           "author": "Isaac Z. Schlueter",
           "start_line": 16,
-          "end_line": 17
+          "end_line": 19
+        },
+        {
+          "author": "Steve Steiner",
+          "start_line": 205,
+          "end_line": 205
+        },
+        {
+          "author": "Mikeal Rogers",
+          "start_line": 209,
+          "end_line": 209
+        },
+        {
+          "author": "Aaron Blohowiak",
+          "start_line": 213,
+          "end_line": 213
+        },
+        {
+          "author": "Martyn Smith",
+          "start_line": 217,
+          "end_line": 217
+        },
+        {
+          "author": "Charlie Robbins",
+          "start_line": 221,
+          "end_line": 221
+        },
+        {
+          "author": "Francisco Treacy",
+          "start_line": 225,
+          "end_line": 225
+        },
+        {
+          "author": "Cliffano Subagio",
+          "start_line": 229,
+          "end_line": 229
+        },
+        {
+          "author": "Christian Eager",
+          "start_line": 233,
+          "end_line": 233
+        },
+        {
+          "author": "Dav Glass",
+          "start_line": 237,
+          "end_line": 237
+        },
+        {
+          "author": "Alex K. Wolfe",
+          "start_line": 241,
+          "end_line": 241
+        },
+        {
+          "author": "James Sanders",
+          "start_line": 245,
+          "end_line": 245
+        },
+        {
+          "author": "Reid Burke",
+          "start_line": 249,
+          "end_line": 249
+        },
+        {
+          "author": "Arlo Breault",
+          "start_line": 253,
+          "end_line": 253
+        },
+        {
+          "author": "Timo Derstappen",
+          "start_line": 257,
+          "end_line": 257
+        },
+        {
+          "author": "Bart Teeuwisse",
+          "start_line": 261,
+          "end_line": 261
+        },
+        {
+          "author": "Ben Noordhuis",
+          "start_line": 265,
+          "end_line": 265
+        },
+        {
+          "author": "Tor Valamo",
+          "start_line": 269,
+          "end_line": 269
+        },
+        {
+          "author": "Whyme.Lyu",
+          "start_line": 273,
+          "end_line": 273
+        },
+        {
+          "author": "Olivier Melcher",
+          "start_line": 277,
+          "end_line": 277
+        },
+        {
+          "author": "Tomaž Muraus",
+          "start_line": 281,
+          "end_line": 281
+        },
+        {
+          "author": "Evan Meagher",
+          "start_line": 285,
+          "end_line": 285
+        },
+        {
+          "author": "Orlando Vazquez",
+          "start_line": 289,
+          "end_line": 289
+        },
+        {
+          "author": "Kai Chen",
+          "start_line": 293,
+          "end_line": 293
+        },
+        {
+          "author": "George Miroshnykov",
+          "start_line": 297,
+          "end_line": 297
+        },
+        {
+          "author": "Geoff Flarity",
+          "start_line": 301,
+          "end_line": 301
+        },
+        {
+          "author": "Max Goodman",
+          "start_line": 305,
+          "end_line": 305
+        },
+        {
+          "author": "Pete Kruckenberg",
+          "start_line": 309,
+          "end_line": 309
+        },
+        {
+          "author": "Laurie Harper",
+          "start_line": 313,
+          "end_line": 313
+        },
+        {
+          "author": "Chris Wong",
+          "start_line": 317,
+          "end_line": 317
+        },
+        {
+          "author": "Scott Bronson",
+          "start_line": 321,
+          "end_line": 321
+        },
+        {
+          "author": "Federico Romero",
+          "start_line": 325,
+          "end_line": 325
+        },
+        {
+          "author": "Visnu Pitiyanuvath",
+          "start_line": 329,
+          "end_line": 329
+        },
+        {
+          "author": "Irakli Gozalishvili",
+          "start_line": 333,
+          "end_line": 333
+        },
+        {
+          "author": "Mark Cahill",
+          "start_line": 337,
+          "end_line": 337
+        },
+        {
+          "author": "Tony",
+          "start_line": 341,
+          "end_line": 341
+        },
+        {
+          "author": "Iain Sproat",
+          "start_line": 345,
+          "end_line": 345
+        },
+        {
+          "author": "Trent Mick",
+          "start_line": 349,
+          "end_line": 349
+        },
+        {
+          "author": "Felix Geisendörfer",
+          "start_line": 353,
+          "end_line": 353
+        },
+        {
+          "author": "Jameson Little",
+          "start_line": 357,
+          "end_line": 357
+        },
+        {
+          "author": "Conny Brunnkvist",
+          "start_line": 361,
+          "end_line": 361
+        },
+        {
+          "author": "Will Elwood",
+          "start_line": 365,
+          "end_line": 365
+        },
+        {
+          "author": "Dean Landolt",
+          "start_line": 369,
+          "end_line": 369
+        },
+        {
+          "author": "Oleg Efimov",
+          "start_line": 373,
+          "end_line": 373
+        },
+        {
+          "author": "Martin Cooper",
+          "start_line": 377,
+          "end_line": 377
+        },
+        {
+          "author": "Jann Horn",
+          "start_line": 381,
+          "end_line": 381
+        },
+        {
+          "author": "Andrew Bradley",
+          "start_line": 385,
+          "end_line": 385
+        },
+        {
+          "author": "Maciej Małecki",
+          "start_line": 389,
+          "end_line": 389
+        },
+        {
+          "author": "Stephen Sugden",
+          "start_line": 393,
+          "end_line": 393
+        },
+        {
+          "author": "Michael Budde",
+          "start_line": 397,
+          "end_line": 397
+        },
+        {
+          "author": "Jason Smith",
+          "start_line": 401,
+          "end_line": 401
+        },
+        {
+          "author": "Gautham Pai",
+          "start_line": 405,
+          "end_line": 405
+        },
+        {
+          "author": "David Trejo",
+          "start_line": 409,
+          "end_line": 409
+        },
+        {
+          "author": "Paul Vorbach",
+          "start_line": 413,
+          "end_line": 413
+        },
+        {
+          "author": "George Ornbo",
+          "start_line": 417,
+          "end_line": 417
+        },
+        {
+          "author": "Tim Oxley",
+          "start_line": 421,
+          "end_line": 421
+        },
+        {
+          "author": "Tyler Green",
+          "start_line": 425,
+          "end_line": 425
+        },
+        {
+          "author": "Dave Pacheco",
+          "start_line": 429,
+          "end_line": 429
+        },
+        {
+          "author": "Danila Gerasimov",
+          "start_line": 433,
+          "end_line": 433
+        },
+        {
+          "author": "Rod Vagg",
+          "start_line": 437,
+          "end_line": 437
+        },
+        {
+          "author": "Christian Howe",
+          "start_line": 441,
+          "end_line": 441
+        },
+        {
+          "author": "Andrew Lunny",
+          "start_line": 445,
+          "end_line": 445
+        },
+        {
+          "author": "Henrik Hodne",
+          "start_line": 449,
+          "end_line": 449
+        },
+        {
+          "author": "Adam Blackburn",
+          "start_line": 453,
+          "end_line": 453
+        },
+        {
+          "author": "Kris Windham",
+          "start_line": 457,
+          "end_line": 457
+        },
+        {
+          "author": "Jens Grunert",
+          "start_line": 461,
+          "end_line": 461
+        },
+        {
+          "author": "Joost-Wim Boekesteijn",
+          "start_line": 465,
+          "end_line": 465
+        },
+        {
+          "author": "Dalmais Maxence",
+          "start_line": 469,
+          "end_line": 469
+        },
+        {
+          "author": "Marcus Ekwall",
+          "start_line": 473,
+          "end_line": 473
+        },
+        {
+          "author": "Aaron Stacy",
+          "start_line": 477,
+          "end_line": 477
+        },
+        {
+          "author": "Phillip Howell",
+          "start_line": 481,
+          "end_line": 481
+        },
+        {
+          "author": "Domenic Denicola",
+          "start_line": 485,
+          "end_line": 485
+        },
+        {
+          "author": "James Halliday",
+          "start_line": 489,
+          "end_line": 489
+        },
+        {
+          "author": "Jeremy Cantrell",
+          "start_line": 493,
+          "end_line": 493
+        },
+        {
+          "author": "Ribettes",
+          "start_line": 497,
+          "end_line": 497
+        },
+        {
+          "author": "Don Park",
+          "start_line": 501,
+          "end_line": 501
+        },
+        {
+          "author": "Einar Otto Stangvik",
+          "start_line": 505,
+          "end_line": 505
+        },
+        {
+          "author": "Kei Son",
+          "start_line": 509,
+          "end_line": 509
+        },
+        {
+          "author": "Nicolas Morel",
+          "start_line": 513,
+          "end_line": 513
+        },
+        {
+          "author": "Mark Dube",
+          "start_line": 517,
+          "end_line": 517
+        },
+        {
+          "author": "Nathan Rajlich",
+          "start_line": 521,
+          "end_line": 521
+        },
+        {
+          "author": "Maxim Bogushevich",
+          "start_line": 525,
+          "end_line": 525
+        },
+        {
+          "author": "Meaglin",
+          "start_line": 529,
+          "end_line": 529
+        },
+        {
+          "author": "Ben Evans",
+          "start_line": 533,
+          "end_line": 533
+        },
+        {
+          "author": "Nathan Zadoks",
+          "start_line": 537,
+          "end_line": 537
+        },
+        {
+          "author": "Brian White",
+          "start_line": 541,
+          "end_line": 541
+        },
+        {
+          "author": "Jed Schmidt",
+          "start_line": 545,
+          "end_line": 545
+        },
+        {
+          "author": "Ian Livingstone",
+          "start_line": 549,
+          "end_line": 549
+        },
+        {
+          "author": "Patrick Pfeiffer",
+          "start_line": 553,
+          "end_line": 553
+        },
+        {
+          "author": "Paul Miller",
+          "start_line": 557,
+          "end_line": 557
+        },
+        {
+          "author": "Ryan Emery",
+          "start_line": 561,
+          "end_line": 561
+        },
+        {
+          "author": "Carl Lange",
+          "start_line": 565,
+          "end_line": 565
+        },
+        {
+          "author": "Jan Lehnardt",
+          "start_line": 569,
+          "end_line": 569
+        },
+        {
+          "author": "Stuart P. Bentley",
+          "start_line": 573,
+          "end_line": 573
+        },
+        {
+          "author": "Johan Sköld",
+          "start_line": 577,
+          "end_line": 577
+        },
+        {
+          "author": "Stuart Knightley",
+          "start_line": 581,
+          "end_line": 581
+        },
+        {
+          "author": "Niggler",
+          "start_line": 585,
+          "end_line": 585
+        },
+        {
+          "author": "Paolo Fragomeni",
+          "start_line": 589,
+          "end_line": 589
+        },
+        {
+          "author": "Jaakko Manninen",
+          "start_line": 593,
+          "end_line": 593
+        },
+        {
+          "author": "Luke Arduini",
+          "start_line": 597,
+          "end_line": 597
+        },
+        {
+          "author": "Larz Conwell",
+          "start_line": 601,
+          "end_line": 601
+        },
+        {
+          "author": "Marcel Klehr",
+          "start_line": 606,
+          "end_line": 606
+        },
+        {
+          "author": "Robert Kowalski",
+          "start_line": 610,
+          "end_line": 610
+        },
+        {
+          "author": "Forbes Lindesay",
+          "start_line": 614,
+          "end_line": 614
+        },
+        {
+          "author": "Vaz Allen",
+          "start_line": 618,
+          "end_line": 618
+        },
+        {
+          "author": "Jake Verbaten",
+          "start_line": 622,
+          "end_line": 622
+        },
+        {
+          "author": "Schabse Laks",
+          "start_line": 626,
+          "end_line": 626
+        },
+        {
+          "author": "Florian Margaine",
+          "start_line": 630,
+          "end_line": 630
+        },
+        {
+          "author": "Johan Nordberg",
+          "start_line": 634,
+          "end_line": 634
+        },
+        {
+          "author": "Ian Babrou",
+          "start_line": 638,
+          "end_line": 638
+        },
+        {
+          "author": "Di Wu",
+          "start_line": 642,
+          "end_line": 642
+        },
+        {
+          "author": "Mathias Bynens",
+          "start_line": 646,
+          "end_line": 646
+        },
+        {
+          "author": "Matt McClure",
+          "start_line": 650,
+          "end_line": 650
+        },
+        {
+          "author": "Matt Lunn",
+          "start_line": 654,
+          "end_line": 654
+        },
+        {
+          "author": "Alexey Kreschuk",
+          "start_line": 658,
+          "end_line": 658
+        },
+        {
+          "author": "Robert Gieseke",
+          "start_line": 666,
+          "end_line": 666
+        },
+        {
+          "author": "François Frisch",
+          "start_line": 670,
+          "end_line": 670
+        },
+        {
+          "author": "Trevor Burnham",
+          "start_line": 674,
+          "end_line": 674
+        },
+        {
+          "author": "Alan Shaw",
+          "start_line": 678,
+          "end_line": 678
+        },
+        {
+          "author": "TJ Holowaychuk",
+          "start_line": 682,
+          "end_line": 682
+        },
+        {
+          "author": "Nicholas Kinsey",
+          "start_line": 686,
+          "end_line": 686
+        },
+        {
+          "author": "Paulo Cesar",
+          "start_line": 690,
+          "end_line": 690
+        },
+        {
+          "author": "Elan Shanker",
+          "start_line": 694,
+          "end_line": 694
+        },
+        {
+          "author": "Jon Spencer",
+          "start_line": 698,
+          "end_line": 698
+        },
+        {
+          "author": "Jason Diamond",
+          "start_line": 702,
+          "end_line": 702
+        },
+        {
+          "author": "Maximilian Antoni",
+          "start_line": 706,
+          "end_line": 706
+        },
+        {
+          "author": "Thom Blake",
+          "start_line": 710,
+          "end_line": 710
+        },
+        {
+          "author": "Jess Martin",
+          "start_line": 714,
+          "end_line": 714
+        },
+        {
+          "author": "Spain Train",
+          "start_line": 718,
+          "end_line": 718
+        },
+        {
+          "author": "Alex Rodionov",
+          "start_line": 722,
+          "end_line": 722
+        },
+        {
+          "author": "Matt Colyer",
+          "start_line": 726,
+          "end_line": 726
+        },
+        {
+          "author": "Evan You",
+          "start_line": 730,
+          "end_line": 730
+        },
+        {
+          "author": "Gabriel Falkenberg",
+          "start_line": 738,
+          "end_line": 738
+        },
+        {
+          "author": "Alexej Yaroshevich",
+          "start_line": 742,
+          "end_line": 742
+        },
+        {
+          "author": "Quim Calpe",
+          "start_line": 746,
+          "end_line": 746
+        },
+        {
+          "author": "Steve Mason",
+          "start_line": 750,
+          "end_line": 750
+        },
+        {
+          "author": "Wil Moore III",
+          "start_line": 754,
+          "end_line": 754
+        },
+        {
+          "author": "Sergey Belov",
+          "start_line": 758,
+          "end_line": 758
+        },
+        {
+          "author": "Tom Huang",
+          "start_line": 762,
+          "end_line": 762
+        },
+        {
+          "author": "CamilleM",
+          "start_line": 766,
+          "end_line": 766
+        },
+        {
+          "author": "Sébastien Santoro",
+          "start_line": 770,
+          "end_line": 770
+        },
+        {
+          "author": "Evan Lucas",
+          "start_line": 774,
+          "end_line": 774
+        },
+        {
+          "author": "Quinn Slack",
+          "start_line": 778,
+          "end_line": 778
+        },
+        {
+          "author": "Alex Kocharin",
+          "start_line": 782,
+          "end_line": 782
+        },
+        {
+          "author": "Daniel Santiago",
+          "start_line": 786,
+          "end_line": 786
+        },
+        {
+          "author": "Denis Gladkikh",
+          "start_line": 790,
+          "end_line": 790
+        },
+        {
+          "author": "Andrew Horton",
+          "start_line": 794,
+          "end_line": 794
+        },
+        {
+          "author": "Zeke Sikelianos",
+          "start_line": 798,
+          "end_line": 798
+        },
+        {
+          "author": "Dylan Greene",
+          "start_line": 802,
+          "end_line": 802
+        },
+        {
+          "author": "Franck Cuny",
+          "start_line": 806,
+          "end_line": 806
+        },
+        {
+          "author": "Yeonghoon Park",
+          "start_line": 810,
+          "end_line": 810
+        },
+        {
+          "author": "Rafael de Oleza",
+          "start_line": 814,
+          "end_line": 814
+        },
+        {
+          "author": "Mikola Lysenko",
+          "start_line": 818,
+          "end_line": 818
+        },
+        {
+          "author": "Yazhong Liu",
+          "start_line": 822,
+          "end_line": 822
+        },
+        {
+          "author": "Neil Gentleman",
+          "start_line": 826,
+          "end_line": 826
+        },
+        {
+          "author": "Kris Kowal",
+          "start_line": 830,
+          "end_line": 830
+        },
+        {
+          "author": "Alex Gorbatchev",
+          "start_line": 834,
+          "end_line": 834
+        },
+        {
+          "author": "Shawn Wildermuth",
+          "start_line": 838,
+          "end_line": 838
+        },
+        {
+          "author": "Wesley de Souza",
+          "start_line": 842,
+          "end_line": 842
+        },
+        {
+          "author": "J. Tangelder",
+          "start_line": 850,
+          "end_line": 850
+        },
+        {
+          "author": "Jean Lauliac",
+          "start_line": 854,
+          "end_line": 854
+        },
+        {
+          "author": "Andrey Kislyuk",
+          "start_line": 858,
+          "end_line": 858
+        },
+        {
+          "author": "Thorsten Lorenz",
+          "start_line": 862,
+          "end_line": 862
+        },
+        {
+          "author": "Julian Gruber",
+          "start_line": 866,
+          "end_line": 866
+        },
+        {
+          "author": "Benjamin Coe",
+          "start_line": 870,
+          "end_line": 870
+        },
+        {
+          "author": "Alex Ford",
+          "start_line": 874,
+          "end_line": 874
+        },
+        {
+          "author": "Matt Hickford",
+          "start_line": 878,
+          "end_line": 878
+        },
+        {
+          "author": "Sean McGivern",
+          "start_line": 882,
+          "end_line": 882
+        },
+        {
+          "author": "C J Silverio",
+          "start_line": 886,
+          "end_line": 886
+        },
+        {
+          "author": "Robin Tweedie",
+          "start_line": 890,
+          "end_line": 890
+        },
+        {
+          "author": "Miroslav Bajtoš",
+          "start_line": 894,
+          "end_line": 894
+        },
+        {
+          "author": "David Glasser",
+          "start_line": 898,
+          "end_line": 898
+        },
+        {
+          "author": "Gianluca Casati",
+          "start_line": 902,
+          "end_line": 902
+        },
+        {
+          "author": "Forrest L Norvell",
+          "start_line": 906,
+          "end_line": 906
+        },
+        {
+          "author": "Karsten Tinnefeld",
+          "start_line": 910,
+          "end_line": 910
+        },
+        {
+          "author": "Bryan Burgers",
+          "start_line": 914,
+          "end_line": 914
+        },
+        {
+          "author": "David Beitey",
+          "start_line": 918,
+          "end_line": 918
+        },
+        {
+          "author": "Zach Pomerantz",
+          "start_line": 926,
+          "end_line": 926
+        },
+        {
+          "author": "Chris Williams",
+          "start_line": 930,
+          "end_line": 930
+        },
+        {
+          "author": "Mick Thompson",
+          "start_line": 938,
+          "end_line": 938
+        },
+        {
+          "author": "Felix Rabe",
+          "start_line": 942,
+          "end_line": 942
+        },
+        {
+          "author": "Michael Hayes",
+          "start_line": 946,
+          "end_line": 946
+        },
+        {
+          "author": "Chris Dickinson",
+          "start_line": 950,
+          "end_line": 950
+        },
+        {
+          "author": "Bradley Meck",
+          "start_line": 954,
+          "end_line": 954
+        },
+        {
+          "author": "Andrew Terris",
+          "start_line": 962,
+          "end_line": 962
+        },
+        {
+          "author": "Michael Nisi",
+          "start_line": 966,
+          "end_line": 966
+        },
+        {
+          "author": "Adam Meadows",
+          "start_line": 974,
+          "end_line": 974
+        },
+        {
+          "author": "Chulki Lee",
+          "start_line": 978,
+          "end_line": 978
+        },
+        {
+          "author": "Kenan Yildirim",
+          "start_line": 990,
+          "end_line": 990
+        },
+        {
+          "author": "Laurie Voss",
+          "start_line": 994,
+          "end_line": 994
+        },
+        {
+          "author": "Rebecca Turner",
+          "start_line": 998,
+          "end_line": 998
+        },
+        {
+          "author": "Hunter Loftis",
+          "start_line": 1002,
+          "end_line": 1002
+        },
+        {
+          "author": "Peter Richardson",
+          "start_line": 1006,
+          "end_line": 1006
+        },
+        {
+          "author": "Jussi Kalliokoski",
+          "start_line": 1010,
+          "end_line": 1010
+        },
+        {
+          "author": "Filip Weiss",
+          "start_line": 1014,
+          "end_line": 1014
+        },
+        {
+          "author": "Timo Weiß",
+          "start_line": 1018,
+          "end_line": 1018
+        },
+        {
+          "author": "Christopher Hiller",
+          "start_line": 1022,
+          "end_line": 1022
+        },
+        {
+          "author": "Jérémy Lal",
+          "start_line": 1026,
+          "end_line": 1026
+        },
+        {
+          "author": "Anders Janmyr",
+          "start_line": 1030,
+          "end_line": 1030
+        },
+        {
+          "author": "Chris Meyers",
+          "start_line": 1034,
+          "end_line": 1034
+        },
+        {
+          "author": "Ludwig Magnusson",
+          "start_line": 1038,
+          "end_line": 1038
+        },
+        {
+          "author": "Wout Mertens",
+          "start_line": 1042,
+          "end_line": 1042
+        },
+        {
+          "author": "Nick Santos",
+          "start_line": 1046,
+          "end_line": 1046
+        },
+        {
+          "author": "Terin Stock",
+          "start_line": 1050,
+          "end_line": 1050
+        },
+        {
+          "author": "Faiq Raza",
+          "start_line": 1054,
+          "end_line": 1054
+        },
+        {
+          "author": "Thomas Torp",
+          "start_line": 1058,
+          "end_line": 1058
+        },
+        {
+          "author": "Sam Mikes",
+          "start_line": 1062,
+          "end_line": 1062
+        },
+        {
+          "author": "Mat Tyndall",
+          "start_line": 1066,
+          "end_line": 1066
+        },
+        {
+          "author": "Tauren Mills",
+          "start_line": 1070,
+          "end_line": 1070
+        },
+        {
+          "author": "Ron Martinez",
+          "start_line": 1074,
+          "end_line": 1074
+        },
+        {
+          "author": "Kazuhito Hokamura",
+          "start_line": 1078,
+          "end_line": 1078
+        },
+        {
+          "author": "Tristan Davies",
+          "start_line": 1082,
+          "end_line": 1082
+        },
+        {
+          "author": "David Volm",
+          "start_line": 1086,
+          "end_line": 1086
+        },
+        {
+          "author": "Lin Clark",
+          "start_line": 1090,
+          "end_line": 1090
+        },
+        {
+          "author": "Ben Page",
+          "start_line": 1094,
+          "end_line": 1094
+        },
+        {
+          "author": "Jeff Jo",
+          "start_line": 1098,
+          "end_line": 1098
+        },
+        {
+          "author": "Mark J. Titorenko",
+          "start_line": 1106,
+          "end_line": 1106
+        },
+        {
+          "author": "Oddur Sigurdsson",
+          "start_line": 1110,
+          "end_line": 1110
+        },
+        {
+          "author": "Eric Mill",
+          "start_line": 1114,
+          "end_line": 1114
+        },
+        {
+          "author": "Gabriel Barros",
+          "start_line": 1118,
+          "end_line": 1118
+        },
+        {
+          "author": "KevinSheedy",
+          "start_line": 1122,
+          "end_line": 1122
+        },
+        {
+          "author": "Aleksey Smolenchuk",
+          "start_line": 1126,
+          "end_line": 1126
+        },
+        {
+          "author": "Ed Morley",
+          "start_line": 1130,
+          "end_line": 1130
+        },
+        {
+          "author": "Blaine Bublitz",
+          "start_line": 1134,
+          "end_line": 1134
+        },
+        {
+          "author": "Andrey Fedorov",
+          "start_line": 1138,
+          "end_line": 1138
+        },
+        {
+          "author": "Daijiro Wachi",
+          "start_line": 1142,
+          "end_line": 1142
+        },
+        {
+          "author": "Luc Thevenard",
+          "start_line": 1146,
+          "end_line": 1146
+        },
+        {
+          "author": "Aria Stewart",
+          "start_line": 1150,
+          "end_line": 1150
+        },
+        {
+          "author": "Charlie Rudolph",
+          "start_line": 1154,
+          "end_line": 1154
+        },
+        {
+          "author": "Vladimir Rutsky",
+          "start_line": 1158,
+          "end_line": 1158
+        },
+        {
+          "author": "Isaac Murchie",
+          "start_line": 1162,
+          "end_line": 1162
+        },
+        {
+          "author": "Marcin Wosinek",
+          "start_line": 1166,
+          "end_line": 1166
+        },
+        {
+          "author": "David Marr",
+          "start_line": 1170,
+          "end_line": 1170
+        },
+        {
+          "author": "Bryan English",
+          "start_line": 1174,
+          "end_line": 1174
+        },
+        {
+          "author": "Anthony Zotti",
+          "start_line": 1178,
+          "end_line": 1178
+        },
+        {
+          "author": "Karl Horky",
+          "start_line": 1182,
+          "end_line": 1182
+        },
+        {
+          "author": "Jordan Harband",
+          "start_line": 1186,
+          "end_line": 1186
+        },
+        {
+          "author": "Guðlaugur Stefán Egilsson",
+          "start_line": 1190,
+          "end_line": 1190
+        },
+        {
+          "author": "Helge Skogly Holm",
+          "start_line": 1194,
+          "end_line": 1194
+        },
+        {
+          "author": "Peter A. Shevtsov",
+          "start_line": 1198,
+          "end_line": 1198
+        },
+        {
+          "author": "Alain Kalker",
+          "start_line": 1202,
+          "end_line": 1202
+        },
+        {
+          "author": "Bryant Williams",
+          "start_line": 1206,
+          "end_line": 1206
+        },
+        {
+          "author": "Jonas Weber",
+          "start_line": 1210,
+          "end_line": 1210
+        },
+        {
+          "author": "Tim Whidden",
+          "start_line": 1214,
+          "end_line": 1214
+        },
+        {
+          "author": "Andreas",
+          "start_line": 1218,
+          "end_line": 1218
+        },
+        {
+          "author": "Karolis Narkevicius",
+          "start_line": 1222,
+          "end_line": 1222
+        },
+        {
+          "author": "Adrian Lynch",
+          "start_line": 1226,
+          "end_line": 1226
+        },
+        {
+          "author": "Richard Littauer",
+          "start_line": 1230,
+          "end_line": 1230
+        },
+        {
+          "author": "Oli Evans",
+          "start_line": 1234,
+          "end_line": 1234
+        },
+        {
+          "author": "Matt Brennan",
+          "start_line": 1238,
+          "end_line": 1238
+        },
+        {
+          "author": "Jeff Barczewski",
+          "start_line": 1242,
+          "end_line": 1242
+        },
+        {
+          "author": "Danny Fritz",
+          "start_line": 1246,
+          "end_line": 1246
+        },
+        {
+          "author": "Takaya Kobayashi",
+          "start_line": 1250,
+          "end_line": 1250
+        },
+        {
+          "author": "Ra'Shaun Stovall",
+          "start_line": 1254,
+          "end_line": 1254
+        },
+        {
+          "author": "Julien Meddah",
+          "start_line": 1258,
+          "end_line": 1258
+        },
+        {
+          "author": "Michiel Sikma",
+          "start_line": 1262,
+          "end_line": 1262
+        },
+        {
+          "author": "Jakob Krigovsky",
+          "start_line": 1266,
+          "end_line": 1266
+        },
+        {
+          "author": "Charmander",
+          "start_line": 1270,
+          "end_line": 1270
+        },
+        {
+          "author": "Erik Wienhold",
+          "start_line": 1274,
+          "end_line": 1274
+        },
+        {
+          "author": "James Butler",
+          "start_line": 1278,
+          "end_line": 1278
+        },
+        {
+          "author": "Kevin Kragenbrink",
+          "start_line": 1282,
+          "end_line": 1282
+        },
+        {
+          "author": "Arnaud Rinquin",
+          "start_line": 1286,
+          "end_line": 1286
+        },
+        {
+          "author": "Mike MacCana",
+          "start_line": 1290,
+          "end_line": 1290
+        },
+        {
+          "author": "Antti Mattila",
+          "start_line": 1294,
+          "end_line": 1294
+        },
+        {
+          "author": "Matt Zorn",
+          "start_line": 1302,
+          "end_line": 1302
+        },
+        {
+          "author": "Kyle Mitchell",
+          "start_line": 1306,
+          "end_line": 1306
+        },
+        {
+          "author": "Jeremiah Senkpiel",
+          "start_line": 1310,
+          "end_line": 1310
+        },
+        {
+          "author": "Michael Klein",
+          "start_line": 1314,
+          "end_line": 1314
+        },
+        {
+          "author": "Simen Bekkhus",
+          "start_line": 1318,
+          "end_line": 1318
+        },
+        {
+          "author": "Victor",
+          "start_line": 1322,
+          "end_line": 1322
+        },
+        {
+          "author": "Clay Carpenter",
+          "start_line": 1330,
+          "end_line": 1330
+        },
+        {
+          "author": "Nick Malaguti",
+          "start_line": 1338,
+          "end_line": 1338
+        },
+        {
+          "author": "Cedric Nelson",
+          "start_line": 1342,
+          "end_line": 1342
+        },
+        {
+          "author": "Kat Marchán",
+          "start_line": 1346,
+          "end_line": 1346
+        },
+        {
+          "author": "Andrew",
+          "start_line": 1350,
+          "end_line": 1350
+        },
+        {
+          "author": "Eduardo Pinho",
+          "start_line": 1354,
+          "end_line": 1354
+        },
+        {
+          "author": "Rachel Hutchison",
+          "start_line": 1358,
+          "end_line": 1358
+        },
+        {
+          "author": "Ryan Temple",
+          "start_line": 1362,
+          "end_line": 1362
+        },
+        {
+          "author": "Eugene Sharygin",
+          "start_line": 1366,
+          "end_line": 1366
+        },
+        {
+          "author": "Nick Heiner",
+          "start_line": 1370,
+          "end_line": 1370
+        },
+        {
+          "author": "James Talmage",
+          "start_line": 1374,
+          "end_line": 1374
+        },
+        {
+          "author": "Joseph Dykstra",
+          "start_line": 1382,
+          "end_line": 1382
+        },
+        {
+          "author": "Joshua Egan",
+          "start_line": 1386,
+          "end_line": 1386
+        },
+        {
+          "author": "Thomas Cort",
+          "start_line": 1390,
+          "end_line": 1390
+        },
+        {
+          "author": "Thaddee Tyl",
+          "start_line": 1394,
+          "end_line": 1394
+        },
+        {
+          "author": "Steve Klabnik",
+          "start_line": 1398,
+          "end_line": 1398
+        },
+        {
+          "author": "Andrew Murray",
+          "start_line": 1402,
+          "end_line": 1402
+        },
+        {
+          "author": "Stephan Bönnemann",
+          "start_line": 1406,
+          "end_line": 1406
+        },
+        {
+          "author": "Kyle M. Tarplee",
+          "start_line": 1410,
+          "end_line": 1410
+        },
+        {
+          "author": "Derek Peterson",
+          "start_line": 1414,
+          "end_line": 1414
+        },
+        {
+          "author": "Greg Whiteley",
+          "start_line": 1418,
+          "end_line": 1418
         }
       ],
       "files_count": 0,

--- a/testdata/summarycode-golden/tallies/full_tallies/tallies_by_facet.expected.json
+++ b/testdata/summarycode-golden/tallies/full_tallies/tallies_by_facet.expected.json
@@ -161,7 +161,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Toma\u017e Muraus",
+          "name": "Tomaž Muraus",
           "email": "kami@k5-storitve.net",
           "url": null
         },
@@ -287,7 +287,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Felix Geisendo\u0308rfer",
+          "name": "Felix Geisendörfer",
           "email": "felix@debuggable.com",
           "url": null
         },
@@ -350,7 +350,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Maciej Ma\u0142ecki",
+          "name": "Maciej Małecki",
           "email": "me@mmalecki.com",
           "url": null
         },
@@ -679,7 +679,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Johan Sk\u00f6ld",
+          "name": "Johan Sköld",
           "email": "johan@skold.cc",
           "url": null
         },
@@ -840,7 +840,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Franc\u0327ois Frisch",
+          "name": "François Frisch",
           "email": "francoisfrisch@gmail.com",
           "url": null
         },
@@ -1015,7 +1015,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "S\u00e9bastien Santoro",
+          "name": "Sébastien Santoro",
           "email": "dereckson@espace-win.org",
           "url": null
         },
@@ -1232,7 +1232,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Miroslav Bajto\u0161",
+          "name": "Miroslav Bajtoš",
           "email": "miroslav@strongloop.com",
           "url": null
         },
@@ -1386,7 +1386,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "\u4e0d\u56db",
+          "name": "不四",
           "email": "busi.hyy@taobao.com",
           "url": null
         },
@@ -1449,7 +1449,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Timo Wei\u00df",
+          "name": "Timo Weiß",
           "email": "timoweiss@Timo-MBP.local",
           "url": null
         },
@@ -1463,7 +1463,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "J\u00e9r\u00e9my Lal",
+          "name": "Jérémy Lal",
           "email": "kapouer@melix.org",
           "url": null
         },
@@ -1750,7 +1750,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Gu\u00f0laugur Stef\u00e1n Egilsson",
+          "name": "Guðlaugur Stefán Egilsson",
           "email": "gulli@kolibri.is",
           "url": null
         },
@@ -2023,7 +2023,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Kat March\u00e1n",
+          "name": "Kat Marchán",
           "email": "kzm@sykosomatic.org",
           "url": null
         },
@@ -2128,7 +2128,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Stephan B\u00f6nnemann",
+          "name": "Stephan Bönnemann",
           "email": "stephan@excellenteasy.com",
           "url": null
         },
@@ -3836,11 +3836,1171 @@
         "count": 4
       },
       {
+        "value": "Aaron Blohowiak",
+        "count": 1
+      },
+      {
+        "value": "Aaron Stacy",
+        "count": 1
+      },
+      {
+        "value": "Adam Blackburn",
+        "count": 1
+      },
+      {
+        "value": "Adam Meadows",
+        "count": 1
+      },
+      {
+        "value": "Adrian Lynch",
+        "count": 1
+      },
+      {
+        "value": "Alain Kalker",
+        "count": 1
+      },
+      {
+        "value": "Alan Shaw",
+        "count": 1
+      },
+      {
+        "value": "Aleksey Smolenchuk",
+        "count": 1
+      },
+      {
+        "value": "Alex Ford",
+        "count": 1
+      },
+      {
+        "value": "Alex Gorbatchev",
+        "count": 1
+      },
+      {
+        "value": "Alex K. Wolfe",
+        "count": 1
+      },
+      {
+        "value": "Alex Kocharin",
+        "count": 1
+      },
+      {
+        "value": "Alex Rodionov",
+        "count": 1
+      },
+      {
+        "value": "Alexej Yaroshevich",
+        "count": 1
+      },
+      {
+        "value": "Alexey Kreschuk",
+        "count": 1
+      },
+      {
+        "value": "Anders Janmyr",
+        "count": 1
+      },
+      {
+        "value": "Andreas",
+        "count": 1
+      },
+      {
+        "value": "Andrew",
+        "count": 1
+      },
+      {
+        "value": "Andrew Bradley",
+        "count": 1
+      },
+      {
+        "value": "Andrew Horton",
+        "count": 1
+      },
+      {
+        "value": "Andrew Lunny",
+        "count": 1
+      },
+      {
+        "value": "Andrew Murray",
+        "count": 1
+      },
+      {
+        "value": "Andrew Terris",
+        "count": 1
+      },
+      {
+        "value": "Andrey Fedorov",
+        "count": 1
+      },
+      {
+        "value": "Andrey Kislyuk",
+        "count": 1
+      },
+      {
+        "value": "Anthony Zotti",
+        "count": 1
+      },
+      {
+        "value": "Antti Mattila",
+        "count": 1
+      },
+      {
+        "value": "Aria Stewart",
+        "count": 1
+      },
+      {
+        "value": "Arlo Breault",
+        "count": 1
+      },
+      {
+        "value": "Arnaud Rinquin",
+        "count": 1
+      },
+      {
+        "value": "Bart Teeuwisse",
+        "count": 1
+      },
+      {
+        "value": "Ben Evans",
+        "count": 1
+      },
+      {
+        "value": "Ben Noordhuis",
+        "count": 1
+      },
+      {
+        "value": "Ben Page",
+        "count": 1
+      },
+      {
+        "value": "Benjamin Coe",
+        "count": 1
+      },
+      {
+        "value": "Blaine Bublitz",
+        "count": 1
+      },
+      {
+        "value": "Bradley Meck",
+        "count": 1
+      },
+      {
+        "value": "Brian White",
+        "count": 1
+      },
+      {
+        "value": "Bryan Burgers",
+        "count": 1
+      },
+      {
+        "value": "Bryan English",
+        "count": 1
+      },
+      {
+        "value": "Bryant Williams",
+        "count": 1
+      },
+      {
+        "value": "C J Silverio",
+        "count": 1
+      },
+      {
+        "value": "CamilleM",
+        "count": 1
+      },
+      {
+        "value": "Carl Lange",
+        "count": 1
+      },
+      {
+        "value": "Cedric Nelson",
+        "count": 1
+      },
+      {
+        "value": "Charlie Robbins",
+        "count": 1
+      },
+      {
+        "value": "Charlie Rudolph",
+        "count": 1
+      },
+      {
+        "value": "Charmander",
+        "count": 1
+      },
+      {
+        "value": "Chris Dickinson",
+        "count": 1
+      },
+      {
+        "value": "Chris Meyers",
+        "count": 1
+      },
+      {
+        "value": "Chris Williams",
+        "count": 1
+      },
+      {
+        "value": "Chris Wong",
+        "count": 1
+      },
+      {
+        "value": "Christian Eager",
+        "count": 1
+      },
+      {
+        "value": "Christian Howe",
+        "count": 1
+      },
+      {
+        "value": "Christopher Hiller",
+        "count": 1
+      },
+      {
+        "value": "Chulki Lee",
+        "count": 1
+      },
+      {
+        "value": "Clay Carpenter",
+        "count": 1
+      },
+      {
+        "value": "Cliffano Subagio",
+        "count": 1
+      },
+      {
+        "value": "Conny Brunnkvist",
+        "count": 1
+      },
+      {
+        "value": "Daijiro Wachi",
+        "count": 1
+      },
+      {
+        "value": "Dalmais Maxence",
+        "count": 1
+      },
+      {
+        "value": "Daniel Santiago",
+        "count": 1
+      },
+      {
+        "value": "Danila Gerasimov",
+        "count": 1
+      },
+      {
+        "value": "Danny Fritz",
+        "count": 1
+      },
+      {
+        "value": "Dav Glass",
+        "count": 1
+      },
+      {
+        "value": "Dave Pacheco",
+        "count": 1
+      },
+      {
+        "value": "David Beitey",
+        "count": 1
+      },
+      {
+        "value": "David Glasser",
+        "count": 1
+      },
+      {
+        "value": "David Marr",
+        "count": 1
+      },
+      {
+        "value": "David Trejo",
+        "count": 1
+      },
+      {
+        "value": "David Volm",
+        "count": 1
+      },
+      {
+        "value": "Dean Landolt",
+        "count": 1
+      },
+      {
+        "value": "Denis Gladkikh",
+        "count": 1
+      },
+      {
+        "value": "Derek Peterson",
+        "count": 1
+      },
+      {
+        "value": "Di Wu",
+        "count": 1
+      },
+      {
+        "value": "Domenic Denicola",
+        "count": 1
+      },
+      {
+        "value": "Don Park",
+        "count": 1
+      },
+      {
+        "value": "Dylan Greene",
+        "count": 1
+      },
+      {
+        "value": "Ed Morley",
+        "count": 1
+      },
+      {
+        "value": "Eduardo Pinho",
+        "count": 1
+      },
+      {
+        "value": "Einar Otto Stangvik",
+        "count": 1
+      },
+      {
+        "value": "Elan Shanker",
+        "count": 1
+      },
+      {
+        "value": "Eric Mill",
+        "count": 1
+      },
+      {
+        "value": "Erik Wienhold",
+        "count": 1
+      },
+      {
+        "value": "Eugene Sharygin",
+        "count": 1
+      },
+      {
+        "value": "Evan Lucas",
+        "count": 1
+      },
+      {
+        "value": "Evan Meagher",
+        "count": 1
+      },
+      {
+        "value": "Evan You",
+        "count": 1
+      },
+      {
+        "value": "Faiq Raza",
+        "count": 1
+      },
+      {
+        "value": "Federico Romero",
+        "count": 1
+      },
+      {
+        "value": "Felix Geisendörfer",
+        "count": 1
+      },
+      {
+        "value": "Felix Rabe",
+        "count": 1
+      },
+      {
+        "value": "Filip Weiss",
+        "count": 1
+      },
+      {
+        "value": "Florian Margaine",
+        "count": 1
+      },
+      {
+        "value": "Forbes Lindesay",
+        "count": 1
+      },
+      {
+        "value": "Forrest L Norvell",
+        "count": 1
+      },
+      {
+        "value": "Francisco Treacy",
+        "count": 1
+      },
+      {
+        "value": "Franck Cuny",
+        "count": 1
+      },
+      {
+        "value": "François Frisch",
+        "count": 1
+      },
+      {
+        "value": "Gabriel Barros",
+        "count": 1
+      },
+      {
+        "value": "Gabriel Falkenberg",
+        "count": 1
+      },
+      {
+        "value": "Gautham Pai",
+        "count": 1
+      },
+      {
+        "value": "Geoff Flarity",
+        "count": 1
+      },
+      {
+        "value": "George Miroshnykov",
+        "count": 1
+      },
+      {
+        "value": "George Ornbo",
+        "count": 1
+      },
+      {
+        "value": "Gianluca Casati",
+        "count": 1
+      },
+      {
         "value": "Gilles Vollant",
         "count": 1
       },
       {
+        "value": "Greg Whiteley",
+        "count": 1
+      },
+      {
+        "value": "Guðlaugur Stefán Egilsson",
+        "count": 1
+      },
+      {
+        "value": "Helge Skogly Holm",
+        "count": 1
+      },
+      {
+        "value": "Henrik Hodne",
+        "count": 1
+      },
+      {
+        "value": "Hunter Loftis",
+        "count": 1
+      },
+      {
+        "value": "Iain Sproat",
+        "count": 1
+      },
+      {
+        "value": "Ian Babrou",
+        "count": 1
+      },
+      {
+        "value": "Ian Livingstone",
+        "count": 1
+      },
+      {
+        "value": "Irakli Gozalishvili",
+        "count": 1
+      },
+      {
+        "value": "Isaac Murchie",
+        "count": 1
+      },
+      {
         "value": "Isaac Z. Schlueter",
+        "count": 1
+      },
+      {
+        "value": "J. Tangelder",
+        "count": 1
+      },
+      {
+        "value": "Jaakko Manninen",
+        "count": 1
+      },
+      {
+        "value": "Jake Verbaten",
+        "count": 1
+      },
+      {
+        "value": "Jakob Krigovsky",
+        "count": 1
+      },
+      {
+        "value": "James Butler",
+        "count": 1
+      },
+      {
+        "value": "James Halliday",
+        "count": 1
+      },
+      {
+        "value": "James Sanders",
+        "count": 1
+      },
+      {
+        "value": "James Talmage",
+        "count": 1
+      },
+      {
+        "value": "Jameson Little",
+        "count": 1
+      },
+      {
+        "value": "Jan Lehnardt",
+        "count": 1
+      },
+      {
+        "value": "Jann Horn",
+        "count": 1
+      },
+      {
+        "value": "Jason Diamond",
+        "count": 1
+      },
+      {
+        "value": "Jason Smith",
+        "count": 1
+      },
+      {
+        "value": "Jean Lauliac",
+        "count": 1
+      },
+      {
+        "value": "Jed Schmidt",
+        "count": 1
+      },
+      {
+        "value": "Jeff Barczewski",
+        "count": 1
+      },
+      {
+        "value": "Jeff Jo",
+        "count": 1
+      },
+      {
+        "value": "Jens Grunert",
+        "count": 1
+      },
+      {
+        "value": "Jeremiah Senkpiel",
+        "count": 1
+      },
+      {
+        "value": "Jeremy Cantrell",
+        "count": 1
+      },
+      {
+        "value": "Jess Martin",
+        "count": 1
+      },
+      {
+        "value": "Johan Nordberg",
+        "count": 1
+      },
+      {
+        "value": "Johan Sköld",
+        "count": 1
+      },
+      {
+        "value": "Jon Spencer",
+        "count": 1
+      },
+      {
+        "value": "Jonas Weber",
+        "count": 1
+      },
+      {
+        "value": "Joost-Wim Boekesteijn",
+        "count": 1
+      },
+      {
+        "value": "Jordan Harband",
+        "count": 1
+      },
+      {
+        "value": "Joseph Dykstra",
+        "count": 1
+      },
+      {
+        "value": "Joshua Egan",
+        "count": 1
+      },
+      {
+        "value": "Julian Gruber",
+        "count": 1
+      },
+      {
+        "value": "Julien Meddah",
+        "count": 1
+      },
+      {
+        "value": "Jussi Kalliokoski",
+        "count": 1
+      },
+      {
+        "value": "Jérémy Lal",
+        "count": 1
+      },
+      {
+        "value": "Kai Chen",
+        "count": 1
+      },
+      {
+        "value": "Karl Horky",
+        "count": 1
+      },
+      {
+        "value": "Karolis Narkevicius",
+        "count": 1
+      },
+      {
+        "value": "Karsten Tinnefeld",
+        "count": 1
+      },
+      {
+        "value": "Kat Marchán",
+        "count": 1
+      },
+      {
+        "value": "Kazuhito Hokamura",
+        "count": 1
+      },
+      {
+        "value": "Kei Son",
+        "count": 1
+      },
+      {
+        "value": "Kenan Yildirim",
+        "count": 1
+      },
+      {
+        "value": "Kevin Kragenbrink",
+        "count": 1
+      },
+      {
+        "value": "KevinSheedy",
+        "count": 1
+      },
+      {
+        "value": "Kris Kowal",
+        "count": 1
+      },
+      {
+        "value": "Kris Windham",
+        "count": 1
+      },
+      {
+        "value": "Kyle M. Tarplee",
+        "count": 1
+      },
+      {
+        "value": "Kyle Mitchell",
+        "count": 1
+      },
+      {
+        "value": "Larz Conwell",
+        "count": 1
+      },
+      {
+        "value": "Laurie Harper",
+        "count": 1
+      },
+      {
+        "value": "Laurie Voss",
+        "count": 1
+      },
+      {
+        "value": "Lin Clark",
+        "count": 1
+      },
+      {
+        "value": "Luc Thevenard",
+        "count": 1
+      },
+      {
+        "value": "Ludwig Magnusson",
+        "count": 1
+      },
+      {
+        "value": "Luke Arduini",
+        "count": 1
+      },
+      {
+        "value": "Maciej Małecki",
+        "count": 1
+      },
+      {
+        "value": "Marcel Klehr",
+        "count": 1
+      },
+      {
+        "value": "Marcin Wosinek",
+        "count": 1
+      },
+      {
+        "value": "Marcus Ekwall",
+        "count": 1
+      },
+      {
+        "value": "Mark Cahill",
+        "count": 1
+      },
+      {
+        "value": "Mark Dube",
+        "count": 1
+      },
+      {
+        "value": "Mark J. Titorenko",
+        "count": 1
+      },
+      {
+        "value": "Martin Cooper",
+        "count": 1
+      },
+      {
+        "value": "Martyn Smith",
+        "count": 1
+      },
+      {
+        "value": "Mat Tyndall",
+        "count": 1
+      },
+      {
+        "value": "Mathias Bynens",
+        "count": 1
+      },
+      {
+        "value": "Matt Brennan",
+        "count": 1
+      },
+      {
+        "value": "Matt Colyer",
+        "count": 1
+      },
+      {
+        "value": "Matt Hickford",
+        "count": 1
+      },
+      {
+        "value": "Matt Lunn",
+        "count": 1
+      },
+      {
+        "value": "Matt McClure",
+        "count": 1
+      },
+      {
+        "value": "Matt Zorn",
+        "count": 1
+      },
+      {
+        "value": "Max Goodman",
+        "count": 1
+      },
+      {
+        "value": "Maxim Bogushevich",
+        "count": 1
+      },
+      {
+        "value": "Maximilian Antoni",
+        "count": 1
+      },
+      {
+        "value": "Meaglin",
+        "count": 1
+      },
+      {
+        "value": "Michael Budde",
+        "count": 1
+      },
+      {
+        "value": "Michael Hayes",
+        "count": 1
+      },
+      {
+        "value": "Michael Klein",
+        "count": 1
+      },
+      {
+        "value": "Michael Nisi",
+        "count": 1
+      },
+      {
+        "value": "Michiel Sikma",
+        "count": 1
+      },
+      {
+        "value": "Mick Thompson",
+        "count": 1
+      },
+      {
+        "value": "Mike MacCana",
+        "count": 1
+      },
+      {
+        "value": "Mikeal Rogers",
+        "count": 1
+      },
+      {
+        "value": "Mikola Lysenko",
+        "count": 1
+      },
+      {
+        "value": "Miroslav Bajtoš",
+        "count": 1
+      },
+      {
+        "value": "Nathan Rajlich",
+        "count": 1
+      },
+      {
+        "value": "Nathan Zadoks",
+        "count": 1
+      },
+      {
+        "value": "Neil Gentleman",
+        "count": 1
+      },
+      {
+        "value": "Nicholas Kinsey",
+        "count": 1
+      },
+      {
+        "value": "Nick Heiner",
+        "count": 1
+      },
+      {
+        "value": "Nick Malaguti",
+        "count": 1
+      },
+      {
+        "value": "Nick Santos",
+        "count": 1
+      },
+      {
+        "value": "Nicolas Morel",
+        "count": 1
+      },
+      {
+        "value": "Niggler",
+        "count": 1
+      },
+      {
+        "value": "Oddur Sigurdsson",
+        "count": 1
+      },
+      {
+        "value": "Oleg Efimov",
+        "count": 1
+      },
+      {
+        "value": "Oli Evans",
+        "count": 1
+      },
+      {
+        "value": "Olivier Melcher",
+        "count": 1
+      },
+      {
+        "value": "Orlando Vazquez",
+        "count": 1
+      },
+      {
+        "value": "Paolo Fragomeni",
+        "count": 1
+      },
+      {
+        "value": "Patrick Pfeiffer",
+        "count": 1
+      },
+      {
+        "value": "Paul Miller",
+        "count": 1
+      },
+      {
+        "value": "Paul Vorbach",
+        "count": 1
+      },
+      {
+        "value": "Paulo Cesar",
+        "count": 1
+      },
+      {
+        "value": "Pete Kruckenberg",
+        "count": 1
+      },
+      {
+        "value": "Peter A. Shevtsov",
+        "count": 1
+      },
+      {
+        "value": "Peter Richardson",
+        "count": 1
+      },
+      {
+        "value": "Phillip Howell",
+        "count": 1
+      },
+      {
+        "value": "Quim Calpe",
+        "count": 1
+      },
+      {
+        "value": "Quinn Slack",
+        "count": 1
+      },
+      {
+        "value": "Ra'Shaun Stovall",
+        "count": 1
+      },
+      {
+        "value": "Rachel Hutchison",
+        "count": 1
+      },
+      {
+        "value": "Rafael de Oleza",
+        "count": 1
+      },
+      {
+        "value": "Rebecca Turner",
+        "count": 1
+      },
+      {
+        "value": "Reid Burke",
+        "count": 1
+      },
+      {
+        "value": "Ribettes",
+        "count": 1
+      },
+      {
+        "value": "Richard Littauer",
+        "count": 1
+      },
+      {
+        "value": "Robert Gieseke",
+        "count": 1
+      },
+      {
+        "value": "Robert Kowalski",
+        "count": 1
+      },
+      {
+        "value": "Robin Tweedie",
+        "count": 1
+      },
+      {
+        "value": "Rod Vagg",
+        "count": 1
+      },
+      {
+        "value": "Ron Martinez",
+        "count": 1
+      },
+      {
+        "value": "Ryan Emery",
+        "count": 1
+      },
+      {
+        "value": "Ryan Temple",
+        "count": 1
+      },
+      {
+        "value": "Sam Mikes",
+        "count": 1
+      },
+      {
+        "value": "Schabse Laks",
+        "count": 1
+      },
+      {
+        "value": "Scott Bronson",
+        "count": 1
+      },
+      {
+        "value": "Sean McGivern",
+        "count": 1
+      },
+      {
+        "value": "Sergey Belov",
+        "count": 1
+      },
+      {
+        "value": "Shawn Wildermuth",
+        "count": 1
+      },
+      {
+        "value": "Simen Bekkhus",
+        "count": 1
+      },
+      {
+        "value": "Spain Train",
+        "count": 1
+      },
+      {
+        "value": "Stephan Bönnemann",
+        "count": 1
+      },
+      {
+        "value": "Stephen Sugden",
+        "count": 1
+      },
+      {
+        "value": "Steve Klabnik",
+        "count": 1
+      },
+      {
+        "value": "Steve Mason",
+        "count": 1
+      },
+      {
+        "value": "Steve Steiner",
+        "count": 1
+      },
+      {
+        "value": "Stuart Knightley",
+        "count": 1
+      },
+      {
+        "value": "Stuart P. Bentley",
+        "count": 1
+      },
+      {
+        "value": "Sébastien Santoro",
+        "count": 1
+      },
+      {
+        "value": "TJ Holowaychuk",
+        "count": 1
+      },
+      {
+        "value": "Takaya Kobayashi",
+        "count": 1
+      },
+      {
+        "value": "Tauren Mills",
+        "count": 1
+      },
+      {
+        "value": "Terin Stock",
+        "count": 1
+      },
+      {
+        "value": "Thaddee Tyl",
+        "count": 1
+      },
+      {
+        "value": "Thom Blake",
+        "count": 1
+      },
+      {
+        "value": "Thomas Cort",
+        "count": 1
+      },
+      {
+        "value": "Thomas Torp",
+        "count": 1
+      },
+      {
+        "value": "Thorsten Lorenz",
+        "count": 1
+      },
+      {
+        "value": "Tim Oxley",
+        "count": 1
+      },
+      {
+        "value": "Tim Whidden",
+        "count": 1
+      },
+      {
+        "value": "Timo Derstappen",
+        "count": 1
+      },
+      {
+        "value": "Timo Weiß",
+        "count": 1
+      },
+      {
+        "value": "Tom Huang",
+        "count": 1
+      },
+      {
+        "value": "Tomaž Muraus",
+        "count": 1
+      },
+      {
+        "value": "Tony",
+        "count": 1
+      },
+      {
+        "value": "Tor Valamo",
+        "count": 1
+      },
+      {
+        "value": "Trent Mick",
+        "count": 1
+      },
+      {
+        "value": "Trevor Burnham",
+        "count": 1
+      },
+      {
+        "value": "Tristan Davies",
+        "count": 1
+      },
+      {
+        "value": "Tyler Green",
+        "count": 1
+      },
+      {
+        "value": "Vaz Allen",
+        "count": 1
+      },
+      {
+        "value": "Victor",
+        "count": 1
+      },
+      {
+        "value": "Visnu Pitiyanuvath",
+        "count": 1
+      },
+      {
+        "value": "Vladimir Rutsky",
+        "count": 1
+      },
+      {
+        "value": "Wesley de Souza",
+        "count": 1
+      },
+      {
+        "value": "Whyme.Lyu",
+        "count": 1
+      },
+      {
+        "value": "Wil Moore III",
+        "count": 1
+      },
+      {
+        "value": "Will Elwood",
+        "count": 1
+      },
+      {
+        "value": "Wout Mertens",
+        "count": 1
+      },
+      {
+        "value": "Yazhong Liu",
+        "count": 1
+      },
+      {
+        "value": "Yeonghoon Park",
+        "count": 1
+      },
+      {
+        "value": "Zach Pomerantz",
+        "count": 1
+      },
+      {
+        "value": "Zeke Sikelianos",
         "count": 1
       }
     ],
@@ -3923,7 +5083,1167 @@
         ],
         "authors": [
           {
+            "value": "Aaron Blohowiak",
+            "count": 1
+          },
+          {
+            "value": "Aaron Stacy",
+            "count": 1
+          },
+          {
+            "value": "Adam Blackburn",
+            "count": 1
+          },
+          {
+            "value": "Adam Meadows",
+            "count": 1
+          },
+          {
+            "value": "Adrian Lynch",
+            "count": 1
+          },
+          {
+            "value": "Alain Kalker",
+            "count": 1
+          },
+          {
+            "value": "Alan Shaw",
+            "count": 1
+          },
+          {
+            "value": "Aleksey Smolenchuk",
+            "count": 1
+          },
+          {
+            "value": "Alex Ford",
+            "count": 1
+          },
+          {
+            "value": "Alex Gorbatchev",
+            "count": 1
+          },
+          {
+            "value": "Alex K. Wolfe",
+            "count": 1
+          },
+          {
+            "value": "Alex Kocharin",
+            "count": 1
+          },
+          {
+            "value": "Alex Rodionov",
+            "count": 1
+          },
+          {
+            "value": "Alexej Yaroshevich",
+            "count": 1
+          },
+          {
+            "value": "Alexey Kreschuk",
+            "count": 1
+          },
+          {
+            "value": "Anders Janmyr",
+            "count": 1
+          },
+          {
+            "value": "Andreas",
+            "count": 1
+          },
+          {
+            "value": "Andrew",
+            "count": 1
+          },
+          {
+            "value": "Andrew Bradley",
+            "count": 1
+          },
+          {
+            "value": "Andrew Horton",
+            "count": 1
+          },
+          {
+            "value": "Andrew Lunny",
+            "count": 1
+          },
+          {
+            "value": "Andrew Murray",
+            "count": 1
+          },
+          {
+            "value": "Andrew Terris",
+            "count": 1
+          },
+          {
+            "value": "Andrey Fedorov",
+            "count": 1
+          },
+          {
+            "value": "Andrey Kislyuk",
+            "count": 1
+          },
+          {
+            "value": "Anthony Zotti",
+            "count": 1
+          },
+          {
+            "value": "Antti Mattila",
+            "count": 1
+          },
+          {
+            "value": "Aria Stewart",
+            "count": 1
+          },
+          {
+            "value": "Arlo Breault",
+            "count": 1
+          },
+          {
+            "value": "Arnaud Rinquin",
+            "count": 1
+          },
+          {
+            "value": "Bart Teeuwisse",
+            "count": 1
+          },
+          {
+            "value": "Ben Evans",
+            "count": 1
+          },
+          {
+            "value": "Ben Noordhuis",
+            "count": 1
+          },
+          {
+            "value": "Ben Page",
+            "count": 1
+          },
+          {
+            "value": "Benjamin Coe",
+            "count": 1
+          },
+          {
+            "value": "Blaine Bublitz",
+            "count": 1
+          },
+          {
+            "value": "Bradley Meck",
+            "count": 1
+          },
+          {
+            "value": "Brian White",
+            "count": 1
+          },
+          {
+            "value": "Bryan Burgers",
+            "count": 1
+          },
+          {
+            "value": "Bryan English",
+            "count": 1
+          },
+          {
+            "value": "Bryant Williams",
+            "count": 1
+          },
+          {
+            "value": "C J Silverio",
+            "count": 1
+          },
+          {
+            "value": "CamilleM",
+            "count": 1
+          },
+          {
+            "value": "Carl Lange",
+            "count": 1
+          },
+          {
+            "value": "Cedric Nelson",
+            "count": 1
+          },
+          {
+            "value": "Charlie Robbins",
+            "count": 1
+          },
+          {
+            "value": "Charlie Rudolph",
+            "count": 1
+          },
+          {
+            "value": "Charmander",
+            "count": 1
+          },
+          {
+            "value": "Chris Dickinson",
+            "count": 1
+          },
+          {
+            "value": "Chris Meyers",
+            "count": 1
+          },
+          {
+            "value": "Chris Williams",
+            "count": 1
+          },
+          {
+            "value": "Chris Wong",
+            "count": 1
+          },
+          {
+            "value": "Christian Eager",
+            "count": 1
+          },
+          {
+            "value": "Christian Howe",
+            "count": 1
+          },
+          {
+            "value": "Christopher Hiller",
+            "count": 1
+          },
+          {
+            "value": "Chulki Lee",
+            "count": 1
+          },
+          {
+            "value": "Clay Carpenter",
+            "count": 1
+          },
+          {
+            "value": "Cliffano Subagio",
+            "count": 1
+          },
+          {
+            "value": "Conny Brunnkvist",
+            "count": 1
+          },
+          {
+            "value": "Daijiro Wachi",
+            "count": 1
+          },
+          {
+            "value": "Dalmais Maxence",
+            "count": 1
+          },
+          {
+            "value": "Daniel Santiago",
+            "count": 1
+          },
+          {
+            "value": "Danila Gerasimov",
+            "count": 1
+          },
+          {
+            "value": "Danny Fritz",
+            "count": 1
+          },
+          {
+            "value": "Dav Glass",
+            "count": 1
+          },
+          {
+            "value": "Dave Pacheco",
+            "count": 1
+          },
+          {
+            "value": "David Beitey",
+            "count": 1
+          },
+          {
+            "value": "David Glasser",
+            "count": 1
+          },
+          {
+            "value": "David Marr",
+            "count": 1
+          },
+          {
+            "value": "David Trejo",
+            "count": 1
+          },
+          {
+            "value": "David Volm",
+            "count": 1
+          },
+          {
+            "value": "Dean Landolt",
+            "count": 1
+          },
+          {
+            "value": "Denis Gladkikh",
+            "count": 1
+          },
+          {
+            "value": "Derek Peterson",
+            "count": 1
+          },
+          {
+            "value": "Di Wu",
+            "count": 1
+          },
+          {
+            "value": "Domenic Denicola",
+            "count": 1
+          },
+          {
+            "value": "Don Park",
+            "count": 1
+          },
+          {
+            "value": "Dylan Greene",
+            "count": 1
+          },
+          {
+            "value": "Ed Morley",
+            "count": 1
+          },
+          {
+            "value": "Eduardo Pinho",
+            "count": 1
+          },
+          {
+            "value": "Einar Otto Stangvik",
+            "count": 1
+          },
+          {
+            "value": "Elan Shanker",
+            "count": 1
+          },
+          {
+            "value": "Eric Mill",
+            "count": 1
+          },
+          {
+            "value": "Erik Wienhold",
+            "count": 1
+          },
+          {
+            "value": "Eugene Sharygin",
+            "count": 1
+          },
+          {
+            "value": "Evan Lucas",
+            "count": 1
+          },
+          {
+            "value": "Evan Meagher",
+            "count": 1
+          },
+          {
+            "value": "Evan You",
+            "count": 1
+          },
+          {
+            "value": "Faiq Raza",
+            "count": 1
+          },
+          {
+            "value": "Federico Romero",
+            "count": 1
+          },
+          {
+            "value": "Felix Geisendörfer",
+            "count": 1
+          },
+          {
+            "value": "Felix Rabe",
+            "count": 1
+          },
+          {
+            "value": "Filip Weiss",
+            "count": 1
+          },
+          {
+            "value": "Florian Margaine",
+            "count": 1
+          },
+          {
+            "value": "Forbes Lindesay",
+            "count": 1
+          },
+          {
+            "value": "Forrest L Norvell",
+            "count": 1
+          },
+          {
+            "value": "Francisco Treacy",
+            "count": 1
+          },
+          {
+            "value": "Franck Cuny",
+            "count": 1
+          },
+          {
+            "value": "François Frisch",
+            "count": 1
+          },
+          {
+            "value": "Gabriel Barros",
+            "count": 1
+          },
+          {
+            "value": "Gabriel Falkenberg",
+            "count": 1
+          },
+          {
+            "value": "Gautham Pai",
+            "count": 1
+          },
+          {
+            "value": "Geoff Flarity",
+            "count": 1
+          },
+          {
+            "value": "George Miroshnykov",
+            "count": 1
+          },
+          {
+            "value": "George Ornbo",
+            "count": 1
+          },
+          {
+            "value": "Gianluca Casati",
+            "count": 1
+          },
+          {
+            "value": "Greg Whiteley",
+            "count": 1
+          },
+          {
+            "value": "Guðlaugur Stefán Egilsson",
+            "count": 1
+          },
+          {
+            "value": "Helge Skogly Holm",
+            "count": 1
+          },
+          {
+            "value": "Henrik Hodne",
+            "count": 1
+          },
+          {
+            "value": "Hunter Loftis",
+            "count": 1
+          },
+          {
+            "value": "Iain Sproat",
+            "count": 1
+          },
+          {
+            "value": "Ian Babrou",
+            "count": 1
+          },
+          {
+            "value": "Ian Livingstone",
+            "count": 1
+          },
+          {
+            "value": "Irakli Gozalishvili",
+            "count": 1
+          },
+          {
+            "value": "Isaac Murchie",
+            "count": 1
+          },
+          {
             "value": "Isaac Z. Schlueter",
+            "count": 1
+          },
+          {
+            "value": "J. Tangelder",
+            "count": 1
+          },
+          {
+            "value": "Jaakko Manninen",
+            "count": 1
+          },
+          {
+            "value": "Jake Verbaten",
+            "count": 1
+          },
+          {
+            "value": "Jakob Krigovsky",
+            "count": 1
+          },
+          {
+            "value": "James Butler",
+            "count": 1
+          },
+          {
+            "value": "James Halliday",
+            "count": 1
+          },
+          {
+            "value": "James Sanders",
+            "count": 1
+          },
+          {
+            "value": "James Talmage",
+            "count": 1
+          },
+          {
+            "value": "Jameson Little",
+            "count": 1
+          },
+          {
+            "value": "Jan Lehnardt",
+            "count": 1
+          },
+          {
+            "value": "Jann Horn",
+            "count": 1
+          },
+          {
+            "value": "Jason Diamond",
+            "count": 1
+          },
+          {
+            "value": "Jason Smith",
+            "count": 1
+          },
+          {
+            "value": "Jean Lauliac",
+            "count": 1
+          },
+          {
+            "value": "Jed Schmidt",
+            "count": 1
+          },
+          {
+            "value": "Jeff Barczewski",
+            "count": 1
+          },
+          {
+            "value": "Jeff Jo",
+            "count": 1
+          },
+          {
+            "value": "Jens Grunert",
+            "count": 1
+          },
+          {
+            "value": "Jeremiah Senkpiel",
+            "count": 1
+          },
+          {
+            "value": "Jeremy Cantrell",
+            "count": 1
+          },
+          {
+            "value": "Jess Martin",
+            "count": 1
+          },
+          {
+            "value": "Johan Nordberg",
+            "count": 1
+          },
+          {
+            "value": "Johan Sköld",
+            "count": 1
+          },
+          {
+            "value": "Jon Spencer",
+            "count": 1
+          },
+          {
+            "value": "Jonas Weber",
+            "count": 1
+          },
+          {
+            "value": "Joost-Wim Boekesteijn",
+            "count": 1
+          },
+          {
+            "value": "Jordan Harband",
+            "count": 1
+          },
+          {
+            "value": "Joseph Dykstra",
+            "count": 1
+          },
+          {
+            "value": "Joshua Egan",
+            "count": 1
+          },
+          {
+            "value": "Julian Gruber",
+            "count": 1
+          },
+          {
+            "value": "Julien Meddah",
+            "count": 1
+          },
+          {
+            "value": "Jussi Kalliokoski",
+            "count": 1
+          },
+          {
+            "value": "Jérémy Lal",
+            "count": 1
+          },
+          {
+            "value": "Kai Chen",
+            "count": 1
+          },
+          {
+            "value": "Karl Horky",
+            "count": 1
+          },
+          {
+            "value": "Karolis Narkevicius",
+            "count": 1
+          },
+          {
+            "value": "Karsten Tinnefeld",
+            "count": 1
+          },
+          {
+            "value": "Kat Marchán",
+            "count": 1
+          },
+          {
+            "value": "Kazuhito Hokamura",
+            "count": 1
+          },
+          {
+            "value": "Kei Son",
+            "count": 1
+          },
+          {
+            "value": "Kenan Yildirim",
+            "count": 1
+          },
+          {
+            "value": "Kevin Kragenbrink",
+            "count": 1
+          },
+          {
+            "value": "KevinSheedy",
+            "count": 1
+          },
+          {
+            "value": "Kris Kowal",
+            "count": 1
+          },
+          {
+            "value": "Kris Windham",
+            "count": 1
+          },
+          {
+            "value": "Kyle M. Tarplee",
+            "count": 1
+          },
+          {
+            "value": "Kyle Mitchell",
+            "count": 1
+          },
+          {
+            "value": "Larz Conwell",
+            "count": 1
+          },
+          {
+            "value": "Laurie Harper",
+            "count": 1
+          },
+          {
+            "value": "Laurie Voss",
+            "count": 1
+          },
+          {
+            "value": "Lin Clark",
+            "count": 1
+          },
+          {
+            "value": "Luc Thevenard",
+            "count": 1
+          },
+          {
+            "value": "Ludwig Magnusson",
+            "count": 1
+          },
+          {
+            "value": "Luke Arduini",
+            "count": 1
+          },
+          {
+            "value": "Maciej Małecki",
+            "count": 1
+          },
+          {
+            "value": "Marcel Klehr",
+            "count": 1
+          },
+          {
+            "value": "Marcin Wosinek",
+            "count": 1
+          },
+          {
+            "value": "Marcus Ekwall",
+            "count": 1
+          },
+          {
+            "value": "Mark Cahill",
+            "count": 1
+          },
+          {
+            "value": "Mark Dube",
+            "count": 1
+          },
+          {
+            "value": "Mark J. Titorenko",
+            "count": 1
+          },
+          {
+            "value": "Martin Cooper",
+            "count": 1
+          },
+          {
+            "value": "Martyn Smith",
+            "count": 1
+          },
+          {
+            "value": "Mat Tyndall",
+            "count": 1
+          },
+          {
+            "value": "Mathias Bynens",
+            "count": 1
+          },
+          {
+            "value": "Matt Brennan",
+            "count": 1
+          },
+          {
+            "value": "Matt Colyer",
+            "count": 1
+          },
+          {
+            "value": "Matt Hickford",
+            "count": 1
+          },
+          {
+            "value": "Matt Lunn",
+            "count": 1
+          },
+          {
+            "value": "Matt McClure",
+            "count": 1
+          },
+          {
+            "value": "Matt Zorn",
+            "count": 1
+          },
+          {
+            "value": "Max Goodman",
+            "count": 1
+          },
+          {
+            "value": "Maxim Bogushevich",
+            "count": 1
+          },
+          {
+            "value": "Maximilian Antoni",
+            "count": 1
+          },
+          {
+            "value": "Meaglin",
+            "count": 1
+          },
+          {
+            "value": "Michael Budde",
+            "count": 1
+          },
+          {
+            "value": "Michael Hayes",
+            "count": 1
+          },
+          {
+            "value": "Michael Klein",
+            "count": 1
+          },
+          {
+            "value": "Michael Nisi",
+            "count": 1
+          },
+          {
+            "value": "Michiel Sikma",
+            "count": 1
+          },
+          {
+            "value": "Mick Thompson",
+            "count": 1
+          },
+          {
+            "value": "Mike MacCana",
+            "count": 1
+          },
+          {
+            "value": "Mikeal Rogers",
+            "count": 1
+          },
+          {
+            "value": "Mikola Lysenko",
+            "count": 1
+          },
+          {
+            "value": "Miroslav Bajtoš",
+            "count": 1
+          },
+          {
+            "value": "Nathan Rajlich",
+            "count": 1
+          },
+          {
+            "value": "Nathan Zadoks",
+            "count": 1
+          },
+          {
+            "value": "Neil Gentleman",
+            "count": 1
+          },
+          {
+            "value": "Nicholas Kinsey",
+            "count": 1
+          },
+          {
+            "value": "Nick Heiner",
+            "count": 1
+          },
+          {
+            "value": "Nick Malaguti",
+            "count": 1
+          },
+          {
+            "value": "Nick Santos",
+            "count": 1
+          },
+          {
+            "value": "Nicolas Morel",
+            "count": 1
+          },
+          {
+            "value": "Niggler",
+            "count": 1
+          },
+          {
+            "value": "Oddur Sigurdsson",
+            "count": 1
+          },
+          {
+            "value": "Oleg Efimov",
+            "count": 1
+          },
+          {
+            "value": "Oli Evans",
+            "count": 1
+          },
+          {
+            "value": "Olivier Melcher",
+            "count": 1
+          },
+          {
+            "value": "Orlando Vazquez",
+            "count": 1
+          },
+          {
+            "value": "Paolo Fragomeni",
+            "count": 1
+          },
+          {
+            "value": "Patrick Pfeiffer",
+            "count": 1
+          },
+          {
+            "value": "Paul Miller",
+            "count": 1
+          },
+          {
+            "value": "Paul Vorbach",
+            "count": 1
+          },
+          {
+            "value": "Paulo Cesar",
+            "count": 1
+          },
+          {
+            "value": "Pete Kruckenberg",
+            "count": 1
+          },
+          {
+            "value": "Peter A. Shevtsov",
+            "count": 1
+          },
+          {
+            "value": "Peter Richardson",
+            "count": 1
+          },
+          {
+            "value": "Phillip Howell",
+            "count": 1
+          },
+          {
+            "value": "Quim Calpe",
+            "count": 1
+          },
+          {
+            "value": "Quinn Slack",
+            "count": 1
+          },
+          {
+            "value": "Ra'Shaun Stovall",
+            "count": 1
+          },
+          {
+            "value": "Rachel Hutchison",
+            "count": 1
+          },
+          {
+            "value": "Rafael de Oleza",
+            "count": 1
+          },
+          {
+            "value": "Rebecca Turner",
+            "count": 1
+          },
+          {
+            "value": "Reid Burke",
+            "count": 1
+          },
+          {
+            "value": "Ribettes",
+            "count": 1
+          },
+          {
+            "value": "Richard Littauer",
+            "count": 1
+          },
+          {
+            "value": "Robert Gieseke",
+            "count": 1
+          },
+          {
+            "value": "Robert Kowalski",
+            "count": 1
+          },
+          {
+            "value": "Robin Tweedie",
+            "count": 1
+          },
+          {
+            "value": "Rod Vagg",
+            "count": 1
+          },
+          {
+            "value": "Ron Martinez",
+            "count": 1
+          },
+          {
+            "value": "Ryan Emery",
+            "count": 1
+          },
+          {
+            "value": "Ryan Temple",
+            "count": 1
+          },
+          {
+            "value": "Sam Mikes",
+            "count": 1
+          },
+          {
+            "value": "Schabse Laks",
+            "count": 1
+          },
+          {
+            "value": "Scott Bronson",
+            "count": 1
+          },
+          {
+            "value": "Sean McGivern",
+            "count": 1
+          },
+          {
+            "value": "Sergey Belov",
+            "count": 1
+          },
+          {
+            "value": "Shawn Wildermuth",
+            "count": 1
+          },
+          {
+            "value": "Simen Bekkhus",
+            "count": 1
+          },
+          {
+            "value": "Spain Train",
+            "count": 1
+          },
+          {
+            "value": "Stephan Bönnemann",
+            "count": 1
+          },
+          {
+            "value": "Stephen Sugden",
+            "count": 1
+          },
+          {
+            "value": "Steve Klabnik",
+            "count": 1
+          },
+          {
+            "value": "Steve Mason",
+            "count": 1
+          },
+          {
+            "value": "Steve Steiner",
+            "count": 1
+          },
+          {
+            "value": "Stuart Knightley",
+            "count": 1
+          },
+          {
+            "value": "Stuart P. Bentley",
+            "count": 1
+          },
+          {
+            "value": "Sébastien Santoro",
+            "count": 1
+          },
+          {
+            "value": "TJ Holowaychuk",
+            "count": 1
+          },
+          {
+            "value": "Takaya Kobayashi",
+            "count": 1
+          },
+          {
+            "value": "Tauren Mills",
+            "count": 1
+          },
+          {
+            "value": "Terin Stock",
+            "count": 1
+          },
+          {
+            "value": "Thaddee Tyl",
+            "count": 1
+          },
+          {
+            "value": "Thom Blake",
+            "count": 1
+          },
+          {
+            "value": "Thomas Cort",
+            "count": 1
+          },
+          {
+            "value": "Thomas Torp",
+            "count": 1
+          },
+          {
+            "value": "Thorsten Lorenz",
+            "count": 1
+          },
+          {
+            "value": "Tim Oxley",
+            "count": 1
+          },
+          {
+            "value": "Tim Whidden",
+            "count": 1
+          },
+          {
+            "value": "Timo Derstappen",
+            "count": 1
+          },
+          {
+            "value": "Timo Weiß",
+            "count": 1
+          },
+          {
+            "value": "Tom Huang",
+            "count": 1
+          },
+          {
+            "value": "Tomaž Muraus",
+            "count": 1
+          },
+          {
+            "value": "Tony",
+            "count": 1
+          },
+          {
+            "value": "Tor Valamo",
+            "count": 1
+          },
+          {
+            "value": "Trent Mick",
+            "count": 1
+          },
+          {
+            "value": "Trevor Burnham",
+            "count": 1
+          },
+          {
+            "value": "Tristan Davies",
+            "count": 1
+          },
+          {
+            "value": "Tyler Green",
+            "count": 1
+          },
+          {
+            "value": "Vaz Allen",
+            "count": 1
+          },
+          {
+            "value": "Victor",
+            "count": 1
+          },
+          {
+            "value": "Visnu Pitiyanuvath",
+            "count": 1
+          },
+          {
+            "value": "Vladimir Rutsky",
+            "count": 1
+          },
+          {
+            "value": "Wesley de Souza",
+            "count": 1
+          },
+          {
+            "value": "Whyme.Lyu",
+            "count": 1
+          },
+          {
+            "value": "Wil Moore III",
+            "count": 1
+          },
+          {
+            "value": "Will Elwood",
+            "count": 1
+          },
+          {
+            "value": "Wout Mertens",
+            "count": 1
+          },
+          {
+            "value": "Yazhong Liu",
+            "count": 1
+          },
+          {
+            "value": "Yeonghoon Park",
+            "count": 1
+          },
+          {
+            "value": "Zach Pomerantz",
+            "count": 1
+          },
+          {
+            "value": "Zeke Sikelianos",
             "count": 1
           }
         ],
@@ -5278,7 +7598,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Toma\u017e Muraus",
+              "name": "Tomaž Muraus",
               "email": "kami@k5-storitve.net",
               "url": null
             },
@@ -5404,7 +7724,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Felix Geisendo\u0308rfer",
+              "name": "Felix Geisendörfer",
               "email": "felix@debuggable.com",
               "url": null
             },
@@ -5467,7 +7787,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Maciej Ma\u0142ecki",
+              "name": "Maciej Małecki",
               "email": "me@mmalecki.com",
               "url": null
             },
@@ -5796,7 +8116,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Johan Sk\u00f6ld",
+              "name": "Johan Sköld",
               "email": "johan@skold.cc",
               "url": null
             },
@@ -5957,7 +8277,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Franc\u0327ois Frisch",
+              "name": "François Frisch",
               "email": "francoisfrisch@gmail.com",
               "url": null
             },
@@ -6132,7 +8452,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "S\u00e9bastien Santoro",
+              "name": "Sébastien Santoro",
               "email": "dereckson@espace-win.org",
               "url": null
             },
@@ -6349,7 +8669,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Miroslav Bajto\u0161",
+              "name": "Miroslav Bajtoš",
               "email": "miroslav@strongloop.com",
               "url": null
             },
@@ -6503,7 +8823,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "\u4e0d\u56db",
+              "name": "不四",
               "email": "busi.hyy@taobao.com",
               "url": null
             },
@@ -6566,7 +8886,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Timo Wei\u00df",
+              "name": "Timo Weiß",
               "email": "timoweiss@Timo-MBP.local",
               "url": null
             },
@@ -6580,7 +8900,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "J\u00e9r\u00e9my Lal",
+              "name": "Jérémy Lal",
               "email": "kapouer@melix.org",
               "url": null
             },
@@ -6867,7 +9187,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Gu\u00f0laugur Stef\u00e1n Egilsson",
+              "name": "Guðlaugur Stefán Egilsson",
               "email": "gulli@kolibri.is",
               "url": null
             },
@@ -7140,7 +9460,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Kat March\u00e1n",
+              "name": "Kat Marchán",
               "email": "kzm@sykosomatic.org",
               "url": null
             },
@@ -7245,7 +9565,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Stephan B\u00f6nnemann",
+              "name": "Stephan Bönnemann",
               "email": "stephan@excellenteasy.com",
               "url": null
             },
@@ -8245,7 +10565,1457 @@
         {
           "author": "Isaac Z. Schlueter",
           "start_line": 16,
-          "end_line": 17
+          "end_line": 19
+        },
+        {
+          "author": "Steve Steiner",
+          "start_line": 205,
+          "end_line": 205
+        },
+        {
+          "author": "Mikeal Rogers",
+          "start_line": 209,
+          "end_line": 209
+        },
+        {
+          "author": "Aaron Blohowiak",
+          "start_line": 213,
+          "end_line": 213
+        },
+        {
+          "author": "Martyn Smith",
+          "start_line": 217,
+          "end_line": 217
+        },
+        {
+          "author": "Charlie Robbins",
+          "start_line": 221,
+          "end_line": 221
+        },
+        {
+          "author": "Francisco Treacy",
+          "start_line": 225,
+          "end_line": 225
+        },
+        {
+          "author": "Cliffano Subagio",
+          "start_line": 229,
+          "end_line": 229
+        },
+        {
+          "author": "Christian Eager",
+          "start_line": 233,
+          "end_line": 233
+        },
+        {
+          "author": "Dav Glass",
+          "start_line": 237,
+          "end_line": 237
+        },
+        {
+          "author": "Alex K. Wolfe",
+          "start_line": 241,
+          "end_line": 241
+        },
+        {
+          "author": "James Sanders",
+          "start_line": 245,
+          "end_line": 245
+        },
+        {
+          "author": "Reid Burke",
+          "start_line": 249,
+          "end_line": 249
+        },
+        {
+          "author": "Arlo Breault",
+          "start_line": 253,
+          "end_line": 253
+        },
+        {
+          "author": "Timo Derstappen",
+          "start_line": 257,
+          "end_line": 257
+        },
+        {
+          "author": "Bart Teeuwisse",
+          "start_line": 261,
+          "end_line": 261
+        },
+        {
+          "author": "Ben Noordhuis",
+          "start_line": 265,
+          "end_line": 265
+        },
+        {
+          "author": "Tor Valamo",
+          "start_line": 269,
+          "end_line": 269
+        },
+        {
+          "author": "Whyme.Lyu",
+          "start_line": 273,
+          "end_line": 273
+        },
+        {
+          "author": "Olivier Melcher",
+          "start_line": 277,
+          "end_line": 277
+        },
+        {
+          "author": "Tomaž Muraus",
+          "start_line": 281,
+          "end_line": 281
+        },
+        {
+          "author": "Evan Meagher",
+          "start_line": 285,
+          "end_line": 285
+        },
+        {
+          "author": "Orlando Vazquez",
+          "start_line": 289,
+          "end_line": 289
+        },
+        {
+          "author": "Kai Chen",
+          "start_line": 293,
+          "end_line": 293
+        },
+        {
+          "author": "George Miroshnykov",
+          "start_line": 297,
+          "end_line": 297
+        },
+        {
+          "author": "Geoff Flarity",
+          "start_line": 301,
+          "end_line": 301
+        },
+        {
+          "author": "Max Goodman",
+          "start_line": 305,
+          "end_line": 305
+        },
+        {
+          "author": "Pete Kruckenberg",
+          "start_line": 309,
+          "end_line": 309
+        },
+        {
+          "author": "Laurie Harper",
+          "start_line": 313,
+          "end_line": 313
+        },
+        {
+          "author": "Chris Wong",
+          "start_line": 317,
+          "end_line": 317
+        },
+        {
+          "author": "Scott Bronson",
+          "start_line": 321,
+          "end_line": 321
+        },
+        {
+          "author": "Federico Romero",
+          "start_line": 325,
+          "end_line": 325
+        },
+        {
+          "author": "Visnu Pitiyanuvath",
+          "start_line": 329,
+          "end_line": 329
+        },
+        {
+          "author": "Irakli Gozalishvili",
+          "start_line": 333,
+          "end_line": 333
+        },
+        {
+          "author": "Mark Cahill",
+          "start_line": 337,
+          "end_line": 337
+        },
+        {
+          "author": "Tony",
+          "start_line": 341,
+          "end_line": 341
+        },
+        {
+          "author": "Iain Sproat",
+          "start_line": 345,
+          "end_line": 345
+        },
+        {
+          "author": "Trent Mick",
+          "start_line": 349,
+          "end_line": 349
+        },
+        {
+          "author": "Felix Geisendörfer",
+          "start_line": 353,
+          "end_line": 353
+        },
+        {
+          "author": "Jameson Little",
+          "start_line": 357,
+          "end_line": 357
+        },
+        {
+          "author": "Conny Brunnkvist",
+          "start_line": 361,
+          "end_line": 361
+        },
+        {
+          "author": "Will Elwood",
+          "start_line": 365,
+          "end_line": 365
+        },
+        {
+          "author": "Dean Landolt",
+          "start_line": 369,
+          "end_line": 369
+        },
+        {
+          "author": "Oleg Efimov",
+          "start_line": 373,
+          "end_line": 373
+        },
+        {
+          "author": "Martin Cooper",
+          "start_line": 377,
+          "end_line": 377
+        },
+        {
+          "author": "Jann Horn",
+          "start_line": 381,
+          "end_line": 381
+        },
+        {
+          "author": "Andrew Bradley",
+          "start_line": 385,
+          "end_line": 385
+        },
+        {
+          "author": "Maciej Małecki",
+          "start_line": 389,
+          "end_line": 389
+        },
+        {
+          "author": "Stephen Sugden",
+          "start_line": 393,
+          "end_line": 393
+        },
+        {
+          "author": "Michael Budde",
+          "start_line": 397,
+          "end_line": 397
+        },
+        {
+          "author": "Jason Smith",
+          "start_line": 401,
+          "end_line": 401
+        },
+        {
+          "author": "Gautham Pai",
+          "start_line": 405,
+          "end_line": 405
+        },
+        {
+          "author": "David Trejo",
+          "start_line": 409,
+          "end_line": 409
+        },
+        {
+          "author": "Paul Vorbach",
+          "start_line": 413,
+          "end_line": 413
+        },
+        {
+          "author": "George Ornbo",
+          "start_line": 417,
+          "end_line": 417
+        },
+        {
+          "author": "Tim Oxley",
+          "start_line": 421,
+          "end_line": 421
+        },
+        {
+          "author": "Tyler Green",
+          "start_line": 425,
+          "end_line": 425
+        },
+        {
+          "author": "Dave Pacheco",
+          "start_line": 429,
+          "end_line": 429
+        },
+        {
+          "author": "Danila Gerasimov",
+          "start_line": 433,
+          "end_line": 433
+        },
+        {
+          "author": "Rod Vagg",
+          "start_line": 437,
+          "end_line": 437
+        },
+        {
+          "author": "Christian Howe",
+          "start_line": 441,
+          "end_line": 441
+        },
+        {
+          "author": "Andrew Lunny",
+          "start_line": 445,
+          "end_line": 445
+        },
+        {
+          "author": "Henrik Hodne",
+          "start_line": 449,
+          "end_line": 449
+        },
+        {
+          "author": "Adam Blackburn",
+          "start_line": 453,
+          "end_line": 453
+        },
+        {
+          "author": "Kris Windham",
+          "start_line": 457,
+          "end_line": 457
+        },
+        {
+          "author": "Jens Grunert",
+          "start_line": 461,
+          "end_line": 461
+        },
+        {
+          "author": "Joost-Wim Boekesteijn",
+          "start_line": 465,
+          "end_line": 465
+        },
+        {
+          "author": "Dalmais Maxence",
+          "start_line": 469,
+          "end_line": 469
+        },
+        {
+          "author": "Marcus Ekwall",
+          "start_line": 473,
+          "end_line": 473
+        },
+        {
+          "author": "Aaron Stacy",
+          "start_line": 477,
+          "end_line": 477
+        },
+        {
+          "author": "Phillip Howell",
+          "start_line": 481,
+          "end_line": 481
+        },
+        {
+          "author": "Domenic Denicola",
+          "start_line": 485,
+          "end_line": 485
+        },
+        {
+          "author": "James Halliday",
+          "start_line": 489,
+          "end_line": 489
+        },
+        {
+          "author": "Jeremy Cantrell",
+          "start_line": 493,
+          "end_line": 493
+        },
+        {
+          "author": "Ribettes",
+          "start_line": 497,
+          "end_line": 497
+        },
+        {
+          "author": "Don Park",
+          "start_line": 501,
+          "end_line": 501
+        },
+        {
+          "author": "Einar Otto Stangvik",
+          "start_line": 505,
+          "end_line": 505
+        },
+        {
+          "author": "Kei Son",
+          "start_line": 509,
+          "end_line": 509
+        },
+        {
+          "author": "Nicolas Morel",
+          "start_line": 513,
+          "end_line": 513
+        },
+        {
+          "author": "Mark Dube",
+          "start_line": 517,
+          "end_line": 517
+        },
+        {
+          "author": "Nathan Rajlich",
+          "start_line": 521,
+          "end_line": 521
+        },
+        {
+          "author": "Maxim Bogushevich",
+          "start_line": 525,
+          "end_line": 525
+        },
+        {
+          "author": "Meaglin",
+          "start_line": 529,
+          "end_line": 529
+        },
+        {
+          "author": "Ben Evans",
+          "start_line": 533,
+          "end_line": 533
+        },
+        {
+          "author": "Nathan Zadoks",
+          "start_line": 537,
+          "end_line": 537
+        },
+        {
+          "author": "Brian White",
+          "start_line": 541,
+          "end_line": 541
+        },
+        {
+          "author": "Jed Schmidt",
+          "start_line": 545,
+          "end_line": 545
+        },
+        {
+          "author": "Ian Livingstone",
+          "start_line": 549,
+          "end_line": 549
+        },
+        {
+          "author": "Patrick Pfeiffer",
+          "start_line": 553,
+          "end_line": 553
+        },
+        {
+          "author": "Paul Miller",
+          "start_line": 557,
+          "end_line": 557
+        },
+        {
+          "author": "Ryan Emery",
+          "start_line": 561,
+          "end_line": 561
+        },
+        {
+          "author": "Carl Lange",
+          "start_line": 565,
+          "end_line": 565
+        },
+        {
+          "author": "Jan Lehnardt",
+          "start_line": 569,
+          "end_line": 569
+        },
+        {
+          "author": "Stuart P. Bentley",
+          "start_line": 573,
+          "end_line": 573
+        },
+        {
+          "author": "Johan Sköld",
+          "start_line": 577,
+          "end_line": 577
+        },
+        {
+          "author": "Stuart Knightley",
+          "start_line": 581,
+          "end_line": 581
+        },
+        {
+          "author": "Niggler",
+          "start_line": 585,
+          "end_line": 585
+        },
+        {
+          "author": "Paolo Fragomeni",
+          "start_line": 589,
+          "end_line": 589
+        },
+        {
+          "author": "Jaakko Manninen",
+          "start_line": 593,
+          "end_line": 593
+        },
+        {
+          "author": "Luke Arduini",
+          "start_line": 597,
+          "end_line": 597
+        },
+        {
+          "author": "Larz Conwell",
+          "start_line": 601,
+          "end_line": 601
+        },
+        {
+          "author": "Marcel Klehr",
+          "start_line": 606,
+          "end_line": 606
+        },
+        {
+          "author": "Robert Kowalski",
+          "start_line": 610,
+          "end_line": 610
+        },
+        {
+          "author": "Forbes Lindesay",
+          "start_line": 614,
+          "end_line": 614
+        },
+        {
+          "author": "Vaz Allen",
+          "start_line": 618,
+          "end_line": 618
+        },
+        {
+          "author": "Jake Verbaten",
+          "start_line": 622,
+          "end_line": 622
+        },
+        {
+          "author": "Schabse Laks",
+          "start_line": 626,
+          "end_line": 626
+        },
+        {
+          "author": "Florian Margaine",
+          "start_line": 630,
+          "end_line": 630
+        },
+        {
+          "author": "Johan Nordberg",
+          "start_line": 634,
+          "end_line": 634
+        },
+        {
+          "author": "Ian Babrou",
+          "start_line": 638,
+          "end_line": 638
+        },
+        {
+          "author": "Di Wu",
+          "start_line": 642,
+          "end_line": 642
+        },
+        {
+          "author": "Mathias Bynens",
+          "start_line": 646,
+          "end_line": 646
+        },
+        {
+          "author": "Matt McClure",
+          "start_line": 650,
+          "end_line": 650
+        },
+        {
+          "author": "Matt Lunn",
+          "start_line": 654,
+          "end_line": 654
+        },
+        {
+          "author": "Alexey Kreschuk",
+          "start_line": 658,
+          "end_line": 658
+        },
+        {
+          "author": "Robert Gieseke",
+          "start_line": 666,
+          "end_line": 666
+        },
+        {
+          "author": "François Frisch",
+          "start_line": 670,
+          "end_line": 670
+        },
+        {
+          "author": "Trevor Burnham",
+          "start_line": 674,
+          "end_line": 674
+        },
+        {
+          "author": "Alan Shaw",
+          "start_line": 678,
+          "end_line": 678
+        },
+        {
+          "author": "TJ Holowaychuk",
+          "start_line": 682,
+          "end_line": 682
+        },
+        {
+          "author": "Nicholas Kinsey",
+          "start_line": 686,
+          "end_line": 686
+        },
+        {
+          "author": "Paulo Cesar",
+          "start_line": 690,
+          "end_line": 690
+        },
+        {
+          "author": "Elan Shanker",
+          "start_line": 694,
+          "end_line": 694
+        },
+        {
+          "author": "Jon Spencer",
+          "start_line": 698,
+          "end_line": 698
+        },
+        {
+          "author": "Jason Diamond",
+          "start_line": 702,
+          "end_line": 702
+        },
+        {
+          "author": "Maximilian Antoni",
+          "start_line": 706,
+          "end_line": 706
+        },
+        {
+          "author": "Thom Blake",
+          "start_line": 710,
+          "end_line": 710
+        },
+        {
+          "author": "Jess Martin",
+          "start_line": 714,
+          "end_line": 714
+        },
+        {
+          "author": "Spain Train",
+          "start_line": 718,
+          "end_line": 718
+        },
+        {
+          "author": "Alex Rodionov",
+          "start_line": 722,
+          "end_line": 722
+        },
+        {
+          "author": "Matt Colyer",
+          "start_line": 726,
+          "end_line": 726
+        },
+        {
+          "author": "Evan You",
+          "start_line": 730,
+          "end_line": 730
+        },
+        {
+          "author": "Gabriel Falkenberg",
+          "start_line": 738,
+          "end_line": 738
+        },
+        {
+          "author": "Alexej Yaroshevich",
+          "start_line": 742,
+          "end_line": 742
+        },
+        {
+          "author": "Quim Calpe",
+          "start_line": 746,
+          "end_line": 746
+        },
+        {
+          "author": "Steve Mason",
+          "start_line": 750,
+          "end_line": 750
+        },
+        {
+          "author": "Wil Moore III",
+          "start_line": 754,
+          "end_line": 754
+        },
+        {
+          "author": "Sergey Belov",
+          "start_line": 758,
+          "end_line": 758
+        },
+        {
+          "author": "Tom Huang",
+          "start_line": 762,
+          "end_line": 762
+        },
+        {
+          "author": "CamilleM",
+          "start_line": 766,
+          "end_line": 766
+        },
+        {
+          "author": "Sébastien Santoro",
+          "start_line": 770,
+          "end_line": 770
+        },
+        {
+          "author": "Evan Lucas",
+          "start_line": 774,
+          "end_line": 774
+        },
+        {
+          "author": "Quinn Slack",
+          "start_line": 778,
+          "end_line": 778
+        },
+        {
+          "author": "Alex Kocharin",
+          "start_line": 782,
+          "end_line": 782
+        },
+        {
+          "author": "Daniel Santiago",
+          "start_line": 786,
+          "end_line": 786
+        },
+        {
+          "author": "Denis Gladkikh",
+          "start_line": 790,
+          "end_line": 790
+        },
+        {
+          "author": "Andrew Horton",
+          "start_line": 794,
+          "end_line": 794
+        },
+        {
+          "author": "Zeke Sikelianos",
+          "start_line": 798,
+          "end_line": 798
+        },
+        {
+          "author": "Dylan Greene",
+          "start_line": 802,
+          "end_line": 802
+        },
+        {
+          "author": "Franck Cuny",
+          "start_line": 806,
+          "end_line": 806
+        },
+        {
+          "author": "Yeonghoon Park",
+          "start_line": 810,
+          "end_line": 810
+        },
+        {
+          "author": "Rafael de Oleza",
+          "start_line": 814,
+          "end_line": 814
+        },
+        {
+          "author": "Mikola Lysenko",
+          "start_line": 818,
+          "end_line": 818
+        },
+        {
+          "author": "Yazhong Liu",
+          "start_line": 822,
+          "end_line": 822
+        },
+        {
+          "author": "Neil Gentleman",
+          "start_line": 826,
+          "end_line": 826
+        },
+        {
+          "author": "Kris Kowal",
+          "start_line": 830,
+          "end_line": 830
+        },
+        {
+          "author": "Alex Gorbatchev",
+          "start_line": 834,
+          "end_line": 834
+        },
+        {
+          "author": "Shawn Wildermuth",
+          "start_line": 838,
+          "end_line": 838
+        },
+        {
+          "author": "Wesley de Souza",
+          "start_line": 842,
+          "end_line": 842
+        },
+        {
+          "author": "J. Tangelder",
+          "start_line": 850,
+          "end_line": 850
+        },
+        {
+          "author": "Jean Lauliac",
+          "start_line": 854,
+          "end_line": 854
+        },
+        {
+          "author": "Andrey Kislyuk",
+          "start_line": 858,
+          "end_line": 858
+        },
+        {
+          "author": "Thorsten Lorenz",
+          "start_line": 862,
+          "end_line": 862
+        },
+        {
+          "author": "Julian Gruber",
+          "start_line": 866,
+          "end_line": 866
+        },
+        {
+          "author": "Benjamin Coe",
+          "start_line": 870,
+          "end_line": 870
+        },
+        {
+          "author": "Alex Ford",
+          "start_line": 874,
+          "end_line": 874
+        },
+        {
+          "author": "Matt Hickford",
+          "start_line": 878,
+          "end_line": 878
+        },
+        {
+          "author": "Sean McGivern",
+          "start_line": 882,
+          "end_line": 882
+        },
+        {
+          "author": "C J Silverio",
+          "start_line": 886,
+          "end_line": 886
+        },
+        {
+          "author": "Robin Tweedie",
+          "start_line": 890,
+          "end_line": 890
+        },
+        {
+          "author": "Miroslav Bajtoš",
+          "start_line": 894,
+          "end_line": 894
+        },
+        {
+          "author": "David Glasser",
+          "start_line": 898,
+          "end_line": 898
+        },
+        {
+          "author": "Gianluca Casati",
+          "start_line": 902,
+          "end_line": 902
+        },
+        {
+          "author": "Forrest L Norvell",
+          "start_line": 906,
+          "end_line": 906
+        },
+        {
+          "author": "Karsten Tinnefeld",
+          "start_line": 910,
+          "end_line": 910
+        },
+        {
+          "author": "Bryan Burgers",
+          "start_line": 914,
+          "end_line": 914
+        },
+        {
+          "author": "David Beitey",
+          "start_line": 918,
+          "end_line": 918
+        },
+        {
+          "author": "Zach Pomerantz",
+          "start_line": 926,
+          "end_line": 926
+        },
+        {
+          "author": "Chris Williams",
+          "start_line": 930,
+          "end_line": 930
+        },
+        {
+          "author": "Mick Thompson",
+          "start_line": 938,
+          "end_line": 938
+        },
+        {
+          "author": "Felix Rabe",
+          "start_line": 942,
+          "end_line": 942
+        },
+        {
+          "author": "Michael Hayes",
+          "start_line": 946,
+          "end_line": 946
+        },
+        {
+          "author": "Chris Dickinson",
+          "start_line": 950,
+          "end_line": 950
+        },
+        {
+          "author": "Bradley Meck",
+          "start_line": 954,
+          "end_line": 954
+        },
+        {
+          "author": "Andrew Terris",
+          "start_line": 962,
+          "end_line": 962
+        },
+        {
+          "author": "Michael Nisi",
+          "start_line": 966,
+          "end_line": 966
+        },
+        {
+          "author": "Adam Meadows",
+          "start_line": 974,
+          "end_line": 974
+        },
+        {
+          "author": "Chulki Lee",
+          "start_line": 978,
+          "end_line": 978
+        },
+        {
+          "author": "Kenan Yildirim",
+          "start_line": 990,
+          "end_line": 990
+        },
+        {
+          "author": "Laurie Voss",
+          "start_line": 994,
+          "end_line": 994
+        },
+        {
+          "author": "Rebecca Turner",
+          "start_line": 998,
+          "end_line": 998
+        },
+        {
+          "author": "Hunter Loftis",
+          "start_line": 1002,
+          "end_line": 1002
+        },
+        {
+          "author": "Peter Richardson",
+          "start_line": 1006,
+          "end_line": 1006
+        },
+        {
+          "author": "Jussi Kalliokoski",
+          "start_line": 1010,
+          "end_line": 1010
+        },
+        {
+          "author": "Filip Weiss",
+          "start_line": 1014,
+          "end_line": 1014
+        },
+        {
+          "author": "Timo Weiß",
+          "start_line": 1018,
+          "end_line": 1018
+        },
+        {
+          "author": "Christopher Hiller",
+          "start_line": 1022,
+          "end_line": 1022
+        },
+        {
+          "author": "Jérémy Lal",
+          "start_line": 1026,
+          "end_line": 1026
+        },
+        {
+          "author": "Anders Janmyr",
+          "start_line": 1030,
+          "end_line": 1030
+        },
+        {
+          "author": "Chris Meyers",
+          "start_line": 1034,
+          "end_line": 1034
+        },
+        {
+          "author": "Ludwig Magnusson",
+          "start_line": 1038,
+          "end_line": 1038
+        },
+        {
+          "author": "Wout Mertens",
+          "start_line": 1042,
+          "end_line": 1042
+        },
+        {
+          "author": "Nick Santos",
+          "start_line": 1046,
+          "end_line": 1046
+        },
+        {
+          "author": "Terin Stock",
+          "start_line": 1050,
+          "end_line": 1050
+        },
+        {
+          "author": "Faiq Raza",
+          "start_line": 1054,
+          "end_line": 1054
+        },
+        {
+          "author": "Thomas Torp",
+          "start_line": 1058,
+          "end_line": 1058
+        },
+        {
+          "author": "Sam Mikes",
+          "start_line": 1062,
+          "end_line": 1062
+        },
+        {
+          "author": "Mat Tyndall",
+          "start_line": 1066,
+          "end_line": 1066
+        },
+        {
+          "author": "Tauren Mills",
+          "start_line": 1070,
+          "end_line": 1070
+        },
+        {
+          "author": "Ron Martinez",
+          "start_line": 1074,
+          "end_line": 1074
+        },
+        {
+          "author": "Kazuhito Hokamura",
+          "start_line": 1078,
+          "end_line": 1078
+        },
+        {
+          "author": "Tristan Davies",
+          "start_line": 1082,
+          "end_line": 1082
+        },
+        {
+          "author": "David Volm",
+          "start_line": 1086,
+          "end_line": 1086
+        },
+        {
+          "author": "Lin Clark",
+          "start_line": 1090,
+          "end_line": 1090
+        },
+        {
+          "author": "Ben Page",
+          "start_line": 1094,
+          "end_line": 1094
+        },
+        {
+          "author": "Jeff Jo",
+          "start_line": 1098,
+          "end_line": 1098
+        },
+        {
+          "author": "Mark J. Titorenko",
+          "start_line": 1106,
+          "end_line": 1106
+        },
+        {
+          "author": "Oddur Sigurdsson",
+          "start_line": 1110,
+          "end_line": 1110
+        },
+        {
+          "author": "Eric Mill",
+          "start_line": 1114,
+          "end_line": 1114
+        },
+        {
+          "author": "Gabriel Barros",
+          "start_line": 1118,
+          "end_line": 1118
+        },
+        {
+          "author": "KevinSheedy",
+          "start_line": 1122,
+          "end_line": 1122
+        },
+        {
+          "author": "Aleksey Smolenchuk",
+          "start_line": 1126,
+          "end_line": 1126
+        },
+        {
+          "author": "Ed Morley",
+          "start_line": 1130,
+          "end_line": 1130
+        },
+        {
+          "author": "Blaine Bublitz",
+          "start_line": 1134,
+          "end_line": 1134
+        },
+        {
+          "author": "Andrey Fedorov",
+          "start_line": 1138,
+          "end_line": 1138
+        },
+        {
+          "author": "Daijiro Wachi",
+          "start_line": 1142,
+          "end_line": 1142
+        },
+        {
+          "author": "Luc Thevenard",
+          "start_line": 1146,
+          "end_line": 1146
+        },
+        {
+          "author": "Aria Stewart",
+          "start_line": 1150,
+          "end_line": 1150
+        },
+        {
+          "author": "Charlie Rudolph",
+          "start_line": 1154,
+          "end_line": 1154
+        },
+        {
+          "author": "Vladimir Rutsky",
+          "start_line": 1158,
+          "end_line": 1158
+        },
+        {
+          "author": "Isaac Murchie",
+          "start_line": 1162,
+          "end_line": 1162
+        },
+        {
+          "author": "Marcin Wosinek",
+          "start_line": 1166,
+          "end_line": 1166
+        },
+        {
+          "author": "David Marr",
+          "start_line": 1170,
+          "end_line": 1170
+        },
+        {
+          "author": "Bryan English",
+          "start_line": 1174,
+          "end_line": 1174
+        },
+        {
+          "author": "Anthony Zotti",
+          "start_line": 1178,
+          "end_line": 1178
+        },
+        {
+          "author": "Karl Horky",
+          "start_line": 1182,
+          "end_line": 1182
+        },
+        {
+          "author": "Jordan Harband",
+          "start_line": 1186,
+          "end_line": 1186
+        },
+        {
+          "author": "Guðlaugur Stefán Egilsson",
+          "start_line": 1190,
+          "end_line": 1190
+        },
+        {
+          "author": "Helge Skogly Holm",
+          "start_line": 1194,
+          "end_line": 1194
+        },
+        {
+          "author": "Peter A. Shevtsov",
+          "start_line": 1198,
+          "end_line": 1198
+        },
+        {
+          "author": "Alain Kalker",
+          "start_line": 1202,
+          "end_line": 1202
+        },
+        {
+          "author": "Bryant Williams",
+          "start_line": 1206,
+          "end_line": 1206
+        },
+        {
+          "author": "Jonas Weber",
+          "start_line": 1210,
+          "end_line": 1210
+        },
+        {
+          "author": "Tim Whidden",
+          "start_line": 1214,
+          "end_line": 1214
+        },
+        {
+          "author": "Andreas",
+          "start_line": 1218,
+          "end_line": 1218
+        },
+        {
+          "author": "Karolis Narkevicius",
+          "start_line": 1222,
+          "end_line": 1222
+        },
+        {
+          "author": "Adrian Lynch",
+          "start_line": 1226,
+          "end_line": 1226
+        },
+        {
+          "author": "Richard Littauer",
+          "start_line": 1230,
+          "end_line": 1230
+        },
+        {
+          "author": "Oli Evans",
+          "start_line": 1234,
+          "end_line": 1234
+        },
+        {
+          "author": "Matt Brennan",
+          "start_line": 1238,
+          "end_line": 1238
+        },
+        {
+          "author": "Jeff Barczewski",
+          "start_line": 1242,
+          "end_line": 1242
+        },
+        {
+          "author": "Danny Fritz",
+          "start_line": 1246,
+          "end_line": 1246
+        },
+        {
+          "author": "Takaya Kobayashi",
+          "start_line": 1250,
+          "end_line": 1250
+        },
+        {
+          "author": "Ra'Shaun Stovall",
+          "start_line": 1254,
+          "end_line": 1254
+        },
+        {
+          "author": "Julien Meddah",
+          "start_line": 1258,
+          "end_line": 1258
+        },
+        {
+          "author": "Michiel Sikma",
+          "start_line": 1262,
+          "end_line": 1262
+        },
+        {
+          "author": "Jakob Krigovsky",
+          "start_line": 1266,
+          "end_line": 1266
+        },
+        {
+          "author": "Charmander",
+          "start_line": 1270,
+          "end_line": 1270
+        },
+        {
+          "author": "Erik Wienhold",
+          "start_line": 1274,
+          "end_line": 1274
+        },
+        {
+          "author": "James Butler",
+          "start_line": 1278,
+          "end_line": 1278
+        },
+        {
+          "author": "Kevin Kragenbrink",
+          "start_line": 1282,
+          "end_line": 1282
+        },
+        {
+          "author": "Arnaud Rinquin",
+          "start_line": 1286,
+          "end_line": 1286
+        },
+        {
+          "author": "Mike MacCana",
+          "start_line": 1290,
+          "end_line": 1290
+        },
+        {
+          "author": "Antti Mattila",
+          "start_line": 1294,
+          "end_line": 1294
+        },
+        {
+          "author": "Matt Zorn",
+          "start_line": 1302,
+          "end_line": 1302
+        },
+        {
+          "author": "Kyle Mitchell",
+          "start_line": 1306,
+          "end_line": 1306
+        },
+        {
+          "author": "Jeremiah Senkpiel",
+          "start_line": 1310,
+          "end_line": 1310
+        },
+        {
+          "author": "Michael Klein",
+          "start_line": 1314,
+          "end_line": 1314
+        },
+        {
+          "author": "Simen Bekkhus",
+          "start_line": 1318,
+          "end_line": 1318
+        },
+        {
+          "author": "Victor",
+          "start_line": 1322,
+          "end_line": 1322
+        },
+        {
+          "author": "Clay Carpenter",
+          "start_line": 1330,
+          "end_line": 1330
+        },
+        {
+          "author": "Nick Malaguti",
+          "start_line": 1338,
+          "end_line": 1338
+        },
+        {
+          "author": "Cedric Nelson",
+          "start_line": 1342,
+          "end_line": 1342
+        },
+        {
+          "author": "Kat Marchán",
+          "start_line": 1346,
+          "end_line": 1346
+        },
+        {
+          "author": "Andrew",
+          "start_line": 1350,
+          "end_line": 1350
+        },
+        {
+          "author": "Eduardo Pinho",
+          "start_line": 1354,
+          "end_line": 1354
+        },
+        {
+          "author": "Rachel Hutchison",
+          "start_line": 1358,
+          "end_line": 1358
+        },
+        {
+          "author": "Ryan Temple",
+          "start_line": 1362,
+          "end_line": 1362
+        },
+        {
+          "author": "Eugene Sharygin",
+          "start_line": 1366,
+          "end_line": 1366
+        },
+        {
+          "author": "Nick Heiner",
+          "start_line": 1370,
+          "end_line": 1370
+        },
+        {
+          "author": "James Talmage",
+          "start_line": 1374,
+          "end_line": 1374
+        },
+        {
+          "author": "Joseph Dykstra",
+          "start_line": 1382,
+          "end_line": 1382
+        },
+        {
+          "author": "Joshua Egan",
+          "start_line": 1386,
+          "end_line": 1386
+        },
+        {
+          "author": "Thomas Cort",
+          "start_line": 1390,
+          "end_line": 1390
+        },
+        {
+          "author": "Thaddee Tyl",
+          "start_line": 1394,
+          "end_line": 1394
+        },
+        {
+          "author": "Steve Klabnik",
+          "start_line": 1398,
+          "end_line": 1398
+        },
+        {
+          "author": "Andrew Murray",
+          "start_line": 1402,
+          "end_line": 1402
+        },
+        {
+          "author": "Stephan Bönnemann",
+          "start_line": 1406,
+          "end_line": 1406
+        },
+        {
+          "author": "Kyle M. Tarplee",
+          "start_line": 1410,
+          "end_line": 1410
+        },
+        {
+          "author": "Derek Peterson",
+          "start_line": 1414,
+          "end_line": 1414
+        },
+        {
+          "author": "Greg Whiteley",
+          "start_line": 1418,
+          "end_line": 1418
         }
       ],
       "emails": [

--- a/testdata/summarycode-golden/tallies/full_tallies/tallies_details.expected.json
+++ b/testdata/summarycode-golden/tallies/full_tallies/tallies_details.expected.json
@@ -161,7 +161,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Toma\u017e Muraus",
+          "name": "Tomaž Muraus",
           "email": "kami@k5-storitve.net",
           "url": null
         },
@@ -287,7 +287,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Felix Geisendo\u0308rfer",
+          "name": "Felix Geisendörfer",
           "email": "felix@debuggable.com",
           "url": null
         },
@@ -350,7 +350,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Maciej Ma\u0142ecki",
+          "name": "Maciej Małecki",
           "email": "me@mmalecki.com",
           "url": null
         },
@@ -679,7 +679,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Johan Sk\u00f6ld",
+          "name": "Johan Sköld",
           "email": "johan@skold.cc",
           "url": null
         },
@@ -840,7 +840,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Franc\u0327ois Frisch",
+          "name": "François Frisch",
           "email": "francoisfrisch@gmail.com",
           "url": null
         },
@@ -1015,7 +1015,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "S\u00e9bastien Santoro",
+          "name": "Sébastien Santoro",
           "email": "dereckson@espace-win.org",
           "url": null
         },
@@ -1232,7 +1232,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Miroslav Bajto\u0161",
+          "name": "Miroslav Bajtoš",
           "email": "miroslav@strongloop.com",
           "url": null
         },
@@ -1386,7 +1386,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "\u4e0d\u56db",
+          "name": "不四",
           "email": "busi.hyy@taobao.com",
           "url": null
         },
@@ -1449,7 +1449,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Timo Wei\u00df",
+          "name": "Timo Weiß",
           "email": "timoweiss@Timo-MBP.local",
           "url": null
         },
@@ -1463,7 +1463,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "J\u00e9r\u00e9my Lal",
+          "name": "Jérémy Lal",
           "email": "kapouer@melix.org",
           "url": null
         },
@@ -1750,7 +1750,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Gu\u00f0laugur Stef\u00e1n Egilsson",
+          "name": "Guðlaugur Stefán Egilsson",
           "email": "gulli@kolibri.is",
           "url": null
         },
@@ -2023,7 +2023,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Kat March\u00e1n",
+          "name": "Kat Marchán",
           "email": "kzm@sykosomatic.org",
           "url": null
         },
@@ -2128,7 +2128,7 @@
         {
           "type": "person",
           "role": "contributor",
-          "name": "Stephan B\u00f6nnemann",
+          "name": "Stephan Bönnemann",
           "email": "stephan@excellenteasy.com",
           "url": null
         },
@@ -3836,11 +3836,1171 @@
         "count": 4
       },
       {
+        "value": "Aaron Blohowiak",
+        "count": 1
+      },
+      {
+        "value": "Aaron Stacy",
+        "count": 1
+      },
+      {
+        "value": "Adam Blackburn",
+        "count": 1
+      },
+      {
+        "value": "Adam Meadows",
+        "count": 1
+      },
+      {
+        "value": "Adrian Lynch",
+        "count": 1
+      },
+      {
+        "value": "Alain Kalker",
+        "count": 1
+      },
+      {
+        "value": "Alan Shaw",
+        "count": 1
+      },
+      {
+        "value": "Aleksey Smolenchuk",
+        "count": 1
+      },
+      {
+        "value": "Alex Ford",
+        "count": 1
+      },
+      {
+        "value": "Alex Gorbatchev",
+        "count": 1
+      },
+      {
+        "value": "Alex K. Wolfe",
+        "count": 1
+      },
+      {
+        "value": "Alex Kocharin",
+        "count": 1
+      },
+      {
+        "value": "Alex Rodionov",
+        "count": 1
+      },
+      {
+        "value": "Alexej Yaroshevich",
+        "count": 1
+      },
+      {
+        "value": "Alexey Kreschuk",
+        "count": 1
+      },
+      {
+        "value": "Anders Janmyr",
+        "count": 1
+      },
+      {
+        "value": "Andreas",
+        "count": 1
+      },
+      {
+        "value": "Andrew",
+        "count": 1
+      },
+      {
+        "value": "Andrew Bradley",
+        "count": 1
+      },
+      {
+        "value": "Andrew Horton",
+        "count": 1
+      },
+      {
+        "value": "Andrew Lunny",
+        "count": 1
+      },
+      {
+        "value": "Andrew Murray",
+        "count": 1
+      },
+      {
+        "value": "Andrew Terris",
+        "count": 1
+      },
+      {
+        "value": "Andrey Fedorov",
+        "count": 1
+      },
+      {
+        "value": "Andrey Kislyuk",
+        "count": 1
+      },
+      {
+        "value": "Anthony Zotti",
+        "count": 1
+      },
+      {
+        "value": "Antti Mattila",
+        "count": 1
+      },
+      {
+        "value": "Aria Stewart",
+        "count": 1
+      },
+      {
+        "value": "Arlo Breault",
+        "count": 1
+      },
+      {
+        "value": "Arnaud Rinquin",
+        "count": 1
+      },
+      {
+        "value": "Bart Teeuwisse",
+        "count": 1
+      },
+      {
+        "value": "Ben Evans",
+        "count": 1
+      },
+      {
+        "value": "Ben Noordhuis",
+        "count": 1
+      },
+      {
+        "value": "Ben Page",
+        "count": 1
+      },
+      {
+        "value": "Benjamin Coe",
+        "count": 1
+      },
+      {
+        "value": "Blaine Bublitz",
+        "count": 1
+      },
+      {
+        "value": "Bradley Meck",
+        "count": 1
+      },
+      {
+        "value": "Brian White",
+        "count": 1
+      },
+      {
+        "value": "Bryan Burgers",
+        "count": 1
+      },
+      {
+        "value": "Bryan English",
+        "count": 1
+      },
+      {
+        "value": "Bryant Williams",
+        "count": 1
+      },
+      {
+        "value": "C J Silverio",
+        "count": 1
+      },
+      {
+        "value": "CamilleM",
+        "count": 1
+      },
+      {
+        "value": "Carl Lange",
+        "count": 1
+      },
+      {
+        "value": "Cedric Nelson",
+        "count": 1
+      },
+      {
+        "value": "Charlie Robbins",
+        "count": 1
+      },
+      {
+        "value": "Charlie Rudolph",
+        "count": 1
+      },
+      {
+        "value": "Charmander",
+        "count": 1
+      },
+      {
+        "value": "Chris Dickinson",
+        "count": 1
+      },
+      {
+        "value": "Chris Meyers",
+        "count": 1
+      },
+      {
+        "value": "Chris Williams",
+        "count": 1
+      },
+      {
+        "value": "Chris Wong",
+        "count": 1
+      },
+      {
+        "value": "Christian Eager",
+        "count": 1
+      },
+      {
+        "value": "Christian Howe",
+        "count": 1
+      },
+      {
+        "value": "Christopher Hiller",
+        "count": 1
+      },
+      {
+        "value": "Chulki Lee",
+        "count": 1
+      },
+      {
+        "value": "Clay Carpenter",
+        "count": 1
+      },
+      {
+        "value": "Cliffano Subagio",
+        "count": 1
+      },
+      {
+        "value": "Conny Brunnkvist",
+        "count": 1
+      },
+      {
+        "value": "Daijiro Wachi",
+        "count": 1
+      },
+      {
+        "value": "Dalmais Maxence",
+        "count": 1
+      },
+      {
+        "value": "Daniel Santiago",
+        "count": 1
+      },
+      {
+        "value": "Danila Gerasimov",
+        "count": 1
+      },
+      {
+        "value": "Danny Fritz",
+        "count": 1
+      },
+      {
+        "value": "Dav Glass",
+        "count": 1
+      },
+      {
+        "value": "Dave Pacheco",
+        "count": 1
+      },
+      {
+        "value": "David Beitey",
+        "count": 1
+      },
+      {
+        "value": "David Glasser",
+        "count": 1
+      },
+      {
+        "value": "David Marr",
+        "count": 1
+      },
+      {
+        "value": "David Trejo",
+        "count": 1
+      },
+      {
+        "value": "David Volm",
+        "count": 1
+      },
+      {
+        "value": "Dean Landolt",
+        "count": 1
+      },
+      {
+        "value": "Denis Gladkikh",
+        "count": 1
+      },
+      {
+        "value": "Derek Peterson",
+        "count": 1
+      },
+      {
+        "value": "Di Wu",
+        "count": 1
+      },
+      {
+        "value": "Domenic Denicola",
+        "count": 1
+      },
+      {
+        "value": "Don Park",
+        "count": 1
+      },
+      {
+        "value": "Dylan Greene",
+        "count": 1
+      },
+      {
+        "value": "Ed Morley",
+        "count": 1
+      },
+      {
+        "value": "Eduardo Pinho",
+        "count": 1
+      },
+      {
+        "value": "Einar Otto Stangvik",
+        "count": 1
+      },
+      {
+        "value": "Elan Shanker",
+        "count": 1
+      },
+      {
+        "value": "Eric Mill",
+        "count": 1
+      },
+      {
+        "value": "Erik Wienhold",
+        "count": 1
+      },
+      {
+        "value": "Eugene Sharygin",
+        "count": 1
+      },
+      {
+        "value": "Evan Lucas",
+        "count": 1
+      },
+      {
+        "value": "Evan Meagher",
+        "count": 1
+      },
+      {
+        "value": "Evan You",
+        "count": 1
+      },
+      {
+        "value": "Faiq Raza",
+        "count": 1
+      },
+      {
+        "value": "Federico Romero",
+        "count": 1
+      },
+      {
+        "value": "Felix Geisendörfer",
+        "count": 1
+      },
+      {
+        "value": "Felix Rabe",
+        "count": 1
+      },
+      {
+        "value": "Filip Weiss",
+        "count": 1
+      },
+      {
+        "value": "Florian Margaine",
+        "count": 1
+      },
+      {
+        "value": "Forbes Lindesay",
+        "count": 1
+      },
+      {
+        "value": "Forrest L Norvell",
+        "count": 1
+      },
+      {
+        "value": "Francisco Treacy",
+        "count": 1
+      },
+      {
+        "value": "Franck Cuny",
+        "count": 1
+      },
+      {
+        "value": "François Frisch",
+        "count": 1
+      },
+      {
+        "value": "Gabriel Barros",
+        "count": 1
+      },
+      {
+        "value": "Gabriel Falkenberg",
+        "count": 1
+      },
+      {
+        "value": "Gautham Pai",
+        "count": 1
+      },
+      {
+        "value": "Geoff Flarity",
+        "count": 1
+      },
+      {
+        "value": "George Miroshnykov",
+        "count": 1
+      },
+      {
+        "value": "George Ornbo",
+        "count": 1
+      },
+      {
+        "value": "Gianluca Casati",
+        "count": 1
+      },
+      {
         "value": "Gilles Vollant",
         "count": 1
       },
       {
+        "value": "Greg Whiteley",
+        "count": 1
+      },
+      {
+        "value": "Guðlaugur Stefán Egilsson",
+        "count": 1
+      },
+      {
+        "value": "Helge Skogly Holm",
+        "count": 1
+      },
+      {
+        "value": "Henrik Hodne",
+        "count": 1
+      },
+      {
+        "value": "Hunter Loftis",
+        "count": 1
+      },
+      {
+        "value": "Iain Sproat",
+        "count": 1
+      },
+      {
+        "value": "Ian Babrou",
+        "count": 1
+      },
+      {
+        "value": "Ian Livingstone",
+        "count": 1
+      },
+      {
+        "value": "Irakli Gozalishvili",
+        "count": 1
+      },
+      {
+        "value": "Isaac Murchie",
+        "count": 1
+      },
+      {
         "value": "Isaac Z. Schlueter",
+        "count": 1
+      },
+      {
+        "value": "J. Tangelder",
+        "count": 1
+      },
+      {
+        "value": "Jaakko Manninen",
+        "count": 1
+      },
+      {
+        "value": "Jake Verbaten",
+        "count": 1
+      },
+      {
+        "value": "Jakob Krigovsky",
+        "count": 1
+      },
+      {
+        "value": "James Butler",
+        "count": 1
+      },
+      {
+        "value": "James Halliday",
+        "count": 1
+      },
+      {
+        "value": "James Sanders",
+        "count": 1
+      },
+      {
+        "value": "James Talmage",
+        "count": 1
+      },
+      {
+        "value": "Jameson Little",
+        "count": 1
+      },
+      {
+        "value": "Jan Lehnardt",
+        "count": 1
+      },
+      {
+        "value": "Jann Horn",
+        "count": 1
+      },
+      {
+        "value": "Jason Diamond",
+        "count": 1
+      },
+      {
+        "value": "Jason Smith",
+        "count": 1
+      },
+      {
+        "value": "Jean Lauliac",
+        "count": 1
+      },
+      {
+        "value": "Jed Schmidt",
+        "count": 1
+      },
+      {
+        "value": "Jeff Barczewski",
+        "count": 1
+      },
+      {
+        "value": "Jeff Jo",
+        "count": 1
+      },
+      {
+        "value": "Jens Grunert",
+        "count": 1
+      },
+      {
+        "value": "Jeremiah Senkpiel",
+        "count": 1
+      },
+      {
+        "value": "Jeremy Cantrell",
+        "count": 1
+      },
+      {
+        "value": "Jess Martin",
+        "count": 1
+      },
+      {
+        "value": "Johan Nordberg",
+        "count": 1
+      },
+      {
+        "value": "Johan Sköld",
+        "count": 1
+      },
+      {
+        "value": "Jon Spencer",
+        "count": 1
+      },
+      {
+        "value": "Jonas Weber",
+        "count": 1
+      },
+      {
+        "value": "Joost-Wim Boekesteijn",
+        "count": 1
+      },
+      {
+        "value": "Jordan Harband",
+        "count": 1
+      },
+      {
+        "value": "Joseph Dykstra",
+        "count": 1
+      },
+      {
+        "value": "Joshua Egan",
+        "count": 1
+      },
+      {
+        "value": "Julian Gruber",
+        "count": 1
+      },
+      {
+        "value": "Julien Meddah",
+        "count": 1
+      },
+      {
+        "value": "Jussi Kalliokoski",
+        "count": 1
+      },
+      {
+        "value": "Jérémy Lal",
+        "count": 1
+      },
+      {
+        "value": "Kai Chen",
+        "count": 1
+      },
+      {
+        "value": "Karl Horky",
+        "count": 1
+      },
+      {
+        "value": "Karolis Narkevicius",
+        "count": 1
+      },
+      {
+        "value": "Karsten Tinnefeld",
+        "count": 1
+      },
+      {
+        "value": "Kat Marchán",
+        "count": 1
+      },
+      {
+        "value": "Kazuhito Hokamura",
+        "count": 1
+      },
+      {
+        "value": "Kei Son",
+        "count": 1
+      },
+      {
+        "value": "Kenan Yildirim",
+        "count": 1
+      },
+      {
+        "value": "Kevin Kragenbrink",
+        "count": 1
+      },
+      {
+        "value": "KevinSheedy",
+        "count": 1
+      },
+      {
+        "value": "Kris Kowal",
+        "count": 1
+      },
+      {
+        "value": "Kris Windham",
+        "count": 1
+      },
+      {
+        "value": "Kyle M. Tarplee",
+        "count": 1
+      },
+      {
+        "value": "Kyle Mitchell",
+        "count": 1
+      },
+      {
+        "value": "Larz Conwell",
+        "count": 1
+      },
+      {
+        "value": "Laurie Harper",
+        "count": 1
+      },
+      {
+        "value": "Laurie Voss",
+        "count": 1
+      },
+      {
+        "value": "Lin Clark",
+        "count": 1
+      },
+      {
+        "value": "Luc Thevenard",
+        "count": 1
+      },
+      {
+        "value": "Ludwig Magnusson",
+        "count": 1
+      },
+      {
+        "value": "Luke Arduini",
+        "count": 1
+      },
+      {
+        "value": "Maciej Małecki",
+        "count": 1
+      },
+      {
+        "value": "Marcel Klehr",
+        "count": 1
+      },
+      {
+        "value": "Marcin Wosinek",
+        "count": 1
+      },
+      {
+        "value": "Marcus Ekwall",
+        "count": 1
+      },
+      {
+        "value": "Mark Cahill",
+        "count": 1
+      },
+      {
+        "value": "Mark Dube",
+        "count": 1
+      },
+      {
+        "value": "Mark J. Titorenko",
+        "count": 1
+      },
+      {
+        "value": "Martin Cooper",
+        "count": 1
+      },
+      {
+        "value": "Martyn Smith",
+        "count": 1
+      },
+      {
+        "value": "Mat Tyndall",
+        "count": 1
+      },
+      {
+        "value": "Mathias Bynens",
+        "count": 1
+      },
+      {
+        "value": "Matt Brennan",
+        "count": 1
+      },
+      {
+        "value": "Matt Colyer",
+        "count": 1
+      },
+      {
+        "value": "Matt Hickford",
+        "count": 1
+      },
+      {
+        "value": "Matt Lunn",
+        "count": 1
+      },
+      {
+        "value": "Matt McClure",
+        "count": 1
+      },
+      {
+        "value": "Matt Zorn",
+        "count": 1
+      },
+      {
+        "value": "Max Goodman",
+        "count": 1
+      },
+      {
+        "value": "Maxim Bogushevich",
+        "count": 1
+      },
+      {
+        "value": "Maximilian Antoni",
+        "count": 1
+      },
+      {
+        "value": "Meaglin",
+        "count": 1
+      },
+      {
+        "value": "Michael Budde",
+        "count": 1
+      },
+      {
+        "value": "Michael Hayes",
+        "count": 1
+      },
+      {
+        "value": "Michael Klein",
+        "count": 1
+      },
+      {
+        "value": "Michael Nisi",
+        "count": 1
+      },
+      {
+        "value": "Michiel Sikma",
+        "count": 1
+      },
+      {
+        "value": "Mick Thompson",
+        "count": 1
+      },
+      {
+        "value": "Mike MacCana",
+        "count": 1
+      },
+      {
+        "value": "Mikeal Rogers",
+        "count": 1
+      },
+      {
+        "value": "Mikola Lysenko",
+        "count": 1
+      },
+      {
+        "value": "Miroslav Bajtoš",
+        "count": 1
+      },
+      {
+        "value": "Nathan Rajlich",
+        "count": 1
+      },
+      {
+        "value": "Nathan Zadoks",
+        "count": 1
+      },
+      {
+        "value": "Neil Gentleman",
+        "count": 1
+      },
+      {
+        "value": "Nicholas Kinsey",
+        "count": 1
+      },
+      {
+        "value": "Nick Heiner",
+        "count": 1
+      },
+      {
+        "value": "Nick Malaguti",
+        "count": 1
+      },
+      {
+        "value": "Nick Santos",
+        "count": 1
+      },
+      {
+        "value": "Nicolas Morel",
+        "count": 1
+      },
+      {
+        "value": "Niggler",
+        "count": 1
+      },
+      {
+        "value": "Oddur Sigurdsson",
+        "count": 1
+      },
+      {
+        "value": "Oleg Efimov",
+        "count": 1
+      },
+      {
+        "value": "Oli Evans",
+        "count": 1
+      },
+      {
+        "value": "Olivier Melcher",
+        "count": 1
+      },
+      {
+        "value": "Orlando Vazquez",
+        "count": 1
+      },
+      {
+        "value": "Paolo Fragomeni",
+        "count": 1
+      },
+      {
+        "value": "Patrick Pfeiffer",
+        "count": 1
+      },
+      {
+        "value": "Paul Miller",
+        "count": 1
+      },
+      {
+        "value": "Paul Vorbach",
+        "count": 1
+      },
+      {
+        "value": "Paulo Cesar",
+        "count": 1
+      },
+      {
+        "value": "Pete Kruckenberg",
+        "count": 1
+      },
+      {
+        "value": "Peter A. Shevtsov",
+        "count": 1
+      },
+      {
+        "value": "Peter Richardson",
+        "count": 1
+      },
+      {
+        "value": "Phillip Howell",
+        "count": 1
+      },
+      {
+        "value": "Quim Calpe",
+        "count": 1
+      },
+      {
+        "value": "Quinn Slack",
+        "count": 1
+      },
+      {
+        "value": "Ra'Shaun Stovall",
+        "count": 1
+      },
+      {
+        "value": "Rachel Hutchison",
+        "count": 1
+      },
+      {
+        "value": "Rafael de Oleza",
+        "count": 1
+      },
+      {
+        "value": "Rebecca Turner",
+        "count": 1
+      },
+      {
+        "value": "Reid Burke",
+        "count": 1
+      },
+      {
+        "value": "Ribettes",
+        "count": 1
+      },
+      {
+        "value": "Richard Littauer",
+        "count": 1
+      },
+      {
+        "value": "Robert Gieseke",
+        "count": 1
+      },
+      {
+        "value": "Robert Kowalski",
+        "count": 1
+      },
+      {
+        "value": "Robin Tweedie",
+        "count": 1
+      },
+      {
+        "value": "Rod Vagg",
+        "count": 1
+      },
+      {
+        "value": "Ron Martinez",
+        "count": 1
+      },
+      {
+        "value": "Ryan Emery",
+        "count": 1
+      },
+      {
+        "value": "Ryan Temple",
+        "count": 1
+      },
+      {
+        "value": "Sam Mikes",
+        "count": 1
+      },
+      {
+        "value": "Schabse Laks",
+        "count": 1
+      },
+      {
+        "value": "Scott Bronson",
+        "count": 1
+      },
+      {
+        "value": "Sean McGivern",
+        "count": 1
+      },
+      {
+        "value": "Sergey Belov",
+        "count": 1
+      },
+      {
+        "value": "Shawn Wildermuth",
+        "count": 1
+      },
+      {
+        "value": "Simen Bekkhus",
+        "count": 1
+      },
+      {
+        "value": "Spain Train",
+        "count": 1
+      },
+      {
+        "value": "Stephan Bönnemann",
+        "count": 1
+      },
+      {
+        "value": "Stephen Sugden",
+        "count": 1
+      },
+      {
+        "value": "Steve Klabnik",
+        "count": 1
+      },
+      {
+        "value": "Steve Mason",
+        "count": 1
+      },
+      {
+        "value": "Steve Steiner",
+        "count": 1
+      },
+      {
+        "value": "Stuart Knightley",
+        "count": 1
+      },
+      {
+        "value": "Stuart P. Bentley",
+        "count": 1
+      },
+      {
+        "value": "Sébastien Santoro",
+        "count": 1
+      },
+      {
+        "value": "TJ Holowaychuk",
+        "count": 1
+      },
+      {
+        "value": "Takaya Kobayashi",
+        "count": 1
+      },
+      {
+        "value": "Tauren Mills",
+        "count": 1
+      },
+      {
+        "value": "Terin Stock",
+        "count": 1
+      },
+      {
+        "value": "Thaddee Tyl",
+        "count": 1
+      },
+      {
+        "value": "Thom Blake",
+        "count": 1
+      },
+      {
+        "value": "Thomas Cort",
+        "count": 1
+      },
+      {
+        "value": "Thomas Torp",
+        "count": 1
+      },
+      {
+        "value": "Thorsten Lorenz",
+        "count": 1
+      },
+      {
+        "value": "Tim Oxley",
+        "count": 1
+      },
+      {
+        "value": "Tim Whidden",
+        "count": 1
+      },
+      {
+        "value": "Timo Derstappen",
+        "count": 1
+      },
+      {
+        "value": "Timo Weiß",
+        "count": 1
+      },
+      {
+        "value": "Tom Huang",
+        "count": 1
+      },
+      {
+        "value": "Tomaž Muraus",
+        "count": 1
+      },
+      {
+        "value": "Tony",
+        "count": 1
+      },
+      {
+        "value": "Tor Valamo",
+        "count": 1
+      },
+      {
+        "value": "Trent Mick",
+        "count": 1
+      },
+      {
+        "value": "Trevor Burnham",
+        "count": 1
+      },
+      {
+        "value": "Tristan Davies",
+        "count": 1
+      },
+      {
+        "value": "Tyler Green",
+        "count": 1
+      },
+      {
+        "value": "Vaz Allen",
+        "count": 1
+      },
+      {
+        "value": "Victor",
+        "count": 1
+      },
+      {
+        "value": "Visnu Pitiyanuvath",
+        "count": 1
+      },
+      {
+        "value": "Vladimir Rutsky",
+        "count": 1
+      },
+      {
+        "value": "Wesley de Souza",
+        "count": 1
+      },
+      {
+        "value": "Whyme.Lyu",
+        "count": 1
+      },
+      {
+        "value": "Wil Moore III",
+        "count": 1
+      },
+      {
+        "value": "Will Elwood",
+        "count": 1
+      },
+      {
+        "value": "Wout Mertens",
+        "count": 1
+      },
+      {
+        "value": "Yazhong Liu",
+        "count": 1
+      },
+      {
+        "value": "Yeonghoon Park",
+        "count": 1
+      },
+      {
+        "value": "Zach Pomerantz",
+        "count": 1
+      },
+      {
+        "value": "Zeke Sikelianos",
         "count": 1
       }
     ],
@@ -4047,11 +5207,1171 @@
             "count": 4
           },
           {
+            "value": "Aaron Blohowiak",
+            "count": 1
+          },
+          {
+            "value": "Aaron Stacy",
+            "count": 1
+          },
+          {
+            "value": "Adam Blackburn",
+            "count": 1
+          },
+          {
+            "value": "Adam Meadows",
+            "count": 1
+          },
+          {
+            "value": "Adrian Lynch",
+            "count": 1
+          },
+          {
+            "value": "Alain Kalker",
+            "count": 1
+          },
+          {
+            "value": "Alan Shaw",
+            "count": 1
+          },
+          {
+            "value": "Aleksey Smolenchuk",
+            "count": 1
+          },
+          {
+            "value": "Alex Ford",
+            "count": 1
+          },
+          {
+            "value": "Alex Gorbatchev",
+            "count": 1
+          },
+          {
+            "value": "Alex K. Wolfe",
+            "count": 1
+          },
+          {
+            "value": "Alex Kocharin",
+            "count": 1
+          },
+          {
+            "value": "Alex Rodionov",
+            "count": 1
+          },
+          {
+            "value": "Alexej Yaroshevich",
+            "count": 1
+          },
+          {
+            "value": "Alexey Kreschuk",
+            "count": 1
+          },
+          {
+            "value": "Anders Janmyr",
+            "count": 1
+          },
+          {
+            "value": "Andreas",
+            "count": 1
+          },
+          {
+            "value": "Andrew",
+            "count": 1
+          },
+          {
+            "value": "Andrew Bradley",
+            "count": 1
+          },
+          {
+            "value": "Andrew Horton",
+            "count": 1
+          },
+          {
+            "value": "Andrew Lunny",
+            "count": 1
+          },
+          {
+            "value": "Andrew Murray",
+            "count": 1
+          },
+          {
+            "value": "Andrew Terris",
+            "count": 1
+          },
+          {
+            "value": "Andrey Fedorov",
+            "count": 1
+          },
+          {
+            "value": "Andrey Kislyuk",
+            "count": 1
+          },
+          {
+            "value": "Anthony Zotti",
+            "count": 1
+          },
+          {
+            "value": "Antti Mattila",
+            "count": 1
+          },
+          {
+            "value": "Aria Stewart",
+            "count": 1
+          },
+          {
+            "value": "Arlo Breault",
+            "count": 1
+          },
+          {
+            "value": "Arnaud Rinquin",
+            "count": 1
+          },
+          {
+            "value": "Bart Teeuwisse",
+            "count": 1
+          },
+          {
+            "value": "Ben Evans",
+            "count": 1
+          },
+          {
+            "value": "Ben Noordhuis",
+            "count": 1
+          },
+          {
+            "value": "Ben Page",
+            "count": 1
+          },
+          {
+            "value": "Benjamin Coe",
+            "count": 1
+          },
+          {
+            "value": "Blaine Bublitz",
+            "count": 1
+          },
+          {
+            "value": "Bradley Meck",
+            "count": 1
+          },
+          {
+            "value": "Brian White",
+            "count": 1
+          },
+          {
+            "value": "Bryan Burgers",
+            "count": 1
+          },
+          {
+            "value": "Bryan English",
+            "count": 1
+          },
+          {
+            "value": "Bryant Williams",
+            "count": 1
+          },
+          {
+            "value": "C J Silverio",
+            "count": 1
+          },
+          {
+            "value": "CamilleM",
+            "count": 1
+          },
+          {
+            "value": "Carl Lange",
+            "count": 1
+          },
+          {
+            "value": "Cedric Nelson",
+            "count": 1
+          },
+          {
+            "value": "Charlie Robbins",
+            "count": 1
+          },
+          {
+            "value": "Charlie Rudolph",
+            "count": 1
+          },
+          {
+            "value": "Charmander",
+            "count": 1
+          },
+          {
+            "value": "Chris Dickinson",
+            "count": 1
+          },
+          {
+            "value": "Chris Meyers",
+            "count": 1
+          },
+          {
+            "value": "Chris Williams",
+            "count": 1
+          },
+          {
+            "value": "Chris Wong",
+            "count": 1
+          },
+          {
+            "value": "Christian Eager",
+            "count": 1
+          },
+          {
+            "value": "Christian Howe",
+            "count": 1
+          },
+          {
+            "value": "Christopher Hiller",
+            "count": 1
+          },
+          {
+            "value": "Chulki Lee",
+            "count": 1
+          },
+          {
+            "value": "Clay Carpenter",
+            "count": 1
+          },
+          {
+            "value": "Cliffano Subagio",
+            "count": 1
+          },
+          {
+            "value": "Conny Brunnkvist",
+            "count": 1
+          },
+          {
+            "value": "Daijiro Wachi",
+            "count": 1
+          },
+          {
+            "value": "Dalmais Maxence",
+            "count": 1
+          },
+          {
+            "value": "Daniel Santiago",
+            "count": 1
+          },
+          {
+            "value": "Danila Gerasimov",
+            "count": 1
+          },
+          {
+            "value": "Danny Fritz",
+            "count": 1
+          },
+          {
+            "value": "Dav Glass",
+            "count": 1
+          },
+          {
+            "value": "Dave Pacheco",
+            "count": 1
+          },
+          {
+            "value": "David Beitey",
+            "count": 1
+          },
+          {
+            "value": "David Glasser",
+            "count": 1
+          },
+          {
+            "value": "David Marr",
+            "count": 1
+          },
+          {
+            "value": "David Trejo",
+            "count": 1
+          },
+          {
+            "value": "David Volm",
+            "count": 1
+          },
+          {
+            "value": "Dean Landolt",
+            "count": 1
+          },
+          {
+            "value": "Denis Gladkikh",
+            "count": 1
+          },
+          {
+            "value": "Derek Peterson",
+            "count": 1
+          },
+          {
+            "value": "Di Wu",
+            "count": 1
+          },
+          {
+            "value": "Domenic Denicola",
+            "count": 1
+          },
+          {
+            "value": "Don Park",
+            "count": 1
+          },
+          {
+            "value": "Dylan Greene",
+            "count": 1
+          },
+          {
+            "value": "Ed Morley",
+            "count": 1
+          },
+          {
+            "value": "Eduardo Pinho",
+            "count": 1
+          },
+          {
+            "value": "Einar Otto Stangvik",
+            "count": 1
+          },
+          {
+            "value": "Elan Shanker",
+            "count": 1
+          },
+          {
+            "value": "Eric Mill",
+            "count": 1
+          },
+          {
+            "value": "Erik Wienhold",
+            "count": 1
+          },
+          {
+            "value": "Eugene Sharygin",
+            "count": 1
+          },
+          {
+            "value": "Evan Lucas",
+            "count": 1
+          },
+          {
+            "value": "Evan Meagher",
+            "count": 1
+          },
+          {
+            "value": "Evan You",
+            "count": 1
+          },
+          {
+            "value": "Faiq Raza",
+            "count": 1
+          },
+          {
+            "value": "Federico Romero",
+            "count": 1
+          },
+          {
+            "value": "Felix Geisendörfer",
+            "count": 1
+          },
+          {
+            "value": "Felix Rabe",
+            "count": 1
+          },
+          {
+            "value": "Filip Weiss",
+            "count": 1
+          },
+          {
+            "value": "Florian Margaine",
+            "count": 1
+          },
+          {
+            "value": "Forbes Lindesay",
+            "count": 1
+          },
+          {
+            "value": "Forrest L Norvell",
+            "count": 1
+          },
+          {
+            "value": "Francisco Treacy",
+            "count": 1
+          },
+          {
+            "value": "Franck Cuny",
+            "count": 1
+          },
+          {
+            "value": "François Frisch",
+            "count": 1
+          },
+          {
+            "value": "Gabriel Barros",
+            "count": 1
+          },
+          {
+            "value": "Gabriel Falkenberg",
+            "count": 1
+          },
+          {
+            "value": "Gautham Pai",
+            "count": 1
+          },
+          {
+            "value": "Geoff Flarity",
+            "count": 1
+          },
+          {
+            "value": "George Miroshnykov",
+            "count": 1
+          },
+          {
+            "value": "George Ornbo",
+            "count": 1
+          },
+          {
+            "value": "Gianluca Casati",
+            "count": 1
+          },
+          {
             "value": "Gilles Vollant",
             "count": 1
           },
           {
+            "value": "Greg Whiteley",
+            "count": 1
+          },
+          {
+            "value": "Guðlaugur Stefán Egilsson",
+            "count": 1
+          },
+          {
+            "value": "Helge Skogly Holm",
+            "count": 1
+          },
+          {
+            "value": "Henrik Hodne",
+            "count": 1
+          },
+          {
+            "value": "Hunter Loftis",
+            "count": 1
+          },
+          {
+            "value": "Iain Sproat",
+            "count": 1
+          },
+          {
+            "value": "Ian Babrou",
+            "count": 1
+          },
+          {
+            "value": "Ian Livingstone",
+            "count": 1
+          },
+          {
+            "value": "Irakli Gozalishvili",
+            "count": 1
+          },
+          {
+            "value": "Isaac Murchie",
+            "count": 1
+          },
+          {
             "value": "Isaac Z. Schlueter",
+            "count": 1
+          },
+          {
+            "value": "J. Tangelder",
+            "count": 1
+          },
+          {
+            "value": "Jaakko Manninen",
+            "count": 1
+          },
+          {
+            "value": "Jake Verbaten",
+            "count": 1
+          },
+          {
+            "value": "Jakob Krigovsky",
+            "count": 1
+          },
+          {
+            "value": "James Butler",
+            "count": 1
+          },
+          {
+            "value": "James Halliday",
+            "count": 1
+          },
+          {
+            "value": "James Sanders",
+            "count": 1
+          },
+          {
+            "value": "James Talmage",
+            "count": 1
+          },
+          {
+            "value": "Jameson Little",
+            "count": 1
+          },
+          {
+            "value": "Jan Lehnardt",
+            "count": 1
+          },
+          {
+            "value": "Jann Horn",
+            "count": 1
+          },
+          {
+            "value": "Jason Diamond",
+            "count": 1
+          },
+          {
+            "value": "Jason Smith",
+            "count": 1
+          },
+          {
+            "value": "Jean Lauliac",
+            "count": 1
+          },
+          {
+            "value": "Jed Schmidt",
+            "count": 1
+          },
+          {
+            "value": "Jeff Barczewski",
+            "count": 1
+          },
+          {
+            "value": "Jeff Jo",
+            "count": 1
+          },
+          {
+            "value": "Jens Grunert",
+            "count": 1
+          },
+          {
+            "value": "Jeremiah Senkpiel",
+            "count": 1
+          },
+          {
+            "value": "Jeremy Cantrell",
+            "count": 1
+          },
+          {
+            "value": "Jess Martin",
+            "count": 1
+          },
+          {
+            "value": "Johan Nordberg",
+            "count": 1
+          },
+          {
+            "value": "Johan Sköld",
+            "count": 1
+          },
+          {
+            "value": "Jon Spencer",
+            "count": 1
+          },
+          {
+            "value": "Jonas Weber",
+            "count": 1
+          },
+          {
+            "value": "Joost-Wim Boekesteijn",
+            "count": 1
+          },
+          {
+            "value": "Jordan Harband",
+            "count": 1
+          },
+          {
+            "value": "Joseph Dykstra",
+            "count": 1
+          },
+          {
+            "value": "Joshua Egan",
+            "count": 1
+          },
+          {
+            "value": "Julian Gruber",
+            "count": 1
+          },
+          {
+            "value": "Julien Meddah",
+            "count": 1
+          },
+          {
+            "value": "Jussi Kalliokoski",
+            "count": 1
+          },
+          {
+            "value": "Jérémy Lal",
+            "count": 1
+          },
+          {
+            "value": "Kai Chen",
+            "count": 1
+          },
+          {
+            "value": "Karl Horky",
+            "count": 1
+          },
+          {
+            "value": "Karolis Narkevicius",
+            "count": 1
+          },
+          {
+            "value": "Karsten Tinnefeld",
+            "count": 1
+          },
+          {
+            "value": "Kat Marchán",
+            "count": 1
+          },
+          {
+            "value": "Kazuhito Hokamura",
+            "count": 1
+          },
+          {
+            "value": "Kei Son",
+            "count": 1
+          },
+          {
+            "value": "Kenan Yildirim",
+            "count": 1
+          },
+          {
+            "value": "Kevin Kragenbrink",
+            "count": 1
+          },
+          {
+            "value": "KevinSheedy",
+            "count": 1
+          },
+          {
+            "value": "Kris Kowal",
+            "count": 1
+          },
+          {
+            "value": "Kris Windham",
+            "count": 1
+          },
+          {
+            "value": "Kyle M. Tarplee",
+            "count": 1
+          },
+          {
+            "value": "Kyle Mitchell",
+            "count": 1
+          },
+          {
+            "value": "Larz Conwell",
+            "count": 1
+          },
+          {
+            "value": "Laurie Harper",
+            "count": 1
+          },
+          {
+            "value": "Laurie Voss",
+            "count": 1
+          },
+          {
+            "value": "Lin Clark",
+            "count": 1
+          },
+          {
+            "value": "Luc Thevenard",
+            "count": 1
+          },
+          {
+            "value": "Ludwig Magnusson",
+            "count": 1
+          },
+          {
+            "value": "Luke Arduini",
+            "count": 1
+          },
+          {
+            "value": "Maciej Małecki",
+            "count": 1
+          },
+          {
+            "value": "Marcel Klehr",
+            "count": 1
+          },
+          {
+            "value": "Marcin Wosinek",
+            "count": 1
+          },
+          {
+            "value": "Marcus Ekwall",
+            "count": 1
+          },
+          {
+            "value": "Mark Cahill",
+            "count": 1
+          },
+          {
+            "value": "Mark Dube",
+            "count": 1
+          },
+          {
+            "value": "Mark J. Titorenko",
+            "count": 1
+          },
+          {
+            "value": "Martin Cooper",
+            "count": 1
+          },
+          {
+            "value": "Martyn Smith",
+            "count": 1
+          },
+          {
+            "value": "Mat Tyndall",
+            "count": 1
+          },
+          {
+            "value": "Mathias Bynens",
+            "count": 1
+          },
+          {
+            "value": "Matt Brennan",
+            "count": 1
+          },
+          {
+            "value": "Matt Colyer",
+            "count": 1
+          },
+          {
+            "value": "Matt Hickford",
+            "count": 1
+          },
+          {
+            "value": "Matt Lunn",
+            "count": 1
+          },
+          {
+            "value": "Matt McClure",
+            "count": 1
+          },
+          {
+            "value": "Matt Zorn",
+            "count": 1
+          },
+          {
+            "value": "Max Goodman",
+            "count": 1
+          },
+          {
+            "value": "Maxim Bogushevich",
+            "count": 1
+          },
+          {
+            "value": "Maximilian Antoni",
+            "count": 1
+          },
+          {
+            "value": "Meaglin",
+            "count": 1
+          },
+          {
+            "value": "Michael Budde",
+            "count": 1
+          },
+          {
+            "value": "Michael Hayes",
+            "count": 1
+          },
+          {
+            "value": "Michael Klein",
+            "count": 1
+          },
+          {
+            "value": "Michael Nisi",
+            "count": 1
+          },
+          {
+            "value": "Michiel Sikma",
+            "count": 1
+          },
+          {
+            "value": "Mick Thompson",
+            "count": 1
+          },
+          {
+            "value": "Mike MacCana",
+            "count": 1
+          },
+          {
+            "value": "Mikeal Rogers",
+            "count": 1
+          },
+          {
+            "value": "Mikola Lysenko",
+            "count": 1
+          },
+          {
+            "value": "Miroslav Bajtoš",
+            "count": 1
+          },
+          {
+            "value": "Nathan Rajlich",
+            "count": 1
+          },
+          {
+            "value": "Nathan Zadoks",
+            "count": 1
+          },
+          {
+            "value": "Neil Gentleman",
+            "count": 1
+          },
+          {
+            "value": "Nicholas Kinsey",
+            "count": 1
+          },
+          {
+            "value": "Nick Heiner",
+            "count": 1
+          },
+          {
+            "value": "Nick Malaguti",
+            "count": 1
+          },
+          {
+            "value": "Nick Santos",
+            "count": 1
+          },
+          {
+            "value": "Nicolas Morel",
+            "count": 1
+          },
+          {
+            "value": "Niggler",
+            "count": 1
+          },
+          {
+            "value": "Oddur Sigurdsson",
+            "count": 1
+          },
+          {
+            "value": "Oleg Efimov",
+            "count": 1
+          },
+          {
+            "value": "Oli Evans",
+            "count": 1
+          },
+          {
+            "value": "Olivier Melcher",
+            "count": 1
+          },
+          {
+            "value": "Orlando Vazquez",
+            "count": 1
+          },
+          {
+            "value": "Paolo Fragomeni",
+            "count": 1
+          },
+          {
+            "value": "Patrick Pfeiffer",
+            "count": 1
+          },
+          {
+            "value": "Paul Miller",
+            "count": 1
+          },
+          {
+            "value": "Paul Vorbach",
+            "count": 1
+          },
+          {
+            "value": "Paulo Cesar",
+            "count": 1
+          },
+          {
+            "value": "Pete Kruckenberg",
+            "count": 1
+          },
+          {
+            "value": "Peter A. Shevtsov",
+            "count": 1
+          },
+          {
+            "value": "Peter Richardson",
+            "count": 1
+          },
+          {
+            "value": "Phillip Howell",
+            "count": 1
+          },
+          {
+            "value": "Quim Calpe",
+            "count": 1
+          },
+          {
+            "value": "Quinn Slack",
+            "count": 1
+          },
+          {
+            "value": "Ra'Shaun Stovall",
+            "count": 1
+          },
+          {
+            "value": "Rachel Hutchison",
+            "count": 1
+          },
+          {
+            "value": "Rafael de Oleza",
+            "count": 1
+          },
+          {
+            "value": "Rebecca Turner",
+            "count": 1
+          },
+          {
+            "value": "Reid Burke",
+            "count": 1
+          },
+          {
+            "value": "Ribettes",
+            "count": 1
+          },
+          {
+            "value": "Richard Littauer",
+            "count": 1
+          },
+          {
+            "value": "Robert Gieseke",
+            "count": 1
+          },
+          {
+            "value": "Robert Kowalski",
+            "count": 1
+          },
+          {
+            "value": "Robin Tweedie",
+            "count": 1
+          },
+          {
+            "value": "Rod Vagg",
+            "count": 1
+          },
+          {
+            "value": "Ron Martinez",
+            "count": 1
+          },
+          {
+            "value": "Ryan Emery",
+            "count": 1
+          },
+          {
+            "value": "Ryan Temple",
+            "count": 1
+          },
+          {
+            "value": "Sam Mikes",
+            "count": 1
+          },
+          {
+            "value": "Schabse Laks",
+            "count": 1
+          },
+          {
+            "value": "Scott Bronson",
+            "count": 1
+          },
+          {
+            "value": "Sean McGivern",
+            "count": 1
+          },
+          {
+            "value": "Sergey Belov",
+            "count": 1
+          },
+          {
+            "value": "Shawn Wildermuth",
+            "count": 1
+          },
+          {
+            "value": "Simen Bekkhus",
+            "count": 1
+          },
+          {
+            "value": "Spain Train",
+            "count": 1
+          },
+          {
+            "value": "Stephan Bönnemann",
+            "count": 1
+          },
+          {
+            "value": "Stephen Sugden",
+            "count": 1
+          },
+          {
+            "value": "Steve Klabnik",
+            "count": 1
+          },
+          {
+            "value": "Steve Mason",
+            "count": 1
+          },
+          {
+            "value": "Steve Steiner",
+            "count": 1
+          },
+          {
+            "value": "Stuart Knightley",
+            "count": 1
+          },
+          {
+            "value": "Stuart P. Bentley",
+            "count": 1
+          },
+          {
+            "value": "Sébastien Santoro",
+            "count": 1
+          },
+          {
+            "value": "TJ Holowaychuk",
+            "count": 1
+          },
+          {
+            "value": "Takaya Kobayashi",
+            "count": 1
+          },
+          {
+            "value": "Tauren Mills",
+            "count": 1
+          },
+          {
+            "value": "Terin Stock",
+            "count": 1
+          },
+          {
+            "value": "Thaddee Tyl",
+            "count": 1
+          },
+          {
+            "value": "Thom Blake",
+            "count": 1
+          },
+          {
+            "value": "Thomas Cort",
+            "count": 1
+          },
+          {
+            "value": "Thomas Torp",
+            "count": 1
+          },
+          {
+            "value": "Thorsten Lorenz",
+            "count": 1
+          },
+          {
+            "value": "Tim Oxley",
+            "count": 1
+          },
+          {
+            "value": "Tim Whidden",
+            "count": 1
+          },
+          {
+            "value": "Timo Derstappen",
+            "count": 1
+          },
+          {
+            "value": "Timo Weiß",
+            "count": 1
+          },
+          {
+            "value": "Tom Huang",
+            "count": 1
+          },
+          {
+            "value": "Tomaž Muraus",
+            "count": 1
+          },
+          {
+            "value": "Tony",
+            "count": 1
+          },
+          {
+            "value": "Tor Valamo",
+            "count": 1
+          },
+          {
+            "value": "Trent Mick",
+            "count": 1
+          },
+          {
+            "value": "Trevor Burnham",
+            "count": 1
+          },
+          {
+            "value": "Tristan Davies",
+            "count": 1
+          },
+          {
+            "value": "Tyler Green",
+            "count": 1
+          },
+          {
+            "value": "Vaz Allen",
+            "count": 1
+          },
+          {
+            "value": "Victor",
+            "count": 1
+          },
+          {
+            "value": "Visnu Pitiyanuvath",
+            "count": 1
+          },
+          {
+            "value": "Vladimir Rutsky",
+            "count": 1
+          },
+          {
+            "value": "Wesley de Souza",
+            "count": 1
+          },
+          {
+            "value": "Whyme.Lyu",
+            "count": 1
+          },
+          {
+            "value": "Wil Moore III",
+            "count": 1
+          },
+          {
+            "value": "Will Elwood",
+            "count": 1
+          },
+          {
+            "value": "Wout Mertens",
+            "count": 1
+          },
+          {
+            "value": "Yazhong Liu",
+            "count": 1
+          },
+          {
+            "value": "Yeonghoon Park",
+            "count": 1
+          },
+          {
+            "value": "Zach Pomerantz",
+            "count": 1
+          },
+          {
+            "value": "Zeke Sikelianos",
             "count": 1
           }
         ],
@@ -5684,7 +8004,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Toma\u017e Muraus",
+              "name": "Tomaž Muraus",
               "email": "kami@k5-storitve.net",
               "url": null
             },
@@ -5810,7 +8130,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Felix Geisendo\u0308rfer",
+              "name": "Felix Geisendörfer",
               "email": "felix@debuggable.com",
               "url": null
             },
@@ -5873,7 +8193,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Maciej Ma\u0142ecki",
+              "name": "Maciej Małecki",
               "email": "me@mmalecki.com",
               "url": null
             },
@@ -6202,7 +8522,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Johan Sk\u00f6ld",
+              "name": "Johan Sköld",
               "email": "johan@skold.cc",
               "url": null
             },
@@ -6363,7 +8683,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Franc\u0327ois Frisch",
+              "name": "François Frisch",
               "email": "francoisfrisch@gmail.com",
               "url": null
             },
@@ -6538,7 +8858,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "S\u00e9bastien Santoro",
+              "name": "Sébastien Santoro",
               "email": "dereckson@espace-win.org",
               "url": null
             },
@@ -6755,7 +9075,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Miroslav Bajto\u0161",
+              "name": "Miroslav Bajtoš",
               "email": "miroslav@strongloop.com",
               "url": null
             },
@@ -6909,7 +9229,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "\u4e0d\u56db",
+              "name": "不四",
               "email": "busi.hyy@taobao.com",
               "url": null
             },
@@ -6972,7 +9292,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Timo Wei\u00df",
+              "name": "Timo Weiß",
               "email": "timoweiss@Timo-MBP.local",
               "url": null
             },
@@ -6986,7 +9306,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "J\u00e9r\u00e9my Lal",
+              "name": "Jérémy Lal",
               "email": "kapouer@melix.org",
               "url": null
             },
@@ -7273,7 +9593,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Gu\u00f0laugur Stef\u00e1n Egilsson",
+              "name": "Guðlaugur Stefán Egilsson",
               "email": "gulli@kolibri.is",
               "url": null
             },
@@ -7546,7 +9866,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Kat March\u00e1n",
+              "name": "Kat Marchán",
               "email": "kzm@sykosomatic.org",
               "url": null
             },
@@ -7651,7 +9971,7 @@
             {
               "type": "person",
               "role": "contributor",
-              "name": "Stephan B\u00f6nnemann",
+              "name": "Stephan Bönnemann",
               "email": "stephan@excellenteasy.com",
               "url": null
             },
@@ -8651,7 +10971,1457 @@
         {
           "author": "Isaac Z. Schlueter",
           "start_line": 16,
-          "end_line": 17
+          "end_line": 19
+        },
+        {
+          "author": "Steve Steiner",
+          "start_line": 205,
+          "end_line": 205
+        },
+        {
+          "author": "Mikeal Rogers",
+          "start_line": 209,
+          "end_line": 209
+        },
+        {
+          "author": "Aaron Blohowiak",
+          "start_line": 213,
+          "end_line": 213
+        },
+        {
+          "author": "Martyn Smith",
+          "start_line": 217,
+          "end_line": 217
+        },
+        {
+          "author": "Charlie Robbins",
+          "start_line": 221,
+          "end_line": 221
+        },
+        {
+          "author": "Francisco Treacy",
+          "start_line": 225,
+          "end_line": 225
+        },
+        {
+          "author": "Cliffano Subagio",
+          "start_line": 229,
+          "end_line": 229
+        },
+        {
+          "author": "Christian Eager",
+          "start_line": 233,
+          "end_line": 233
+        },
+        {
+          "author": "Dav Glass",
+          "start_line": 237,
+          "end_line": 237
+        },
+        {
+          "author": "Alex K. Wolfe",
+          "start_line": 241,
+          "end_line": 241
+        },
+        {
+          "author": "James Sanders",
+          "start_line": 245,
+          "end_line": 245
+        },
+        {
+          "author": "Reid Burke",
+          "start_line": 249,
+          "end_line": 249
+        },
+        {
+          "author": "Arlo Breault",
+          "start_line": 253,
+          "end_line": 253
+        },
+        {
+          "author": "Timo Derstappen",
+          "start_line": 257,
+          "end_line": 257
+        },
+        {
+          "author": "Bart Teeuwisse",
+          "start_line": 261,
+          "end_line": 261
+        },
+        {
+          "author": "Ben Noordhuis",
+          "start_line": 265,
+          "end_line": 265
+        },
+        {
+          "author": "Tor Valamo",
+          "start_line": 269,
+          "end_line": 269
+        },
+        {
+          "author": "Whyme.Lyu",
+          "start_line": 273,
+          "end_line": 273
+        },
+        {
+          "author": "Olivier Melcher",
+          "start_line": 277,
+          "end_line": 277
+        },
+        {
+          "author": "Tomaž Muraus",
+          "start_line": 281,
+          "end_line": 281
+        },
+        {
+          "author": "Evan Meagher",
+          "start_line": 285,
+          "end_line": 285
+        },
+        {
+          "author": "Orlando Vazquez",
+          "start_line": 289,
+          "end_line": 289
+        },
+        {
+          "author": "Kai Chen",
+          "start_line": 293,
+          "end_line": 293
+        },
+        {
+          "author": "George Miroshnykov",
+          "start_line": 297,
+          "end_line": 297
+        },
+        {
+          "author": "Geoff Flarity",
+          "start_line": 301,
+          "end_line": 301
+        },
+        {
+          "author": "Max Goodman",
+          "start_line": 305,
+          "end_line": 305
+        },
+        {
+          "author": "Pete Kruckenberg",
+          "start_line": 309,
+          "end_line": 309
+        },
+        {
+          "author": "Laurie Harper",
+          "start_line": 313,
+          "end_line": 313
+        },
+        {
+          "author": "Chris Wong",
+          "start_line": 317,
+          "end_line": 317
+        },
+        {
+          "author": "Scott Bronson",
+          "start_line": 321,
+          "end_line": 321
+        },
+        {
+          "author": "Federico Romero",
+          "start_line": 325,
+          "end_line": 325
+        },
+        {
+          "author": "Visnu Pitiyanuvath",
+          "start_line": 329,
+          "end_line": 329
+        },
+        {
+          "author": "Irakli Gozalishvili",
+          "start_line": 333,
+          "end_line": 333
+        },
+        {
+          "author": "Mark Cahill",
+          "start_line": 337,
+          "end_line": 337
+        },
+        {
+          "author": "Tony",
+          "start_line": 341,
+          "end_line": 341
+        },
+        {
+          "author": "Iain Sproat",
+          "start_line": 345,
+          "end_line": 345
+        },
+        {
+          "author": "Trent Mick",
+          "start_line": 349,
+          "end_line": 349
+        },
+        {
+          "author": "Felix Geisendörfer",
+          "start_line": 353,
+          "end_line": 353
+        },
+        {
+          "author": "Jameson Little",
+          "start_line": 357,
+          "end_line": 357
+        },
+        {
+          "author": "Conny Brunnkvist",
+          "start_line": 361,
+          "end_line": 361
+        },
+        {
+          "author": "Will Elwood",
+          "start_line": 365,
+          "end_line": 365
+        },
+        {
+          "author": "Dean Landolt",
+          "start_line": 369,
+          "end_line": 369
+        },
+        {
+          "author": "Oleg Efimov",
+          "start_line": 373,
+          "end_line": 373
+        },
+        {
+          "author": "Martin Cooper",
+          "start_line": 377,
+          "end_line": 377
+        },
+        {
+          "author": "Jann Horn",
+          "start_line": 381,
+          "end_line": 381
+        },
+        {
+          "author": "Andrew Bradley",
+          "start_line": 385,
+          "end_line": 385
+        },
+        {
+          "author": "Maciej Małecki",
+          "start_line": 389,
+          "end_line": 389
+        },
+        {
+          "author": "Stephen Sugden",
+          "start_line": 393,
+          "end_line": 393
+        },
+        {
+          "author": "Michael Budde",
+          "start_line": 397,
+          "end_line": 397
+        },
+        {
+          "author": "Jason Smith",
+          "start_line": 401,
+          "end_line": 401
+        },
+        {
+          "author": "Gautham Pai",
+          "start_line": 405,
+          "end_line": 405
+        },
+        {
+          "author": "David Trejo",
+          "start_line": 409,
+          "end_line": 409
+        },
+        {
+          "author": "Paul Vorbach",
+          "start_line": 413,
+          "end_line": 413
+        },
+        {
+          "author": "George Ornbo",
+          "start_line": 417,
+          "end_line": 417
+        },
+        {
+          "author": "Tim Oxley",
+          "start_line": 421,
+          "end_line": 421
+        },
+        {
+          "author": "Tyler Green",
+          "start_line": 425,
+          "end_line": 425
+        },
+        {
+          "author": "Dave Pacheco",
+          "start_line": 429,
+          "end_line": 429
+        },
+        {
+          "author": "Danila Gerasimov",
+          "start_line": 433,
+          "end_line": 433
+        },
+        {
+          "author": "Rod Vagg",
+          "start_line": 437,
+          "end_line": 437
+        },
+        {
+          "author": "Christian Howe",
+          "start_line": 441,
+          "end_line": 441
+        },
+        {
+          "author": "Andrew Lunny",
+          "start_line": 445,
+          "end_line": 445
+        },
+        {
+          "author": "Henrik Hodne",
+          "start_line": 449,
+          "end_line": 449
+        },
+        {
+          "author": "Adam Blackburn",
+          "start_line": 453,
+          "end_line": 453
+        },
+        {
+          "author": "Kris Windham",
+          "start_line": 457,
+          "end_line": 457
+        },
+        {
+          "author": "Jens Grunert",
+          "start_line": 461,
+          "end_line": 461
+        },
+        {
+          "author": "Joost-Wim Boekesteijn",
+          "start_line": 465,
+          "end_line": 465
+        },
+        {
+          "author": "Dalmais Maxence",
+          "start_line": 469,
+          "end_line": 469
+        },
+        {
+          "author": "Marcus Ekwall",
+          "start_line": 473,
+          "end_line": 473
+        },
+        {
+          "author": "Aaron Stacy",
+          "start_line": 477,
+          "end_line": 477
+        },
+        {
+          "author": "Phillip Howell",
+          "start_line": 481,
+          "end_line": 481
+        },
+        {
+          "author": "Domenic Denicola",
+          "start_line": 485,
+          "end_line": 485
+        },
+        {
+          "author": "James Halliday",
+          "start_line": 489,
+          "end_line": 489
+        },
+        {
+          "author": "Jeremy Cantrell",
+          "start_line": 493,
+          "end_line": 493
+        },
+        {
+          "author": "Ribettes",
+          "start_line": 497,
+          "end_line": 497
+        },
+        {
+          "author": "Don Park",
+          "start_line": 501,
+          "end_line": 501
+        },
+        {
+          "author": "Einar Otto Stangvik",
+          "start_line": 505,
+          "end_line": 505
+        },
+        {
+          "author": "Kei Son",
+          "start_line": 509,
+          "end_line": 509
+        },
+        {
+          "author": "Nicolas Morel",
+          "start_line": 513,
+          "end_line": 513
+        },
+        {
+          "author": "Mark Dube",
+          "start_line": 517,
+          "end_line": 517
+        },
+        {
+          "author": "Nathan Rajlich",
+          "start_line": 521,
+          "end_line": 521
+        },
+        {
+          "author": "Maxim Bogushevich",
+          "start_line": 525,
+          "end_line": 525
+        },
+        {
+          "author": "Meaglin",
+          "start_line": 529,
+          "end_line": 529
+        },
+        {
+          "author": "Ben Evans",
+          "start_line": 533,
+          "end_line": 533
+        },
+        {
+          "author": "Nathan Zadoks",
+          "start_line": 537,
+          "end_line": 537
+        },
+        {
+          "author": "Brian White",
+          "start_line": 541,
+          "end_line": 541
+        },
+        {
+          "author": "Jed Schmidt",
+          "start_line": 545,
+          "end_line": 545
+        },
+        {
+          "author": "Ian Livingstone",
+          "start_line": 549,
+          "end_line": 549
+        },
+        {
+          "author": "Patrick Pfeiffer",
+          "start_line": 553,
+          "end_line": 553
+        },
+        {
+          "author": "Paul Miller",
+          "start_line": 557,
+          "end_line": 557
+        },
+        {
+          "author": "Ryan Emery",
+          "start_line": 561,
+          "end_line": 561
+        },
+        {
+          "author": "Carl Lange",
+          "start_line": 565,
+          "end_line": 565
+        },
+        {
+          "author": "Jan Lehnardt",
+          "start_line": 569,
+          "end_line": 569
+        },
+        {
+          "author": "Stuart P. Bentley",
+          "start_line": 573,
+          "end_line": 573
+        },
+        {
+          "author": "Johan Sköld",
+          "start_line": 577,
+          "end_line": 577
+        },
+        {
+          "author": "Stuart Knightley",
+          "start_line": 581,
+          "end_line": 581
+        },
+        {
+          "author": "Niggler",
+          "start_line": 585,
+          "end_line": 585
+        },
+        {
+          "author": "Paolo Fragomeni",
+          "start_line": 589,
+          "end_line": 589
+        },
+        {
+          "author": "Jaakko Manninen",
+          "start_line": 593,
+          "end_line": 593
+        },
+        {
+          "author": "Luke Arduini",
+          "start_line": 597,
+          "end_line": 597
+        },
+        {
+          "author": "Larz Conwell",
+          "start_line": 601,
+          "end_line": 601
+        },
+        {
+          "author": "Marcel Klehr",
+          "start_line": 606,
+          "end_line": 606
+        },
+        {
+          "author": "Robert Kowalski",
+          "start_line": 610,
+          "end_line": 610
+        },
+        {
+          "author": "Forbes Lindesay",
+          "start_line": 614,
+          "end_line": 614
+        },
+        {
+          "author": "Vaz Allen",
+          "start_line": 618,
+          "end_line": 618
+        },
+        {
+          "author": "Jake Verbaten",
+          "start_line": 622,
+          "end_line": 622
+        },
+        {
+          "author": "Schabse Laks",
+          "start_line": 626,
+          "end_line": 626
+        },
+        {
+          "author": "Florian Margaine",
+          "start_line": 630,
+          "end_line": 630
+        },
+        {
+          "author": "Johan Nordberg",
+          "start_line": 634,
+          "end_line": 634
+        },
+        {
+          "author": "Ian Babrou",
+          "start_line": 638,
+          "end_line": 638
+        },
+        {
+          "author": "Di Wu",
+          "start_line": 642,
+          "end_line": 642
+        },
+        {
+          "author": "Mathias Bynens",
+          "start_line": 646,
+          "end_line": 646
+        },
+        {
+          "author": "Matt McClure",
+          "start_line": 650,
+          "end_line": 650
+        },
+        {
+          "author": "Matt Lunn",
+          "start_line": 654,
+          "end_line": 654
+        },
+        {
+          "author": "Alexey Kreschuk",
+          "start_line": 658,
+          "end_line": 658
+        },
+        {
+          "author": "Robert Gieseke",
+          "start_line": 666,
+          "end_line": 666
+        },
+        {
+          "author": "François Frisch",
+          "start_line": 670,
+          "end_line": 670
+        },
+        {
+          "author": "Trevor Burnham",
+          "start_line": 674,
+          "end_line": 674
+        },
+        {
+          "author": "Alan Shaw",
+          "start_line": 678,
+          "end_line": 678
+        },
+        {
+          "author": "TJ Holowaychuk",
+          "start_line": 682,
+          "end_line": 682
+        },
+        {
+          "author": "Nicholas Kinsey",
+          "start_line": 686,
+          "end_line": 686
+        },
+        {
+          "author": "Paulo Cesar",
+          "start_line": 690,
+          "end_line": 690
+        },
+        {
+          "author": "Elan Shanker",
+          "start_line": 694,
+          "end_line": 694
+        },
+        {
+          "author": "Jon Spencer",
+          "start_line": 698,
+          "end_line": 698
+        },
+        {
+          "author": "Jason Diamond",
+          "start_line": 702,
+          "end_line": 702
+        },
+        {
+          "author": "Maximilian Antoni",
+          "start_line": 706,
+          "end_line": 706
+        },
+        {
+          "author": "Thom Blake",
+          "start_line": 710,
+          "end_line": 710
+        },
+        {
+          "author": "Jess Martin",
+          "start_line": 714,
+          "end_line": 714
+        },
+        {
+          "author": "Spain Train",
+          "start_line": 718,
+          "end_line": 718
+        },
+        {
+          "author": "Alex Rodionov",
+          "start_line": 722,
+          "end_line": 722
+        },
+        {
+          "author": "Matt Colyer",
+          "start_line": 726,
+          "end_line": 726
+        },
+        {
+          "author": "Evan You",
+          "start_line": 730,
+          "end_line": 730
+        },
+        {
+          "author": "Gabriel Falkenberg",
+          "start_line": 738,
+          "end_line": 738
+        },
+        {
+          "author": "Alexej Yaroshevich",
+          "start_line": 742,
+          "end_line": 742
+        },
+        {
+          "author": "Quim Calpe",
+          "start_line": 746,
+          "end_line": 746
+        },
+        {
+          "author": "Steve Mason",
+          "start_line": 750,
+          "end_line": 750
+        },
+        {
+          "author": "Wil Moore III",
+          "start_line": 754,
+          "end_line": 754
+        },
+        {
+          "author": "Sergey Belov",
+          "start_line": 758,
+          "end_line": 758
+        },
+        {
+          "author": "Tom Huang",
+          "start_line": 762,
+          "end_line": 762
+        },
+        {
+          "author": "CamilleM",
+          "start_line": 766,
+          "end_line": 766
+        },
+        {
+          "author": "Sébastien Santoro",
+          "start_line": 770,
+          "end_line": 770
+        },
+        {
+          "author": "Evan Lucas",
+          "start_line": 774,
+          "end_line": 774
+        },
+        {
+          "author": "Quinn Slack",
+          "start_line": 778,
+          "end_line": 778
+        },
+        {
+          "author": "Alex Kocharin",
+          "start_line": 782,
+          "end_line": 782
+        },
+        {
+          "author": "Daniel Santiago",
+          "start_line": 786,
+          "end_line": 786
+        },
+        {
+          "author": "Denis Gladkikh",
+          "start_line": 790,
+          "end_line": 790
+        },
+        {
+          "author": "Andrew Horton",
+          "start_line": 794,
+          "end_line": 794
+        },
+        {
+          "author": "Zeke Sikelianos",
+          "start_line": 798,
+          "end_line": 798
+        },
+        {
+          "author": "Dylan Greene",
+          "start_line": 802,
+          "end_line": 802
+        },
+        {
+          "author": "Franck Cuny",
+          "start_line": 806,
+          "end_line": 806
+        },
+        {
+          "author": "Yeonghoon Park",
+          "start_line": 810,
+          "end_line": 810
+        },
+        {
+          "author": "Rafael de Oleza",
+          "start_line": 814,
+          "end_line": 814
+        },
+        {
+          "author": "Mikola Lysenko",
+          "start_line": 818,
+          "end_line": 818
+        },
+        {
+          "author": "Yazhong Liu",
+          "start_line": 822,
+          "end_line": 822
+        },
+        {
+          "author": "Neil Gentleman",
+          "start_line": 826,
+          "end_line": 826
+        },
+        {
+          "author": "Kris Kowal",
+          "start_line": 830,
+          "end_line": 830
+        },
+        {
+          "author": "Alex Gorbatchev",
+          "start_line": 834,
+          "end_line": 834
+        },
+        {
+          "author": "Shawn Wildermuth",
+          "start_line": 838,
+          "end_line": 838
+        },
+        {
+          "author": "Wesley de Souza",
+          "start_line": 842,
+          "end_line": 842
+        },
+        {
+          "author": "J. Tangelder",
+          "start_line": 850,
+          "end_line": 850
+        },
+        {
+          "author": "Jean Lauliac",
+          "start_line": 854,
+          "end_line": 854
+        },
+        {
+          "author": "Andrey Kislyuk",
+          "start_line": 858,
+          "end_line": 858
+        },
+        {
+          "author": "Thorsten Lorenz",
+          "start_line": 862,
+          "end_line": 862
+        },
+        {
+          "author": "Julian Gruber",
+          "start_line": 866,
+          "end_line": 866
+        },
+        {
+          "author": "Benjamin Coe",
+          "start_line": 870,
+          "end_line": 870
+        },
+        {
+          "author": "Alex Ford",
+          "start_line": 874,
+          "end_line": 874
+        },
+        {
+          "author": "Matt Hickford",
+          "start_line": 878,
+          "end_line": 878
+        },
+        {
+          "author": "Sean McGivern",
+          "start_line": 882,
+          "end_line": 882
+        },
+        {
+          "author": "C J Silverio",
+          "start_line": 886,
+          "end_line": 886
+        },
+        {
+          "author": "Robin Tweedie",
+          "start_line": 890,
+          "end_line": 890
+        },
+        {
+          "author": "Miroslav Bajtoš",
+          "start_line": 894,
+          "end_line": 894
+        },
+        {
+          "author": "David Glasser",
+          "start_line": 898,
+          "end_line": 898
+        },
+        {
+          "author": "Gianluca Casati",
+          "start_line": 902,
+          "end_line": 902
+        },
+        {
+          "author": "Forrest L Norvell",
+          "start_line": 906,
+          "end_line": 906
+        },
+        {
+          "author": "Karsten Tinnefeld",
+          "start_line": 910,
+          "end_line": 910
+        },
+        {
+          "author": "Bryan Burgers",
+          "start_line": 914,
+          "end_line": 914
+        },
+        {
+          "author": "David Beitey",
+          "start_line": 918,
+          "end_line": 918
+        },
+        {
+          "author": "Zach Pomerantz",
+          "start_line": 926,
+          "end_line": 926
+        },
+        {
+          "author": "Chris Williams",
+          "start_line": 930,
+          "end_line": 930
+        },
+        {
+          "author": "Mick Thompson",
+          "start_line": 938,
+          "end_line": 938
+        },
+        {
+          "author": "Felix Rabe",
+          "start_line": 942,
+          "end_line": 942
+        },
+        {
+          "author": "Michael Hayes",
+          "start_line": 946,
+          "end_line": 946
+        },
+        {
+          "author": "Chris Dickinson",
+          "start_line": 950,
+          "end_line": 950
+        },
+        {
+          "author": "Bradley Meck",
+          "start_line": 954,
+          "end_line": 954
+        },
+        {
+          "author": "Andrew Terris",
+          "start_line": 962,
+          "end_line": 962
+        },
+        {
+          "author": "Michael Nisi",
+          "start_line": 966,
+          "end_line": 966
+        },
+        {
+          "author": "Adam Meadows",
+          "start_line": 974,
+          "end_line": 974
+        },
+        {
+          "author": "Chulki Lee",
+          "start_line": 978,
+          "end_line": 978
+        },
+        {
+          "author": "Kenan Yildirim",
+          "start_line": 990,
+          "end_line": 990
+        },
+        {
+          "author": "Laurie Voss",
+          "start_line": 994,
+          "end_line": 994
+        },
+        {
+          "author": "Rebecca Turner",
+          "start_line": 998,
+          "end_line": 998
+        },
+        {
+          "author": "Hunter Loftis",
+          "start_line": 1002,
+          "end_line": 1002
+        },
+        {
+          "author": "Peter Richardson",
+          "start_line": 1006,
+          "end_line": 1006
+        },
+        {
+          "author": "Jussi Kalliokoski",
+          "start_line": 1010,
+          "end_line": 1010
+        },
+        {
+          "author": "Filip Weiss",
+          "start_line": 1014,
+          "end_line": 1014
+        },
+        {
+          "author": "Timo Weiß",
+          "start_line": 1018,
+          "end_line": 1018
+        },
+        {
+          "author": "Christopher Hiller",
+          "start_line": 1022,
+          "end_line": 1022
+        },
+        {
+          "author": "Jérémy Lal",
+          "start_line": 1026,
+          "end_line": 1026
+        },
+        {
+          "author": "Anders Janmyr",
+          "start_line": 1030,
+          "end_line": 1030
+        },
+        {
+          "author": "Chris Meyers",
+          "start_line": 1034,
+          "end_line": 1034
+        },
+        {
+          "author": "Ludwig Magnusson",
+          "start_line": 1038,
+          "end_line": 1038
+        },
+        {
+          "author": "Wout Mertens",
+          "start_line": 1042,
+          "end_line": 1042
+        },
+        {
+          "author": "Nick Santos",
+          "start_line": 1046,
+          "end_line": 1046
+        },
+        {
+          "author": "Terin Stock",
+          "start_line": 1050,
+          "end_line": 1050
+        },
+        {
+          "author": "Faiq Raza",
+          "start_line": 1054,
+          "end_line": 1054
+        },
+        {
+          "author": "Thomas Torp",
+          "start_line": 1058,
+          "end_line": 1058
+        },
+        {
+          "author": "Sam Mikes",
+          "start_line": 1062,
+          "end_line": 1062
+        },
+        {
+          "author": "Mat Tyndall",
+          "start_line": 1066,
+          "end_line": 1066
+        },
+        {
+          "author": "Tauren Mills",
+          "start_line": 1070,
+          "end_line": 1070
+        },
+        {
+          "author": "Ron Martinez",
+          "start_line": 1074,
+          "end_line": 1074
+        },
+        {
+          "author": "Kazuhito Hokamura",
+          "start_line": 1078,
+          "end_line": 1078
+        },
+        {
+          "author": "Tristan Davies",
+          "start_line": 1082,
+          "end_line": 1082
+        },
+        {
+          "author": "David Volm",
+          "start_line": 1086,
+          "end_line": 1086
+        },
+        {
+          "author": "Lin Clark",
+          "start_line": 1090,
+          "end_line": 1090
+        },
+        {
+          "author": "Ben Page",
+          "start_line": 1094,
+          "end_line": 1094
+        },
+        {
+          "author": "Jeff Jo",
+          "start_line": 1098,
+          "end_line": 1098
+        },
+        {
+          "author": "Mark J. Titorenko",
+          "start_line": 1106,
+          "end_line": 1106
+        },
+        {
+          "author": "Oddur Sigurdsson",
+          "start_line": 1110,
+          "end_line": 1110
+        },
+        {
+          "author": "Eric Mill",
+          "start_line": 1114,
+          "end_line": 1114
+        },
+        {
+          "author": "Gabriel Barros",
+          "start_line": 1118,
+          "end_line": 1118
+        },
+        {
+          "author": "KevinSheedy",
+          "start_line": 1122,
+          "end_line": 1122
+        },
+        {
+          "author": "Aleksey Smolenchuk",
+          "start_line": 1126,
+          "end_line": 1126
+        },
+        {
+          "author": "Ed Morley",
+          "start_line": 1130,
+          "end_line": 1130
+        },
+        {
+          "author": "Blaine Bublitz",
+          "start_line": 1134,
+          "end_line": 1134
+        },
+        {
+          "author": "Andrey Fedorov",
+          "start_line": 1138,
+          "end_line": 1138
+        },
+        {
+          "author": "Daijiro Wachi",
+          "start_line": 1142,
+          "end_line": 1142
+        },
+        {
+          "author": "Luc Thevenard",
+          "start_line": 1146,
+          "end_line": 1146
+        },
+        {
+          "author": "Aria Stewart",
+          "start_line": 1150,
+          "end_line": 1150
+        },
+        {
+          "author": "Charlie Rudolph",
+          "start_line": 1154,
+          "end_line": 1154
+        },
+        {
+          "author": "Vladimir Rutsky",
+          "start_line": 1158,
+          "end_line": 1158
+        },
+        {
+          "author": "Isaac Murchie",
+          "start_line": 1162,
+          "end_line": 1162
+        },
+        {
+          "author": "Marcin Wosinek",
+          "start_line": 1166,
+          "end_line": 1166
+        },
+        {
+          "author": "David Marr",
+          "start_line": 1170,
+          "end_line": 1170
+        },
+        {
+          "author": "Bryan English",
+          "start_line": 1174,
+          "end_line": 1174
+        },
+        {
+          "author": "Anthony Zotti",
+          "start_line": 1178,
+          "end_line": 1178
+        },
+        {
+          "author": "Karl Horky",
+          "start_line": 1182,
+          "end_line": 1182
+        },
+        {
+          "author": "Jordan Harband",
+          "start_line": 1186,
+          "end_line": 1186
+        },
+        {
+          "author": "Guðlaugur Stefán Egilsson",
+          "start_line": 1190,
+          "end_line": 1190
+        },
+        {
+          "author": "Helge Skogly Holm",
+          "start_line": 1194,
+          "end_line": 1194
+        },
+        {
+          "author": "Peter A. Shevtsov",
+          "start_line": 1198,
+          "end_line": 1198
+        },
+        {
+          "author": "Alain Kalker",
+          "start_line": 1202,
+          "end_line": 1202
+        },
+        {
+          "author": "Bryant Williams",
+          "start_line": 1206,
+          "end_line": 1206
+        },
+        {
+          "author": "Jonas Weber",
+          "start_line": 1210,
+          "end_line": 1210
+        },
+        {
+          "author": "Tim Whidden",
+          "start_line": 1214,
+          "end_line": 1214
+        },
+        {
+          "author": "Andreas",
+          "start_line": 1218,
+          "end_line": 1218
+        },
+        {
+          "author": "Karolis Narkevicius",
+          "start_line": 1222,
+          "end_line": 1222
+        },
+        {
+          "author": "Adrian Lynch",
+          "start_line": 1226,
+          "end_line": 1226
+        },
+        {
+          "author": "Richard Littauer",
+          "start_line": 1230,
+          "end_line": 1230
+        },
+        {
+          "author": "Oli Evans",
+          "start_line": 1234,
+          "end_line": 1234
+        },
+        {
+          "author": "Matt Brennan",
+          "start_line": 1238,
+          "end_line": 1238
+        },
+        {
+          "author": "Jeff Barczewski",
+          "start_line": 1242,
+          "end_line": 1242
+        },
+        {
+          "author": "Danny Fritz",
+          "start_line": 1246,
+          "end_line": 1246
+        },
+        {
+          "author": "Takaya Kobayashi",
+          "start_line": 1250,
+          "end_line": 1250
+        },
+        {
+          "author": "Ra'Shaun Stovall",
+          "start_line": 1254,
+          "end_line": 1254
+        },
+        {
+          "author": "Julien Meddah",
+          "start_line": 1258,
+          "end_line": 1258
+        },
+        {
+          "author": "Michiel Sikma",
+          "start_line": 1262,
+          "end_line": 1262
+        },
+        {
+          "author": "Jakob Krigovsky",
+          "start_line": 1266,
+          "end_line": 1266
+        },
+        {
+          "author": "Charmander",
+          "start_line": 1270,
+          "end_line": 1270
+        },
+        {
+          "author": "Erik Wienhold",
+          "start_line": 1274,
+          "end_line": 1274
+        },
+        {
+          "author": "James Butler",
+          "start_line": 1278,
+          "end_line": 1278
+        },
+        {
+          "author": "Kevin Kragenbrink",
+          "start_line": 1282,
+          "end_line": 1282
+        },
+        {
+          "author": "Arnaud Rinquin",
+          "start_line": 1286,
+          "end_line": 1286
+        },
+        {
+          "author": "Mike MacCana",
+          "start_line": 1290,
+          "end_line": 1290
+        },
+        {
+          "author": "Antti Mattila",
+          "start_line": 1294,
+          "end_line": 1294
+        },
+        {
+          "author": "Matt Zorn",
+          "start_line": 1302,
+          "end_line": 1302
+        },
+        {
+          "author": "Kyle Mitchell",
+          "start_line": 1306,
+          "end_line": 1306
+        },
+        {
+          "author": "Jeremiah Senkpiel",
+          "start_line": 1310,
+          "end_line": 1310
+        },
+        {
+          "author": "Michael Klein",
+          "start_line": 1314,
+          "end_line": 1314
+        },
+        {
+          "author": "Simen Bekkhus",
+          "start_line": 1318,
+          "end_line": 1318
+        },
+        {
+          "author": "Victor",
+          "start_line": 1322,
+          "end_line": 1322
+        },
+        {
+          "author": "Clay Carpenter",
+          "start_line": 1330,
+          "end_line": 1330
+        },
+        {
+          "author": "Nick Malaguti",
+          "start_line": 1338,
+          "end_line": 1338
+        },
+        {
+          "author": "Cedric Nelson",
+          "start_line": 1342,
+          "end_line": 1342
+        },
+        {
+          "author": "Kat Marchán",
+          "start_line": 1346,
+          "end_line": 1346
+        },
+        {
+          "author": "Andrew",
+          "start_line": 1350,
+          "end_line": 1350
+        },
+        {
+          "author": "Eduardo Pinho",
+          "start_line": 1354,
+          "end_line": 1354
+        },
+        {
+          "author": "Rachel Hutchison",
+          "start_line": 1358,
+          "end_line": 1358
+        },
+        {
+          "author": "Ryan Temple",
+          "start_line": 1362,
+          "end_line": 1362
+        },
+        {
+          "author": "Eugene Sharygin",
+          "start_line": 1366,
+          "end_line": 1366
+        },
+        {
+          "author": "Nick Heiner",
+          "start_line": 1370,
+          "end_line": 1370
+        },
+        {
+          "author": "James Talmage",
+          "start_line": 1374,
+          "end_line": 1374
+        },
+        {
+          "author": "Joseph Dykstra",
+          "start_line": 1382,
+          "end_line": 1382
+        },
+        {
+          "author": "Joshua Egan",
+          "start_line": 1386,
+          "end_line": 1386
+        },
+        {
+          "author": "Thomas Cort",
+          "start_line": 1390,
+          "end_line": 1390
+        },
+        {
+          "author": "Thaddee Tyl",
+          "start_line": 1394,
+          "end_line": 1394
+        },
+        {
+          "author": "Steve Klabnik",
+          "start_line": 1398,
+          "end_line": 1398
+        },
+        {
+          "author": "Andrew Murray",
+          "start_line": 1402,
+          "end_line": 1402
+        },
+        {
+          "author": "Stephan Bönnemann",
+          "start_line": 1406,
+          "end_line": 1406
+        },
+        {
+          "author": "Kyle M. Tarplee",
+          "start_line": 1410,
+          "end_line": 1410
+        },
+        {
+          "author": "Derek Peterson",
+          "start_line": 1414,
+          "end_line": 1414
+        },
+        {
+          "author": "Greg Whiteley",
+          "start_line": 1418,
+          "end_line": 1418
         }
       ],
       "tallies": {
@@ -8675,7 +12445,1167 @@
         ],
         "authors": [
           {
+            "value": "Aaron Blohowiak",
+            "count": 1
+          },
+          {
+            "value": "Aaron Stacy",
+            "count": 1
+          },
+          {
+            "value": "Adam Blackburn",
+            "count": 1
+          },
+          {
+            "value": "Adam Meadows",
+            "count": 1
+          },
+          {
+            "value": "Adrian Lynch",
+            "count": 1
+          },
+          {
+            "value": "Alain Kalker",
+            "count": 1
+          },
+          {
+            "value": "Alan Shaw",
+            "count": 1
+          },
+          {
+            "value": "Aleksey Smolenchuk",
+            "count": 1
+          },
+          {
+            "value": "Alex Ford",
+            "count": 1
+          },
+          {
+            "value": "Alex Gorbatchev",
+            "count": 1
+          },
+          {
+            "value": "Alex K. Wolfe",
+            "count": 1
+          },
+          {
+            "value": "Alex Kocharin",
+            "count": 1
+          },
+          {
+            "value": "Alex Rodionov",
+            "count": 1
+          },
+          {
+            "value": "Alexej Yaroshevich",
+            "count": 1
+          },
+          {
+            "value": "Alexey Kreschuk",
+            "count": 1
+          },
+          {
+            "value": "Anders Janmyr",
+            "count": 1
+          },
+          {
+            "value": "Andreas",
+            "count": 1
+          },
+          {
+            "value": "Andrew",
+            "count": 1
+          },
+          {
+            "value": "Andrew Bradley",
+            "count": 1
+          },
+          {
+            "value": "Andrew Horton",
+            "count": 1
+          },
+          {
+            "value": "Andrew Lunny",
+            "count": 1
+          },
+          {
+            "value": "Andrew Murray",
+            "count": 1
+          },
+          {
+            "value": "Andrew Terris",
+            "count": 1
+          },
+          {
+            "value": "Andrey Fedorov",
+            "count": 1
+          },
+          {
+            "value": "Andrey Kislyuk",
+            "count": 1
+          },
+          {
+            "value": "Anthony Zotti",
+            "count": 1
+          },
+          {
+            "value": "Antti Mattila",
+            "count": 1
+          },
+          {
+            "value": "Aria Stewart",
+            "count": 1
+          },
+          {
+            "value": "Arlo Breault",
+            "count": 1
+          },
+          {
+            "value": "Arnaud Rinquin",
+            "count": 1
+          },
+          {
+            "value": "Bart Teeuwisse",
+            "count": 1
+          },
+          {
+            "value": "Ben Evans",
+            "count": 1
+          },
+          {
+            "value": "Ben Noordhuis",
+            "count": 1
+          },
+          {
+            "value": "Ben Page",
+            "count": 1
+          },
+          {
+            "value": "Benjamin Coe",
+            "count": 1
+          },
+          {
+            "value": "Blaine Bublitz",
+            "count": 1
+          },
+          {
+            "value": "Bradley Meck",
+            "count": 1
+          },
+          {
+            "value": "Brian White",
+            "count": 1
+          },
+          {
+            "value": "Bryan Burgers",
+            "count": 1
+          },
+          {
+            "value": "Bryan English",
+            "count": 1
+          },
+          {
+            "value": "Bryant Williams",
+            "count": 1
+          },
+          {
+            "value": "C J Silverio",
+            "count": 1
+          },
+          {
+            "value": "CamilleM",
+            "count": 1
+          },
+          {
+            "value": "Carl Lange",
+            "count": 1
+          },
+          {
+            "value": "Cedric Nelson",
+            "count": 1
+          },
+          {
+            "value": "Charlie Robbins",
+            "count": 1
+          },
+          {
+            "value": "Charlie Rudolph",
+            "count": 1
+          },
+          {
+            "value": "Charmander",
+            "count": 1
+          },
+          {
+            "value": "Chris Dickinson",
+            "count": 1
+          },
+          {
+            "value": "Chris Meyers",
+            "count": 1
+          },
+          {
+            "value": "Chris Williams",
+            "count": 1
+          },
+          {
+            "value": "Chris Wong",
+            "count": 1
+          },
+          {
+            "value": "Christian Eager",
+            "count": 1
+          },
+          {
+            "value": "Christian Howe",
+            "count": 1
+          },
+          {
+            "value": "Christopher Hiller",
+            "count": 1
+          },
+          {
+            "value": "Chulki Lee",
+            "count": 1
+          },
+          {
+            "value": "Clay Carpenter",
+            "count": 1
+          },
+          {
+            "value": "Cliffano Subagio",
+            "count": 1
+          },
+          {
+            "value": "Conny Brunnkvist",
+            "count": 1
+          },
+          {
+            "value": "Daijiro Wachi",
+            "count": 1
+          },
+          {
+            "value": "Dalmais Maxence",
+            "count": 1
+          },
+          {
+            "value": "Daniel Santiago",
+            "count": 1
+          },
+          {
+            "value": "Danila Gerasimov",
+            "count": 1
+          },
+          {
+            "value": "Danny Fritz",
+            "count": 1
+          },
+          {
+            "value": "Dav Glass",
+            "count": 1
+          },
+          {
+            "value": "Dave Pacheco",
+            "count": 1
+          },
+          {
+            "value": "David Beitey",
+            "count": 1
+          },
+          {
+            "value": "David Glasser",
+            "count": 1
+          },
+          {
+            "value": "David Marr",
+            "count": 1
+          },
+          {
+            "value": "David Trejo",
+            "count": 1
+          },
+          {
+            "value": "David Volm",
+            "count": 1
+          },
+          {
+            "value": "Dean Landolt",
+            "count": 1
+          },
+          {
+            "value": "Denis Gladkikh",
+            "count": 1
+          },
+          {
+            "value": "Derek Peterson",
+            "count": 1
+          },
+          {
+            "value": "Di Wu",
+            "count": 1
+          },
+          {
+            "value": "Domenic Denicola",
+            "count": 1
+          },
+          {
+            "value": "Don Park",
+            "count": 1
+          },
+          {
+            "value": "Dylan Greene",
+            "count": 1
+          },
+          {
+            "value": "Ed Morley",
+            "count": 1
+          },
+          {
+            "value": "Eduardo Pinho",
+            "count": 1
+          },
+          {
+            "value": "Einar Otto Stangvik",
+            "count": 1
+          },
+          {
+            "value": "Elan Shanker",
+            "count": 1
+          },
+          {
+            "value": "Eric Mill",
+            "count": 1
+          },
+          {
+            "value": "Erik Wienhold",
+            "count": 1
+          },
+          {
+            "value": "Eugene Sharygin",
+            "count": 1
+          },
+          {
+            "value": "Evan Lucas",
+            "count": 1
+          },
+          {
+            "value": "Evan Meagher",
+            "count": 1
+          },
+          {
+            "value": "Evan You",
+            "count": 1
+          },
+          {
+            "value": "Faiq Raza",
+            "count": 1
+          },
+          {
+            "value": "Federico Romero",
+            "count": 1
+          },
+          {
+            "value": "Felix Geisendörfer",
+            "count": 1
+          },
+          {
+            "value": "Felix Rabe",
+            "count": 1
+          },
+          {
+            "value": "Filip Weiss",
+            "count": 1
+          },
+          {
+            "value": "Florian Margaine",
+            "count": 1
+          },
+          {
+            "value": "Forbes Lindesay",
+            "count": 1
+          },
+          {
+            "value": "Forrest L Norvell",
+            "count": 1
+          },
+          {
+            "value": "Francisco Treacy",
+            "count": 1
+          },
+          {
+            "value": "Franck Cuny",
+            "count": 1
+          },
+          {
+            "value": "François Frisch",
+            "count": 1
+          },
+          {
+            "value": "Gabriel Barros",
+            "count": 1
+          },
+          {
+            "value": "Gabriel Falkenberg",
+            "count": 1
+          },
+          {
+            "value": "Gautham Pai",
+            "count": 1
+          },
+          {
+            "value": "Geoff Flarity",
+            "count": 1
+          },
+          {
+            "value": "George Miroshnykov",
+            "count": 1
+          },
+          {
+            "value": "George Ornbo",
+            "count": 1
+          },
+          {
+            "value": "Gianluca Casati",
+            "count": 1
+          },
+          {
+            "value": "Greg Whiteley",
+            "count": 1
+          },
+          {
+            "value": "Guðlaugur Stefán Egilsson",
+            "count": 1
+          },
+          {
+            "value": "Helge Skogly Holm",
+            "count": 1
+          },
+          {
+            "value": "Henrik Hodne",
+            "count": 1
+          },
+          {
+            "value": "Hunter Loftis",
+            "count": 1
+          },
+          {
+            "value": "Iain Sproat",
+            "count": 1
+          },
+          {
+            "value": "Ian Babrou",
+            "count": 1
+          },
+          {
+            "value": "Ian Livingstone",
+            "count": 1
+          },
+          {
+            "value": "Irakli Gozalishvili",
+            "count": 1
+          },
+          {
+            "value": "Isaac Murchie",
+            "count": 1
+          },
+          {
             "value": "Isaac Z. Schlueter",
+            "count": 1
+          },
+          {
+            "value": "J. Tangelder",
+            "count": 1
+          },
+          {
+            "value": "Jaakko Manninen",
+            "count": 1
+          },
+          {
+            "value": "Jake Verbaten",
+            "count": 1
+          },
+          {
+            "value": "Jakob Krigovsky",
+            "count": 1
+          },
+          {
+            "value": "James Butler",
+            "count": 1
+          },
+          {
+            "value": "James Halliday",
+            "count": 1
+          },
+          {
+            "value": "James Sanders",
+            "count": 1
+          },
+          {
+            "value": "James Talmage",
+            "count": 1
+          },
+          {
+            "value": "Jameson Little",
+            "count": 1
+          },
+          {
+            "value": "Jan Lehnardt",
+            "count": 1
+          },
+          {
+            "value": "Jann Horn",
+            "count": 1
+          },
+          {
+            "value": "Jason Diamond",
+            "count": 1
+          },
+          {
+            "value": "Jason Smith",
+            "count": 1
+          },
+          {
+            "value": "Jean Lauliac",
+            "count": 1
+          },
+          {
+            "value": "Jed Schmidt",
+            "count": 1
+          },
+          {
+            "value": "Jeff Barczewski",
+            "count": 1
+          },
+          {
+            "value": "Jeff Jo",
+            "count": 1
+          },
+          {
+            "value": "Jens Grunert",
+            "count": 1
+          },
+          {
+            "value": "Jeremiah Senkpiel",
+            "count": 1
+          },
+          {
+            "value": "Jeremy Cantrell",
+            "count": 1
+          },
+          {
+            "value": "Jess Martin",
+            "count": 1
+          },
+          {
+            "value": "Johan Nordberg",
+            "count": 1
+          },
+          {
+            "value": "Johan Sköld",
+            "count": 1
+          },
+          {
+            "value": "Jon Spencer",
+            "count": 1
+          },
+          {
+            "value": "Jonas Weber",
+            "count": 1
+          },
+          {
+            "value": "Joost-Wim Boekesteijn",
+            "count": 1
+          },
+          {
+            "value": "Jordan Harband",
+            "count": 1
+          },
+          {
+            "value": "Joseph Dykstra",
+            "count": 1
+          },
+          {
+            "value": "Joshua Egan",
+            "count": 1
+          },
+          {
+            "value": "Julian Gruber",
+            "count": 1
+          },
+          {
+            "value": "Julien Meddah",
+            "count": 1
+          },
+          {
+            "value": "Jussi Kalliokoski",
+            "count": 1
+          },
+          {
+            "value": "Jérémy Lal",
+            "count": 1
+          },
+          {
+            "value": "Kai Chen",
+            "count": 1
+          },
+          {
+            "value": "Karl Horky",
+            "count": 1
+          },
+          {
+            "value": "Karolis Narkevicius",
+            "count": 1
+          },
+          {
+            "value": "Karsten Tinnefeld",
+            "count": 1
+          },
+          {
+            "value": "Kat Marchán",
+            "count": 1
+          },
+          {
+            "value": "Kazuhito Hokamura",
+            "count": 1
+          },
+          {
+            "value": "Kei Son",
+            "count": 1
+          },
+          {
+            "value": "Kenan Yildirim",
+            "count": 1
+          },
+          {
+            "value": "Kevin Kragenbrink",
+            "count": 1
+          },
+          {
+            "value": "KevinSheedy",
+            "count": 1
+          },
+          {
+            "value": "Kris Kowal",
+            "count": 1
+          },
+          {
+            "value": "Kris Windham",
+            "count": 1
+          },
+          {
+            "value": "Kyle M. Tarplee",
+            "count": 1
+          },
+          {
+            "value": "Kyle Mitchell",
+            "count": 1
+          },
+          {
+            "value": "Larz Conwell",
+            "count": 1
+          },
+          {
+            "value": "Laurie Harper",
+            "count": 1
+          },
+          {
+            "value": "Laurie Voss",
+            "count": 1
+          },
+          {
+            "value": "Lin Clark",
+            "count": 1
+          },
+          {
+            "value": "Luc Thevenard",
+            "count": 1
+          },
+          {
+            "value": "Ludwig Magnusson",
+            "count": 1
+          },
+          {
+            "value": "Luke Arduini",
+            "count": 1
+          },
+          {
+            "value": "Maciej Małecki",
+            "count": 1
+          },
+          {
+            "value": "Marcel Klehr",
+            "count": 1
+          },
+          {
+            "value": "Marcin Wosinek",
+            "count": 1
+          },
+          {
+            "value": "Marcus Ekwall",
+            "count": 1
+          },
+          {
+            "value": "Mark Cahill",
+            "count": 1
+          },
+          {
+            "value": "Mark Dube",
+            "count": 1
+          },
+          {
+            "value": "Mark J. Titorenko",
+            "count": 1
+          },
+          {
+            "value": "Martin Cooper",
+            "count": 1
+          },
+          {
+            "value": "Martyn Smith",
+            "count": 1
+          },
+          {
+            "value": "Mat Tyndall",
+            "count": 1
+          },
+          {
+            "value": "Mathias Bynens",
+            "count": 1
+          },
+          {
+            "value": "Matt Brennan",
+            "count": 1
+          },
+          {
+            "value": "Matt Colyer",
+            "count": 1
+          },
+          {
+            "value": "Matt Hickford",
+            "count": 1
+          },
+          {
+            "value": "Matt Lunn",
+            "count": 1
+          },
+          {
+            "value": "Matt McClure",
+            "count": 1
+          },
+          {
+            "value": "Matt Zorn",
+            "count": 1
+          },
+          {
+            "value": "Max Goodman",
+            "count": 1
+          },
+          {
+            "value": "Maxim Bogushevich",
+            "count": 1
+          },
+          {
+            "value": "Maximilian Antoni",
+            "count": 1
+          },
+          {
+            "value": "Meaglin",
+            "count": 1
+          },
+          {
+            "value": "Michael Budde",
+            "count": 1
+          },
+          {
+            "value": "Michael Hayes",
+            "count": 1
+          },
+          {
+            "value": "Michael Klein",
+            "count": 1
+          },
+          {
+            "value": "Michael Nisi",
+            "count": 1
+          },
+          {
+            "value": "Michiel Sikma",
+            "count": 1
+          },
+          {
+            "value": "Mick Thompson",
+            "count": 1
+          },
+          {
+            "value": "Mike MacCana",
+            "count": 1
+          },
+          {
+            "value": "Mikeal Rogers",
+            "count": 1
+          },
+          {
+            "value": "Mikola Lysenko",
+            "count": 1
+          },
+          {
+            "value": "Miroslav Bajtoš",
+            "count": 1
+          },
+          {
+            "value": "Nathan Rajlich",
+            "count": 1
+          },
+          {
+            "value": "Nathan Zadoks",
+            "count": 1
+          },
+          {
+            "value": "Neil Gentleman",
+            "count": 1
+          },
+          {
+            "value": "Nicholas Kinsey",
+            "count": 1
+          },
+          {
+            "value": "Nick Heiner",
+            "count": 1
+          },
+          {
+            "value": "Nick Malaguti",
+            "count": 1
+          },
+          {
+            "value": "Nick Santos",
+            "count": 1
+          },
+          {
+            "value": "Nicolas Morel",
+            "count": 1
+          },
+          {
+            "value": "Niggler",
+            "count": 1
+          },
+          {
+            "value": "Oddur Sigurdsson",
+            "count": 1
+          },
+          {
+            "value": "Oleg Efimov",
+            "count": 1
+          },
+          {
+            "value": "Oli Evans",
+            "count": 1
+          },
+          {
+            "value": "Olivier Melcher",
+            "count": 1
+          },
+          {
+            "value": "Orlando Vazquez",
+            "count": 1
+          },
+          {
+            "value": "Paolo Fragomeni",
+            "count": 1
+          },
+          {
+            "value": "Patrick Pfeiffer",
+            "count": 1
+          },
+          {
+            "value": "Paul Miller",
+            "count": 1
+          },
+          {
+            "value": "Paul Vorbach",
+            "count": 1
+          },
+          {
+            "value": "Paulo Cesar",
+            "count": 1
+          },
+          {
+            "value": "Pete Kruckenberg",
+            "count": 1
+          },
+          {
+            "value": "Peter A. Shevtsov",
+            "count": 1
+          },
+          {
+            "value": "Peter Richardson",
+            "count": 1
+          },
+          {
+            "value": "Phillip Howell",
+            "count": 1
+          },
+          {
+            "value": "Quim Calpe",
+            "count": 1
+          },
+          {
+            "value": "Quinn Slack",
+            "count": 1
+          },
+          {
+            "value": "Ra'Shaun Stovall",
+            "count": 1
+          },
+          {
+            "value": "Rachel Hutchison",
+            "count": 1
+          },
+          {
+            "value": "Rafael de Oleza",
+            "count": 1
+          },
+          {
+            "value": "Rebecca Turner",
+            "count": 1
+          },
+          {
+            "value": "Reid Burke",
+            "count": 1
+          },
+          {
+            "value": "Ribettes",
+            "count": 1
+          },
+          {
+            "value": "Richard Littauer",
+            "count": 1
+          },
+          {
+            "value": "Robert Gieseke",
+            "count": 1
+          },
+          {
+            "value": "Robert Kowalski",
+            "count": 1
+          },
+          {
+            "value": "Robin Tweedie",
+            "count": 1
+          },
+          {
+            "value": "Rod Vagg",
+            "count": 1
+          },
+          {
+            "value": "Ron Martinez",
+            "count": 1
+          },
+          {
+            "value": "Ryan Emery",
+            "count": 1
+          },
+          {
+            "value": "Ryan Temple",
+            "count": 1
+          },
+          {
+            "value": "Sam Mikes",
+            "count": 1
+          },
+          {
+            "value": "Schabse Laks",
+            "count": 1
+          },
+          {
+            "value": "Scott Bronson",
+            "count": 1
+          },
+          {
+            "value": "Sean McGivern",
+            "count": 1
+          },
+          {
+            "value": "Sergey Belov",
+            "count": 1
+          },
+          {
+            "value": "Shawn Wildermuth",
+            "count": 1
+          },
+          {
+            "value": "Simen Bekkhus",
+            "count": 1
+          },
+          {
+            "value": "Spain Train",
+            "count": 1
+          },
+          {
+            "value": "Stephan Bönnemann",
+            "count": 1
+          },
+          {
+            "value": "Stephen Sugden",
+            "count": 1
+          },
+          {
+            "value": "Steve Klabnik",
+            "count": 1
+          },
+          {
+            "value": "Steve Mason",
+            "count": 1
+          },
+          {
+            "value": "Steve Steiner",
+            "count": 1
+          },
+          {
+            "value": "Stuart Knightley",
+            "count": 1
+          },
+          {
+            "value": "Stuart P. Bentley",
+            "count": 1
+          },
+          {
+            "value": "Sébastien Santoro",
+            "count": 1
+          },
+          {
+            "value": "TJ Holowaychuk",
+            "count": 1
+          },
+          {
+            "value": "Takaya Kobayashi",
+            "count": 1
+          },
+          {
+            "value": "Tauren Mills",
+            "count": 1
+          },
+          {
+            "value": "Terin Stock",
+            "count": 1
+          },
+          {
+            "value": "Thaddee Tyl",
+            "count": 1
+          },
+          {
+            "value": "Thom Blake",
+            "count": 1
+          },
+          {
+            "value": "Thomas Cort",
+            "count": 1
+          },
+          {
+            "value": "Thomas Torp",
+            "count": 1
+          },
+          {
+            "value": "Thorsten Lorenz",
+            "count": 1
+          },
+          {
+            "value": "Tim Oxley",
+            "count": 1
+          },
+          {
+            "value": "Tim Whidden",
+            "count": 1
+          },
+          {
+            "value": "Timo Derstappen",
+            "count": 1
+          },
+          {
+            "value": "Timo Weiß",
+            "count": 1
+          },
+          {
+            "value": "Tom Huang",
+            "count": 1
+          },
+          {
+            "value": "Tomaž Muraus",
+            "count": 1
+          },
+          {
+            "value": "Tony",
+            "count": 1
+          },
+          {
+            "value": "Tor Valamo",
+            "count": 1
+          },
+          {
+            "value": "Trent Mick",
+            "count": 1
+          },
+          {
+            "value": "Trevor Burnham",
+            "count": 1
+          },
+          {
+            "value": "Tristan Davies",
+            "count": 1
+          },
+          {
+            "value": "Tyler Green",
+            "count": 1
+          },
+          {
+            "value": "Vaz Allen",
+            "count": 1
+          },
+          {
+            "value": "Victor",
+            "count": 1
+          },
+          {
+            "value": "Visnu Pitiyanuvath",
+            "count": 1
+          },
+          {
+            "value": "Vladimir Rutsky",
+            "count": 1
+          },
+          {
+            "value": "Wesley de Souza",
+            "count": 1
+          },
+          {
+            "value": "Whyme.Lyu",
+            "count": 1
+          },
+          {
+            "value": "Wil Moore III",
+            "count": 1
+          },
+          {
+            "value": "Will Elwood",
+            "count": 1
+          },
+          {
+            "value": "Wout Mertens",
+            "count": 1
+          },
+          {
+            "value": "Yazhong Liu",
+            "count": 1
+          },
+          {
+            "value": "Yeonghoon Park",
+            "count": 1
+          },
+          {
+            "value": "Zach Pomerantz",
+            "count": 1
+          },
+          {
+            "value": "Zeke Sikelianos",
             "count": 1
           }
         ],

--- a/testdata/summarycode-golden/tallies/full_tallies/tallies_key_files.expected.json
+++ b/testdata/summarycode-golden/tallies/full_tallies/tallies_key_files.expected.json
@@ -410,11 +410,1171 @@
         "count": 4
       },
       {
+        "value": "Aaron Blohowiak",
+        "count": 1
+      },
+      {
+        "value": "Aaron Stacy",
+        "count": 1
+      },
+      {
+        "value": "Adam Blackburn",
+        "count": 1
+      },
+      {
+        "value": "Adam Meadows",
+        "count": 1
+      },
+      {
+        "value": "Adrian Lynch",
+        "count": 1
+      },
+      {
+        "value": "Alain Kalker",
+        "count": 1
+      },
+      {
+        "value": "Alan Shaw",
+        "count": 1
+      },
+      {
+        "value": "Aleksey Smolenchuk",
+        "count": 1
+      },
+      {
+        "value": "Alex Ford",
+        "count": 1
+      },
+      {
+        "value": "Alex Gorbatchev",
+        "count": 1
+      },
+      {
+        "value": "Alex K. Wolfe",
+        "count": 1
+      },
+      {
+        "value": "Alex Kocharin",
+        "count": 1
+      },
+      {
+        "value": "Alex Rodionov",
+        "count": 1
+      },
+      {
+        "value": "Alexej Yaroshevich",
+        "count": 1
+      },
+      {
+        "value": "Alexey Kreschuk",
+        "count": 1
+      },
+      {
+        "value": "Anders Janmyr",
+        "count": 1
+      },
+      {
+        "value": "Andreas",
+        "count": 1
+      },
+      {
+        "value": "Andrew",
+        "count": 1
+      },
+      {
+        "value": "Andrew Bradley",
+        "count": 1
+      },
+      {
+        "value": "Andrew Horton",
+        "count": 1
+      },
+      {
+        "value": "Andrew Lunny",
+        "count": 1
+      },
+      {
+        "value": "Andrew Murray",
+        "count": 1
+      },
+      {
+        "value": "Andrew Terris",
+        "count": 1
+      },
+      {
+        "value": "Andrey Fedorov",
+        "count": 1
+      },
+      {
+        "value": "Andrey Kislyuk",
+        "count": 1
+      },
+      {
+        "value": "Anthony Zotti",
+        "count": 1
+      },
+      {
+        "value": "Antti Mattila",
+        "count": 1
+      },
+      {
+        "value": "Aria Stewart",
+        "count": 1
+      },
+      {
+        "value": "Arlo Breault",
+        "count": 1
+      },
+      {
+        "value": "Arnaud Rinquin",
+        "count": 1
+      },
+      {
+        "value": "Bart Teeuwisse",
+        "count": 1
+      },
+      {
+        "value": "Ben Evans",
+        "count": 1
+      },
+      {
+        "value": "Ben Noordhuis",
+        "count": 1
+      },
+      {
+        "value": "Ben Page",
+        "count": 1
+      },
+      {
+        "value": "Benjamin Coe",
+        "count": 1
+      },
+      {
+        "value": "Blaine Bublitz",
+        "count": 1
+      },
+      {
+        "value": "Bradley Meck",
+        "count": 1
+      },
+      {
+        "value": "Brian White",
+        "count": 1
+      },
+      {
+        "value": "Bryan Burgers",
+        "count": 1
+      },
+      {
+        "value": "Bryan English",
+        "count": 1
+      },
+      {
+        "value": "Bryant Williams",
+        "count": 1
+      },
+      {
+        "value": "C J Silverio",
+        "count": 1
+      },
+      {
+        "value": "CamilleM",
+        "count": 1
+      },
+      {
+        "value": "Carl Lange",
+        "count": 1
+      },
+      {
+        "value": "Cedric Nelson",
+        "count": 1
+      },
+      {
+        "value": "Charlie Robbins",
+        "count": 1
+      },
+      {
+        "value": "Charlie Rudolph",
+        "count": 1
+      },
+      {
+        "value": "Charmander",
+        "count": 1
+      },
+      {
+        "value": "Chris Dickinson",
+        "count": 1
+      },
+      {
+        "value": "Chris Meyers",
+        "count": 1
+      },
+      {
+        "value": "Chris Williams",
+        "count": 1
+      },
+      {
+        "value": "Chris Wong",
+        "count": 1
+      },
+      {
+        "value": "Christian Eager",
+        "count": 1
+      },
+      {
+        "value": "Christian Howe",
+        "count": 1
+      },
+      {
+        "value": "Christopher Hiller",
+        "count": 1
+      },
+      {
+        "value": "Chulki Lee",
+        "count": 1
+      },
+      {
+        "value": "Clay Carpenter",
+        "count": 1
+      },
+      {
+        "value": "Cliffano Subagio",
+        "count": 1
+      },
+      {
+        "value": "Conny Brunnkvist",
+        "count": 1
+      },
+      {
+        "value": "Daijiro Wachi",
+        "count": 1
+      },
+      {
+        "value": "Dalmais Maxence",
+        "count": 1
+      },
+      {
+        "value": "Daniel Santiago",
+        "count": 1
+      },
+      {
+        "value": "Danila Gerasimov",
+        "count": 1
+      },
+      {
+        "value": "Danny Fritz",
+        "count": 1
+      },
+      {
+        "value": "Dav Glass",
+        "count": 1
+      },
+      {
+        "value": "Dave Pacheco",
+        "count": 1
+      },
+      {
+        "value": "David Beitey",
+        "count": 1
+      },
+      {
+        "value": "David Glasser",
+        "count": 1
+      },
+      {
+        "value": "David Marr",
+        "count": 1
+      },
+      {
+        "value": "David Trejo",
+        "count": 1
+      },
+      {
+        "value": "David Volm",
+        "count": 1
+      },
+      {
+        "value": "Dean Landolt",
+        "count": 1
+      },
+      {
+        "value": "Denis Gladkikh",
+        "count": 1
+      },
+      {
+        "value": "Derek Peterson",
+        "count": 1
+      },
+      {
+        "value": "Di Wu",
+        "count": 1
+      },
+      {
+        "value": "Domenic Denicola",
+        "count": 1
+      },
+      {
+        "value": "Don Park",
+        "count": 1
+      },
+      {
+        "value": "Dylan Greene",
+        "count": 1
+      },
+      {
+        "value": "Ed Morley",
+        "count": 1
+      },
+      {
+        "value": "Eduardo Pinho",
+        "count": 1
+      },
+      {
+        "value": "Einar Otto Stangvik",
+        "count": 1
+      },
+      {
+        "value": "Elan Shanker",
+        "count": 1
+      },
+      {
+        "value": "Eric Mill",
+        "count": 1
+      },
+      {
+        "value": "Erik Wienhold",
+        "count": 1
+      },
+      {
+        "value": "Eugene Sharygin",
+        "count": 1
+      },
+      {
+        "value": "Evan Lucas",
+        "count": 1
+      },
+      {
+        "value": "Evan Meagher",
+        "count": 1
+      },
+      {
+        "value": "Evan You",
+        "count": 1
+      },
+      {
+        "value": "Faiq Raza",
+        "count": 1
+      },
+      {
+        "value": "Federico Romero",
+        "count": 1
+      },
+      {
+        "value": "Felix Geisendörfer",
+        "count": 1
+      },
+      {
+        "value": "Felix Rabe",
+        "count": 1
+      },
+      {
+        "value": "Filip Weiss",
+        "count": 1
+      },
+      {
+        "value": "Florian Margaine",
+        "count": 1
+      },
+      {
+        "value": "Forbes Lindesay",
+        "count": 1
+      },
+      {
+        "value": "Forrest L Norvell",
+        "count": 1
+      },
+      {
+        "value": "Francisco Treacy",
+        "count": 1
+      },
+      {
+        "value": "Franck Cuny",
+        "count": 1
+      },
+      {
+        "value": "François Frisch",
+        "count": 1
+      },
+      {
+        "value": "Gabriel Barros",
+        "count": 1
+      },
+      {
+        "value": "Gabriel Falkenberg",
+        "count": 1
+      },
+      {
+        "value": "Gautham Pai",
+        "count": 1
+      },
+      {
+        "value": "Geoff Flarity",
+        "count": 1
+      },
+      {
+        "value": "George Miroshnykov",
+        "count": 1
+      },
+      {
+        "value": "George Ornbo",
+        "count": 1
+      },
+      {
+        "value": "Gianluca Casati",
+        "count": 1
+      },
+      {
         "value": "Gilles Vollant",
         "count": 1
       },
       {
+        "value": "Greg Whiteley",
+        "count": 1
+      },
+      {
+        "value": "Guðlaugur Stefán Egilsson",
+        "count": 1
+      },
+      {
+        "value": "Helge Skogly Holm",
+        "count": 1
+      },
+      {
+        "value": "Henrik Hodne",
+        "count": 1
+      },
+      {
+        "value": "Hunter Loftis",
+        "count": 1
+      },
+      {
+        "value": "Iain Sproat",
+        "count": 1
+      },
+      {
+        "value": "Ian Babrou",
+        "count": 1
+      },
+      {
+        "value": "Ian Livingstone",
+        "count": 1
+      },
+      {
+        "value": "Irakli Gozalishvili",
+        "count": 1
+      },
+      {
+        "value": "Isaac Murchie",
+        "count": 1
+      },
+      {
         "value": "Isaac Z. Schlueter",
+        "count": 1
+      },
+      {
+        "value": "J. Tangelder",
+        "count": 1
+      },
+      {
+        "value": "Jaakko Manninen",
+        "count": 1
+      },
+      {
+        "value": "Jake Verbaten",
+        "count": 1
+      },
+      {
+        "value": "Jakob Krigovsky",
+        "count": 1
+      },
+      {
+        "value": "James Butler",
+        "count": 1
+      },
+      {
+        "value": "James Halliday",
+        "count": 1
+      },
+      {
+        "value": "James Sanders",
+        "count": 1
+      },
+      {
+        "value": "James Talmage",
+        "count": 1
+      },
+      {
+        "value": "Jameson Little",
+        "count": 1
+      },
+      {
+        "value": "Jan Lehnardt",
+        "count": 1
+      },
+      {
+        "value": "Jann Horn",
+        "count": 1
+      },
+      {
+        "value": "Jason Diamond",
+        "count": 1
+      },
+      {
+        "value": "Jason Smith",
+        "count": 1
+      },
+      {
+        "value": "Jean Lauliac",
+        "count": 1
+      },
+      {
+        "value": "Jed Schmidt",
+        "count": 1
+      },
+      {
+        "value": "Jeff Barczewski",
+        "count": 1
+      },
+      {
+        "value": "Jeff Jo",
+        "count": 1
+      },
+      {
+        "value": "Jens Grunert",
+        "count": 1
+      },
+      {
+        "value": "Jeremiah Senkpiel",
+        "count": 1
+      },
+      {
+        "value": "Jeremy Cantrell",
+        "count": 1
+      },
+      {
+        "value": "Jess Martin",
+        "count": 1
+      },
+      {
+        "value": "Johan Nordberg",
+        "count": 1
+      },
+      {
+        "value": "Johan Sköld",
+        "count": 1
+      },
+      {
+        "value": "Jon Spencer",
+        "count": 1
+      },
+      {
+        "value": "Jonas Weber",
+        "count": 1
+      },
+      {
+        "value": "Joost-Wim Boekesteijn",
+        "count": 1
+      },
+      {
+        "value": "Jordan Harband",
+        "count": 1
+      },
+      {
+        "value": "Joseph Dykstra",
+        "count": 1
+      },
+      {
+        "value": "Joshua Egan",
+        "count": 1
+      },
+      {
+        "value": "Julian Gruber",
+        "count": 1
+      },
+      {
+        "value": "Julien Meddah",
+        "count": 1
+      },
+      {
+        "value": "Jussi Kalliokoski",
+        "count": 1
+      },
+      {
+        "value": "Jérémy Lal",
+        "count": 1
+      },
+      {
+        "value": "Kai Chen",
+        "count": 1
+      },
+      {
+        "value": "Karl Horky",
+        "count": 1
+      },
+      {
+        "value": "Karolis Narkevicius",
+        "count": 1
+      },
+      {
+        "value": "Karsten Tinnefeld",
+        "count": 1
+      },
+      {
+        "value": "Kat Marchán",
+        "count": 1
+      },
+      {
+        "value": "Kazuhito Hokamura",
+        "count": 1
+      },
+      {
+        "value": "Kei Son",
+        "count": 1
+      },
+      {
+        "value": "Kenan Yildirim",
+        "count": 1
+      },
+      {
+        "value": "Kevin Kragenbrink",
+        "count": 1
+      },
+      {
+        "value": "KevinSheedy",
+        "count": 1
+      },
+      {
+        "value": "Kris Kowal",
+        "count": 1
+      },
+      {
+        "value": "Kris Windham",
+        "count": 1
+      },
+      {
+        "value": "Kyle M. Tarplee",
+        "count": 1
+      },
+      {
+        "value": "Kyle Mitchell",
+        "count": 1
+      },
+      {
+        "value": "Larz Conwell",
+        "count": 1
+      },
+      {
+        "value": "Laurie Harper",
+        "count": 1
+      },
+      {
+        "value": "Laurie Voss",
+        "count": 1
+      },
+      {
+        "value": "Lin Clark",
+        "count": 1
+      },
+      {
+        "value": "Luc Thevenard",
+        "count": 1
+      },
+      {
+        "value": "Ludwig Magnusson",
+        "count": 1
+      },
+      {
+        "value": "Luke Arduini",
+        "count": 1
+      },
+      {
+        "value": "Maciej Małecki",
+        "count": 1
+      },
+      {
+        "value": "Marcel Klehr",
+        "count": 1
+      },
+      {
+        "value": "Marcin Wosinek",
+        "count": 1
+      },
+      {
+        "value": "Marcus Ekwall",
+        "count": 1
+      },
+      {
+        "value": "Mark Cahill",
+        "count": 1
+      },
+      {
+        "value": "Mark Dube",
+        "count": 1
+      },
+      {
+        "value": "Mark J. Titorenko",
+        "count": 1
+      },
+      {
+        "value": "Martin Cooper",
+        "count": 1
+      },
+      {
+        "value": "Martyn Smith",
+        "count": 1
+      },
+      {
+        "value": "Mat Tyndall",
+        "count": 1
+      },
+      {
+        "value": "Mathias Bynens",
+        "count": 1
+      },
+      {
+        "value": "Matt Brennan",
+        "count": 1
+      },
+      {
+        "value": "Matt Colyer",
+        "count": 1
+      },
+      {
+        "value": "Matt Hickford",
+        "count": 1
+      },
+      {
+        "value": "Matt Lunn",
+        "count": 1
+      },
+      {
+        "value": "Matt McClure",
+        "count": 1
+      },
+      {
+        "value": "Matt Zorn",
+        "count": 1
+      },
+      {
+        "value": "Max Goodman",
+        "count": 1
+      },
+      {
+        "value": "Maxim Bogushevich",
+        "count": 1
+      },
+      {
+        "value": "Maximilian Antoni",
+        "count": 1
+      },
+      {
+        "value": "Meaglin",
+        "count": 1
+      },
+      {
+        "value": "Michael Budde",
+        "count": 1
+      },
+      {
+        "value": "Michael Hayes",
+        "count": 1
+      },
+      {
+        "value": "Michael Klein",
+        "count": 1
+      },
+      {
+        "value": "Michael Nisi",
+        "count": 1
+      },
+      {
+        "value": "Michiel Sikma",
+        "count": 1
+      },
+      {
+        "value": "Mick Thompson",
+        "count": 1
+      },
+      {
+        "value": "Mike MacCana",
+        "count": 1
+      },
+      {
+        "value": "Mikeal Rogers",
+        "count": 1
+      },
+      {
+        "value": "Mikola Lysenko",
+        "count": 1
+      },
+      {
+        "value": "Miroslav Bajtoš",
+        "count": 1
+      },
+      {
+        "value": "Nathan Rajlich",
+        "count": 1
+      },
+      {
+        "value": "Nathan Zadoks",
+        "count": 1
+      },
+      {
+        "value": "Neil Gentleman",
+        "count": 1
+      },
+      {
+        "value": "Nicholas Kinsey",
+        "count": 1
+      },
+      {
+        "value": "Nick Heiner",
+        "count": 1
+      },
+      {
+        "value": "Nick Malaguti",
+        "count": 1
+      },
+      {
+        "value": "Nick Santos",
+        "count": 1
+      },
+      {
+        "value": "Nicolas Morel",
+        "count": 1
+      },
+      {
+        "value": "Niggler",
+        "count": 1
+      },
+      {
+        "value": "Oddur Sigurdsson",
+        "count": 1
+      },
+      {
+        "value": "Oleg Efimov",
+        "count": 1
+      },
+      {
+        "value": "Oli Evans",
+        "count": 1
+      },
+      {
+        "value": "Olivier Melcher",
+        "count": 1
+      },
+      {
+        "value": "Orlando Vazquez",
+        "count": 1
+      },
+      {
+        "value": "Paolo Fragomeni",
+        "count": 1
+      },
+      {
+        "value": "Patrick Pfeiffer",
+        "count": 1
+      },
+      {
+        "value": "Paul Miller",
+        "count": 1
+      },
+      {
+        "value": "Paul Vorbach",
+        "count": 1
+      },
+      {
+        "value": "Paulo Cesar",
+        "count": 1
+      },
+      {
+        "value": "Pete Kruckenberg",
+        "count": 1
+      },
+      {
+        "value": "Peter A. Shevtsov",
+        "count": 1
+      },
+      {
+        "value": "Peter Richardson",
+        "count": 1
+      },
+      {
+        "value": "Phillip Howell",
+        "count": 1
+      },
+      {
+        "value": "Quim Calpe",
+        "count": 1
+      },
+      {
+        "value": "Quinn Slack",
+        "count": 1
+      },
+      {
+        "value": "Ra'Shaun Stovall",
+        "count": 1
+      },
+      {
+        "value": "Rachel Hutchison",
+        "count": 1
+      },
+      {
+        "value": "Rafael de Oleza",
+        "count": 1
+      },
+      {
+        "value": "Rebecca Turner",
+        "count": 1
+      },
+      {
+        "value": "Reid Burke",
+        "count": 1
+      },
+      {
+        "value": "Ribettes",
+        "count": 1
+      },
+      {
+        "value": "Richard Littauer",
+        "count": 1
+      },
+      {
+        "value": "Robert Gieseke",
+        "count": 1
+      },
+      {
+        "value": "Robert Kowalski",
+        "count": 1
+      },
+      {
+        "value": "Robin Tweedie",
+        "count": 1
+      },
+      {
+        "value": "Rod Vagg",
+        "count": 1
+      },
+      {
+        "value": "Ron Martinez",
+        "count": 1
+      },
+      {
+        "value": "Ryan Emery",
+        "count": 1
+      },
+      {
+        "value": "Ryan Temple",
+        "count": 1
+      },
+      {
+        "value": "Sam Mikes",
+        "count": 1
+      },
+      {
+        "value": "Schabse Laks",
+        "count": 1
+      },
+      {
+        "value": "Scott Bronson",
+        "count": 1
+      },
+      {
+        "value": "Sean McGivern",
+        "count": 1
+      },
+      {
+        "value": "Sergey Belov",
+        "count": 1
+      },
+      {
+        "value": "Shawn Wildermuth",
+        "count": 1
+      },
+      {
+        "value": "Simen Bekkhus",
+        "count": 1
+      },
+      {
+        "value": "Spain Train",
+        "count": 1
+      },
+      {
+        "value": "Stephan Bönnemann",
+        "count": 1
+      },
+      {
+        "value": "Stephen Sugden",
+        "count": 1
+      },
+      {
+        "value": "Steve Klabnik",
+        "count": 1
+      },
+      {
+        "value": "Steve Mason",
+        "count": 1
+      },
+      {
+        "value": "Steve Steiner",
+        "count": 1
+      },
+      {
+        "value": "Stuart Knightley",
+        "count": 1
+      },
+      {
+        "value": "Stuart P. Bentley",
+        "count": 1
+      },
+      {
+        "value": "Sébastien Santoro",
+        "count": 1
+      },
+      {
+        "value": "TJ Holowaychuk",
+        "count": 1
+      },
+      {
+        "value": "Takaya Kobayashi",
+        "count": 1
+      },
+      {
+        "value": "Tauren Mills",
+        "count": 1
+      },
+      {
+        "value": "Terin Stock",
+        "count": 1
+      },
+      {
+        "value": "Thaddee Tyl",
+        "count": 1
+      },
+      {
+        "value": "Thom Blake",
+        "count": 1
+      },
+      {
+        "value": "Thomas Cort",
+        "count": 1
+      },
+      {
+        "value": "Thomas Torp",
+        "count": 1
+      },
+      {
+        "value": "Thorsten Lorenz",
+        "count": 1
+      },
+      {
+        "value": "Tim Oxley",
+        "count": 1
+      },
+      {
+        "value": "Tim Whidden",
+        "count": 1
+      },
+      {
+        "value": "Timo Derstappen",
+        "count": 1
+      },
+      {
+        "value": "Timo Weiß",
+        "count": 1
+      },
+      {
+        "value": "Tom Huang",
+        "count": 1
+      },
+      {
+        "value": "Tomaž Muraus",
+        "count": 1
+      },
+      {
+        "value": "Tony",
+        "count": 1
+      },
+      {
+        "value": "Tor Valamo",
+        "count": 1
+      },
+      {
+        "value": "Trent Mick",
+        "count": 1
+      },
+      {
+        "value": "Trevor Burnham",
+        "count": 1
+      },
+      {
+        "value": "Tristan Davies",
+        "count": 1
+      },
+      {
+        "value": "Tyler Green",
+        "count": 1
+      },
+      {
+        "value": "Vaz Allen",
+        "count": 1
+      },
+      {
+        "value": "Victor",
+        "count": 1
+      },
+      {
+        "value": "Visnu Pitiyanuvath",
+        "count": 1
+      },
+      {
+        "value": "Vladimir Rutsky",
+        "count": 1
+      },
+      {
+        "value": "Wesley de Souza",
+        "count": 1
+      },
+      {
+        "value": "Whyme.Lyu",
+        "count": 1
+      },
+      {
+        "value": "Wil Moore III",
+        "count": 1
+      },
+      {
+        "value": "Will Elwood",
+        "count": 1
+      },
+      {
+        "value": "Wout Mertens",
+        "count": 1
+      },
+      {
+        "value": "Yazhong Liu",
+        "count": 1
+      },
+      {
+        "value": "Yeonghoon Park",
+        "count": 1
+      },
+      {
+        "value": "Zach Pomerantz",
+        "count": 1
+      },
+      {
+        "value": "Zeke Sikelianos",
         "count": 1
       }
     ],
@@ -452,7 +1612,1167 @@
     "holders": [],
     "authors": [
       {
+        "value": "Aaron Blohowiak",
+        "count": 1
+      },
+      {
+        "value": "Aaron Stacy",
+        "count": 1
+      },
+      {
+        "value": "Adam Blackburn",
+        "count": 1
+      },
+      {
+        "value": "Adam Meadows",
+        "count": 1
+      },
+      {
+        "value": "Adrian Lynch",
+        "count": 1
+      },
+      {
+        "value": "Alain Kalker",
+        "count": 1
+      },
+      {
+        "value": "Alan Shaw",
+        "count": 1
+      },
+      {
+        "value": "Aleksey Smolenchuk",
+        "count": 1
+      },
+      {
+        "value": "Alex Ford",
+        "count": 1
+      },
+      {
+        "value": "Alex Gorbatchev",
+        "count": 1
+      },
+      {
+        "value": "Alex K. Wolfe",
+        "count": 1
+      },
+      {
+        "value": "Alex Kocharin",
+        "count": 1
+      },
+      {
+        "value": "Alex Rodionov",
+        "count": 1
+      },
+      {
+        "value": "Alexej Yaroshevich",
+        "count": 1
+      },
+      {
+        "value": "Alexey Kreschuk",
+        "count": 1
+      },
+      {
+        "value": "Anders Janmyr",
+        "count": 1
+      },
+      {
+        "value": "Andreas",
+        "count": 1
+      },
+      {
+        "value": "Andrew",
+        "count": 1
+      },
+      {
+        "value": "Andrew Bradley",
+        "count": 1
+      },
+      {
+        "value": "Andrew Horton",
+        "count": 1
+      },
+      {
+        "value": "Andrew Lunny",
+        "count": 1
+      },
+      {
+        "value": "Andrew Murray",
+        "count": 1
+      },
+      {
+        "value": "Andrew Terris",
+        "count": 1
+      },
+      {
+        "value": "Andrey Fedorov",
+        "count": 1
+      },
+      {
+        "value": "Andrey Kislyuk",
+        "count": 1
+      },
+      {
+        "value": "Anthony Zotti",
+        "count": 1
+      },
+      {
+        "value": "Antti Mattila",
+        "count": 1
+      },
+      {
+        "value": "Aria Stewart",
+        "count": 1
+      },
+      {
+        "value": "Arlo Breault",
+        "count": 1
+      },
+      {
+        "value": "Arnaud Rinquin",
+        "count": 1
+      },
+      {
+        "value": "Bart Teeuwisse",
+        "count": 1
+      },
+      {
+        "value": "Ben Evans",
+        "count": 1
+      },
+      {
+        "value": "Ben Noordhuis",
+        "count": 1
+      },
+      {
+        "value": "Ben Page",
+        "count": 1
+      },
+      {
+        "value": "Benjamin Coe",
+        "count": 1
+      },
+      {
+        "value": "Blaine Bublitz",
+        "count": 1
+      },
+      {
+        "value": "Bradley Meck",
+        "count": 1
+      },
+      {
+        "value": "Brian White",
+        "count": 1
+      },
+      {
+        "value": "Bryan Burgers",
+        "count": 1
+      },
+      {
+        "value": "Bryan English",
+        "count": 1
+      },
+      {
+        "value": "Bryant Williams",
+        "count": 1
+      },
+      {
+        "value": "C J Silverio",
+        "count": 1
+      },
+      {
+        "value": "CamilleM",
+        "count": 1
+      },
+      {
+        "value": "Carl Lange",
+        "count": 1
+      },
+      {
+        "value": "Cedric Nelson",
+        "count": 1
+      },
+      {
+        "value": "Charlie Robbins",
+        "count": 1
+      },
+      {
+        "value": "Charlie Rudolph",
+        "count": 1
+      },
+      {
+        "value": "Charmander",
+        "count": 1
+      },
+      {
+        "value": "Chris Dickinson",
+        "count": 1
+      },
+      {
+        "value": "Chris Meyers",
+        "count": 1
+      },
+      {
+        "value": "Chris Williams",
+        "count": 1
+      },
+      {
+        "value": "Chris Wong",
+        "count": 1
+      },
+      {
+        "value": "Christian Eager",
+        "count": 1
+      },
+      {
+        "value": "Christian Howe",
+        "count": 1
+      },
+      {
+        "value": "Christopher Hiller",
+        "count": 1
+      },
+      {
+        "value": "Chulki Lee",
+        "count": 1
+      },
+      {
+        "value": "Clay Carpenter",
+        "count": 1
+      },
+      {
+        "value": "Cliffano Subagio",
+        "count": 1
+      },
+      {
+        "value": "Conny Brunnkvist",
+        "count": 1
+      },
+      {
+        "value": "Daijiro Wachi",
+        "count": 1
+      },
+      {
+        "value": "Dalmais Maxence",
+        "count": 1
+      },
+      {
+        "value": "Daniel Santiago",
+        "count": 1
+      },
+      {
+        "value": "Danila Gerasimov",
+        "count": 1
+      },
+      {
+        "value": "Danny Fritz",
+        "count": 1
+      },
+      {
+        "value": "Dav Glass",
+        "count": 1
+      },
+      {
+        "value": "Dave Pacheco",
+        "count": 1
+      },
+      {
+        "value": "David Beitey",
+        "count": 1
+      },
+      {
+        "value": "David Glasser",
+        "count": 1
+      },
+      {
+        "value": "David Marr",
+        "count": 1
+      },
+      {
+        "value": "David Trejo",
+        "count": 1
+      },
+      {
+        "value": "David Volm",
+        "count": 1
+      },
+      {
+        "value": "Dean Landolt",
+        "count": 1
+      },
+      {
+        "value": "Denis Gladkikh",
+        "count": 1
+      },
+      {
+        "value": "Derek Peterson",
+        "count": 1
+      },
+      {
+        "value": "Di Wu",
+        "count": 1
+      },
+      {
+        "value": "Domenic Denicola",
+        "count": 1
+      },
+      {
+        "value": "Don Park",
+        "count": 1
+      },
+      {
+        "value": "Dylan Greene",
+        "count": 1
+      },
+      {
+        "value": "Ed Morley",
+        "count": 1
+      },
+      {
+        "value": "Eduardo Pinho",
+        "count": 1
+      },
+      {
+        "value": "Einar Otto Stangvik",
+        "count": 1
+      },
+      {
+        "value": "Elan Shanker",
+        "count": 1
+      },
+      {
+        "value": "Eric Mill",
+        "count": 1
+      },
+      {
+        "value": "Erik Wienhold",
+        "count": 1
+      },
+      {
+        "value": "Eugene Sharygin",
+        "count": 1
+      },
+      {
+        "value": "Evan Lucas",
+        "count": 1
+      },
+      {
+        "value": "Evan Meagher",
+        "count": 1
+      },
+      {
+        "value": "Evan You",
+        "count": 1
+      },
+      {
+        "value": "Faiq Raza",
+        "count": 1
+      },
+      {
+        "value": "Federico Romero",
+        "count": 1
+      },
+      {
+        "value": "Felix Geisendörfer",
+        "count": 1
+      },
+      {
+        "value": "Felix Rabe",
+        "count": 1
+      },
+      {
+        "value": "Filip Weiss",
+        "count": 1
+      },
+      {
+        "value": "Florian Margaine",
+        "count": 1
+      },
+      {
+        "value": "Forbes Lindesay",
+        "count": 1
+      },
+      {
+        "value": "Forrest L Norvell",
+        "count": 1
+      },
+      {
+        "value": "Francisco Treacy",
+        "count": 1
+      },
+      {
+        "value": "Franck Cuny",
+        "count": 1
+      },
+      {
+        "value": "François Frisch",
+        "count": 1
+      },
+      {
+        "value": "Gabriel Barros",
+        "count": 1
+      },
+      {
+        "value": "Gabriel Falkenberg",
+        "count": 1
+      },
+      {
+        "value": "Gautham Pai",
+        "count": 1
+      },
+      {
+        "value": "Geoff Flarity",
+        "count": 1
+      },
+      {
+        "value": "George Miroshnykov",
+        "count": 1
+      },
+      {
+        "value": "George Ornbo",
+        "count": 1
+      },
+      {
+        "value": "Gianluca Casati",
+        "count": 1
+      },
+      {
+        "value": "Greg Whiteley",
+        "count": 1
+      },
+      {
+        "value": "Guðlaugur Stefán Egilsson",
+        "count": 1
+      },
+      {
+        "value": "Helge Skogly Holm",
+        "count": 1
+      },
+      {
+        "value": "Henrik Hodne",
+        "count": 1
+      },
+      {
+        "value": "Hunter Loftis",
+        "count": 1
+      },
+      {
+        "value": "Iain Sproat",
+        "count": 1
+      },
+      {
+        "value": "Ian Babrou",
+        "count": 1
+      },
+      {
+        "value": "Ian Livingstone",
+        "count": 1
+      },
+      {
+        "value": "Irakli Gozalishvili",
+        "count": 1
+      },
+      {
+        "value": "Isaac Murchie",
+        "count": 1
+      },
+      {
         "value": "Isaac Z. Schlueter",
+        "count": 1
+      },
+      {
+        "value": "J. Tangelder",
+        "count": 1
+      },
+      {
+        "value": "Jaakko Manninen",
+        "count": 1
+      },
+      {
+        "value": "Jake Verbaten",
+        "count": 1
+      },
+      {
+        "value": "Jakob Krigovsky",
+        "count": 1
+      },
+      {
+        "value": "James Butler",
+        "count": 1
+      },
+      {
+        "value": "James Halliday",
+        "count": 1
+      },
+      {
+        "value": "James Sanders",
+        "count": 1
+      },
+      {
+        "value": "James Talmage",
+        "count": 1
+      },
+      {
+        "value": "Jameson Little",
+        "count": 1
+      },
+      {
+        "value": "Jan Lehnardt",
+        "count": 1
+      },
+      {
+        "value": "Jann Horn",
+        "count": 1
+      },
+      {
+        "value": "Jason Diamond",
+        "count": 1
+      },
+      {
+        "value": "Jason Smith",
+        "count": 1
+      },
+      {
+        "value": "Jean Lauliac",
+        "count": 1
+      },
+      {
+        "value": "Jed Schmidt",
+        "count": 1
+      },
+      {
+        "value": "Jeff Barczewski",
+        "count": 1
+      },
+      {
+        "value": "Jeff Jo",
+        "count": 1
+      },
+      {
+        "value": "Jens Grunert",
+        "count": 1
+      },
+      {
+        "value": "Jeremiah Senkpiel",
+        "count": 1
+      },
+      {
+        "value": "Jeremy Cantrell",
+        "count": 1
+      },
+      {
+        "value": "Jess Martin",
+        "count": 1
+      },
+      {
+        "value": "Johan Nordberg",
+        "count": 1
+      },
+      {
+        "value": "Johan Sköld",
+        "count": 1
+      },
+      {
+        "value": "Jon Spencer",
+        "count": 1
+      },
+      {
+        "value": "Jonas Weber",
+        "count": 1
+      },
+      {
+        "value": "Joost-Wim Boekesteijn",
+        "count": 1
+      },
+      {
+        "value": "Jordan Harband",
+        "count": 1
+      },
+      {
+        "value": "Joseph Dykstra",
+        "count": 1
+      },
+      {
+        "value": "Joshua Egan",
+        "count": 1
+      },
+      {
+        "value": "Julian Gruber",
+        "count": 1
+      },
+      {
+        "value": "Julien Meddah",
+        "count": 1
+      },
+      {
+        "value": "Jussi Kalliokoski",
+        "count": 1
+      },
+      {
+        "value": "Jérémy Lal",
+        "count": 1
+      },
+      {
+        "value": "Kai Chen",
+        "count": 1
+      },
+      {
+        "value": "Karl Horky",
+        "count": 1
+      },
+      {
+        "value": "Karolis Narkevicius",
+        "count": 1
+      },
+      {
+        "value": "Karsten Tinnefeld",
+        "count": 1
+      },
+      {
+        "value": "Kat Marchán",
+        "count": 1
+      },
+      {
+        "value": "Kazuhito Hokamura",
+        "count": 1
+      },
+      {
+        "value": "Kei Son",
+        "count": 1
+      },
+      {
+        "value": "Kenan Yildirim",
+        "count": 1
+      },
+      {
+        "value": "Kevin Kragenbrink",
+        "count": 1
+      },
+      {
+        "value": "KevinSheedy",
+        "count": 1
+      },
+      {
+        "value": "Kris Kowal",
+        "count": 1
+      },
+      {
+        "value": "Kris Windham",
+        "count": 1
+      },
+      {
+        "value": "Kyle M. Tarplee",
+        "count": 1
+      },
+      {
+        "value": "Kyle Mitchell",
+        "count": 1
+      },
+      {
+        "value": "Larz Conwell",
+        "count": 1
+      },
+      {
+        "value": "Laurie Harper",
+        "count": 1
+      },
+      {
+        "value": "Laurie Voss",
+        "count": 1
+      },
+      {
+        "value": "Lin Clark",
+        "count": 1
+      },
+      {
+        "value": "Luc Thevenard",
+        "count": 1
+      },
+      {
+        "value": "Ludwig Magnusson",
+        "count": 1
+      },
+      {
+        "value": "Luke Arduini",
+        "count": 1
+      },
+      {
+        "value": "Maciej Małecki",
+        "count": 1
+      },
+      {
+        "value": "Marcel Klehr",
+        "count": 1
+      },
+      {
+        "value": "Marcin Wosinek",
+        "count": 1
+      },
+      {
+        "value": "Marcus Ekwall",
+        "count": 1
+      },
+      {
+        "value": "Mark Cahill",
+        "count": 1
+      },
+      {
+        "value": "Mark Dube",
+        "count": 1
+      },
+      {
+        "value": "Mark J. Titorenko",
+        "count": 1
+      },
+      {
+        "value": "Martin Cooper",
+        "count": 1
+      },
+      {
+        "value": "Martyn Smith",
+        "count": 1
+      },
+      {
+        "value": "Mat Tyndall",
+        "count": 1
+      },
+      {
+        "value": "Mathias Bynens",
+        "count": 1
+      },
+      {
+        "value": "Matt Brennan",
+        "count": 1
+      },
+      {
+        "value": "Matt Colyer",
+        "count": 1
+      },
+      {
+        "value": "Matt Hickford",
+        "count": 1
+      },
+      {
+        "value": "Matt Lunn",
+        "count": 1
+      },
+      {
+        "value": "Matt McClure",
+        "count": 1
+      },
+      {
+        "value": "Matt Zorn",
+        "count": 1
+      },
+      {
+        "value": "Max Goodman",
+        "count": 1
+      },
+      {
+        "value": "Maxim Bogushevich",
+        "count": 1
+      },
+      {
+        "value": "Maximilian Antoni",
+        "count": 1
+      },
+      {
+        "value": "Meaglin",
+        "count": 1
+      },
+      {
+        "value": "Michael Budde",
+        "count": 1
+      },
+      {
+        "value": "Michael Hayes",
+        "count": 1
+      },
+      {
+        "value": "Michael Klein",
+        "count": 1
+      },
+      {
+        "value": "Michael Nisi",
+        "count": 1
+      },
+      {
+        "value": "Michiel Sikma",
+        "count": 1
+      },
+      {
+        "value": "Mick Thompson",
+        "count": 1
+      },
+      {
+        "value": "Mike MacCana",
+        "count": 1
+      },
+      {
+        "value": "Mikeal Rogers",
+        "count": 1
+      },
+      {
+        "value": "Mikola Lysenko",
+        "count": 1
+      },
+      {
+        "value": "Miroslav Bajtoš",
+        "count": 1
+      },
+      {
+        "value": "Nathan Rajlich",
+        "count": 1
+      },
+      {
+        "value": "Nathan Zadoks",
+        "count": 1
+      },
+      {
+        "value": "Neil Gentleman",
+        "count": 1
+      },
+      {
+        "value": "Nicholas Kinsey",
+        "count": 1
+      },
+      {
+        "value": "Nick Heiner",
+        "count": 1
+      },
+      {
+        "value": "Nick Malaguti",
+        "count": 1
+      },
+      {
+        "value": "Nick Santos",
+        "count": 1
+      },
+      {
+        "value": "Nicolas Morel",
+        "count": 1
+      },
+      {
+        "value": "Niggler",
+        "count": 1
+      },
+      {
+        "value": "Oddur Sigurdsson",
+        "count": 1
+      },
+      {
+        "value": "Oleg Efimov",
+        "count": 1
+      },
+      {
+        "value": "Oli Evans",
+        "count": 1
+      },
+      {
+        "value": "Olivier Melcher",
+        "count": 1
+      },
+      {
+        "value": "Orlando Vazquez",
+        "count": 1
+      },
+      {
+        "value": "Paolo Fragomeni",
+        "count": 1
+      },
+      {
+        "value": "Patrick Pfeiffer",
+        "count": 1
+      },
+      {
+        "value": "Paul Miller",
+        "count": 1
+      },
+      {
+        "value": "Paul Vorbach",
+        "count": 1
+      },
+      {
+        "value": "Paulo Cesar",
+        "count": 1
+      },
+      {
+        "value": "Pete Kruckenberg",
+        "count": 1
+      },
+      {
+        "value": "Peter A. Shevtsov",
+        "count": 1
+      },
+      {
+        "value": "Peter Richardson",
+        "count": 1
+      },
+      {
+        "value": "Phillip Howell",
+        "count": 1
+      },
+      {
+        "value": "Quim Calpe",
+        "count": 1
+      },
+      {
+        "value": "Quinn Slack",
+        "count": 1
+      },
+      {
+        "value": "Ra'Shaun Stovall",
+        "count": 1
+      },
+      {
+        "value": "Rachel Hutchison",
+        "count": 1
+      },
+      {
+        "value": "Rafael de Oleza",
+        "count": 1
+      },
+      {
+        "value": "Rebecca Turner",
+        "count": 1
+      },
+      {
+        "value": "Reid Burke",
+        "count": 1
+      },
+      {
+        "value": "Ribettes",
+        "count": 1
+      },
+      {
+        "value": "Richard Littauer",
+        "count": 1
+      },
+      {
+        "value": "Robert Gieseke",
+        "count": 1
+      },
+      {
+        "value": "Robert Kowalski",
+        "count": 1
+      },
+      {
+        "value": "Robin Tweedie",
+        "count": 1
+      },
+      {
+        "value": "Rod Vagg",
+        "count": 1
+      },
+      {
+        "value": "Ron Martinez",
+        "count": 1
+      },
+      {
+        "value": "Ryan Emery",
+        "count": 1
+      },
+      {
+        "value": "Ryan Temple",
+        "count": 1
+      },
+      {
+        "value": "Sam Mikes",
+        "count": 1
+      },
+      {
+        "value": "Schabse Laks",
+        "count": 1
+      },
+      {
+        "value": "Scott Bronson",
+        "count": 1
+      },
+      {
+        "value": "Sean McGivern",
+        "count": 1
+      },
+      {
+        "value": "Sergey Belov",
+        "count": 1
+      },
+      {
+        "value": "Shawn Wildermuth",
+        "count": 1
+      },
+      {
+        "value": "Simen Bekkhus",
+        "count": 1
+      },
+      {
+        "value": "Spain Train",
+        "count": 1
+      },
+      {
+        "value": "Stephan Bönnemann",
+        "count": 1
+      },
+      {
+        "value": "Stephen Sugden",
+        "count": 1
+      },
+      {
+        "value": "Steve Klabnik",
+        "count": 1
+      },
+      {
+        "value": "Steve Mason",
+        "count": 1
+      },
+      {
+        "value": "Steve Steiner",
+        "count": 1
+      },
+      {
+        "value": "Stuart Knightley",
+        "count": 1
+      },
+      {
+        "value": "Stuart P. Bentley",
+        "count": 1
+      },
+      {
+        "value": "Sébastien Santoro",
+        "count": 1
+      },
+      {
+        "value": "TJ Holowaychuk",
+        "count": 1
+      },
+      {
+        "value": "Takaya Kobayashi",
+        "count": 1
+      },
+      {
+        "value": "Tauren Mills",
+        "count": 1
+      },
+      {
+        "value": "Terin Stock",
+        "count": 1
+      },
+      {
+        "value": "Thaddee Tyl",
+        "count": 1
+      },
+      {
+        "value": "Thom Blake",
+        "count": 1
+      },
+      {
+        "value": "Thomas Cort",
+        "count": 1
+      },
+      {
+        "value": "Thomas Torp",
+        "count": 1
+      },
+      {
+        "value": "Thorsten Lorenz",
+        "count": 1
+      },
+      {
+        "value": "Tim Oxley",
+        "count": 1
+      },
+      {
+        "value": "Tim Whidden",
+        "count": 1
+      },
+      {
+        "value": "Timo Derstappen",
+        "count": 1
+      },
+      {
+        "value": "Timo Weiß",
+        "count": 1
+      },
+      {
+        "value": "Tom Huang",
+        "count": 1
+      },
+      {
+        "value": "Tomaž Muraus",
+        "count": 1
+      },
+      {
+        "value": "Tony",
+        "count": 1
+      },
+      {
+        "value": "Tor Valamo",
+        "count": 1
+      },
+      {
+        "value": "Trent Mick",
+        "count": 1
+      },
+      {
+        "value": "Trevor Burnham",
+        "count": 1
+      },
+      {
+        "value": "Tristan Davies",
+        "count": 1
+      },
+      {
+        "value": "Tyler Green",
+        "count": 1
+      },
+      {
+        "value": "Vaz Allen",
+        "count": 1
+      },
+      {
+        "value": "Victor",
+        "count": 1
+      },
+      {
+        "value": "Visnu Pitiyanuvath",
+        "count": 1
+      },
+      {
+        "value": "Vladimir Rutsky",
+        "count": 1
+      },
+      {
+        "value": "Wesley de Souza",
+        "count": 1
+      },
+      {
+        "value": "Whyme.Lyu",
+        "count": 1
+      },
+      {
+        "value": "Wil Moore III",
+        "count": 1
+      },
+      {
+        "value": "Will Elwood",
+        "count": 1
+      },
+      {
+        "value": "Wout Mertens",
+        "count": 1
+      },
+      {
+        "value": "Yazhong Liu",
+        "count": 1
+      },
+      {
+        "value": "Yeonghoon Park",
+        "count": 1
+      },
+      {
+        "value": "Zach Pomerantz",
+        "count": 1
+      },
+      {
+        "value": "Zeke Sikelianos",
         "count": 1
       }
     ],
@@ -1456,7 +3776,1457 @@
         {
           "author": "Isaac Z. Schlueter",
           "start_line": 16,
-          "end_line": 17
+          "end_line": 19
+        },
+        {
+          "author": "Steve Steiner",
+          "start_line": 205,
+          "end_line": 205
+        },
+        {
+          "author": "Mikeal Rogers",
+          "start_line": 209,
+          "end_line": 209
+        },
+        {
+          "author": "Aaron Blohowiak",
+          "start_line": 213,
+          "end_line": 213
+        },
+        {
+          "author": "Martyn Smith",
+          "start_line": 217,
+          "end_line": 217
+        },
+        {
+          "author": "Charlie Robbins",
+          "start_line": 221,
+          "end_line": 221
+        },
+        {
+          "author": "Francisco Treacy",
+          "start_line": 225,
+          "end_line": 225
+        },
+        {
+          "author": "Cliffano Subagio",
+          "start_line": 229,
+          "end_line": 229
+        },
+        {
+          "author": "Christian Eager",
+          "start_line": 233,
+          "end_line": 233
+        },
+        {
+          "author": "Dav Glass",
+          "start_line": 237,
+          "end_line": 237
+        },
+        {
+          "author": "Alex K. Wolfe",
+          "start_line": 241,
+          "end_line": 241
+        },
+        {
+          "author": "James Sanders",
+          "start_line": 245,
+          "end_line": 245
+        },
+        {
+          "author": "Reid Burke",
+          "start_line": 249,
+          "end_line": 249
+        },
+        {
+          "author": "Arlo Breault",
+          "start_line": 253,
+          "end_line": 253
+        },
+        {
+          "author": "Timo Derstappen",
+          "start_line": 257,
+          "end_line": 257
+        },
+        {
+          "author": "Bart Teeuwisse",
+          "start_line": 261,
+          "end_line": 261
+        },
+        {
+          "author": "Ben Noordhuis",
+          "start_line": 265,
+          "end_line": 265
+        },
+        {
+          "author": "Tor Valamo",
+          "start_line": 269,
+          "end_line": 269
+        },
+        {
+          "author": "Whyme.Lyu",
+          "start_line": 273,
+          "end_line": 273
+        },
+        {
+          "author": "Olivier Melcher",
+          "start_line": 277,
+          "end_line": 277
+        },
+        {
+          "author": "Tomaž Muraus",
+          "start_line": 281,
+          "end_line": 281
+        },
+        {
+          "author": "Evan Meagher",
+          "start_line": 285,
+          "end_line": 285
+        },
+        {
+          "author": "Orlando Vazquez",
+          "start_line": 289,
+          "end_line": 289
+        },
+        {
+          "author": "Kai Chen",
+          "start_line": 293,
+          "end_line": 293
+        },
+        {
+          "author": "George Miroshnykov",
+          "start_line": 297,
+          "end_line": 297
+        },
+        {
+          "author": "Geoff Flarity",
+          "start_line": 301,
+          "end_line": 301
+        },
+        {
+          "author": "Max Goodman",
+          "start_line": 305,
+          "end_line": 305
+        },
+        {
+          "author": "Pete Kruckenberg",
+          "start_line": 309,
+          "end_line": 309
+        },
+        {
+          "author": "Laurie Harper",
+          "start_line": 313,
+          "end_line": 313
+        },
+        {
+          "author": "Chris Wong",
+          "start_line": 317,
+          "end_line": 317
+        },
+        {
+          "author": "Scott Bronson",
+          "start_line": 321,
+          "end_line": 321
+        },
+        {
+          "author": "Federico Romero",
+          "start_line": 325,
+          "end_line": 325
+        },
+        {
+          "author": "Visnu Pitiyanuvath",
+          "start_line": 329,
+          "end_line": 329
+        },
+        {
+          "author": "Irakli Gozalishvili",
+          "start_line": 333,
+          "end_line": 333
+        },
+        {
+          "author": "Mark Cahill",
+          "start_line": 337,
+          "end_line": 337
+        },
+        {
+          "author": "Tony",
+          "start_line": 341,
+          "end_line": 341
+        },
+        {
+          "author": "Iain Sproat",
+          "start_line": 345,
+          "end_line": 345
+        },
+        {
+          "author": "Trent Mick",
+          "start_line": 349,
+          "end_line": 349
+        },
+        {
+          "author": "Felix Geisendörfer",
+          "start_line": 353,
+          "end_line": 353
+        },
+        {
+          "author": "Jameson Little",
+          "start_line": 357,
+          "end_line": 357
+        },
+        {
+          "author": "Conny Brunnkvist",
+          "start_line": 361,
+          "end_line": 361
+        },
+        {
+          "author": "Will Elwood",
+          "start_line": 365,
+          "end_line": 365
+        },
+        {
+          "author": "Dean Landolt",
+          "start_line": 369,
+          "end_line": 369
+        },
+        {
+          "author": "Oleg Efimov",
+          "start_line": 373,
+          "end_line": 373
+        },
+        {
+          "author": "Martin Cooper",
+          "start_line": 377,
+          "end_line": 377
+        },
+        {
+          "author": "Jann Horn",
+          "start_line": 381,
+          "end_line": 381
+        },
+        {
+          "author": "Andrew Bradley",
+          "start_line": 385,
+          "end_line": 385
+        },
+        {
+          "author": "Maciej Małecki",
+          "start_line": 389,
+          "end_line": 389
+        },
+        {
+          "author": "Stephen Sugden",
+          "start_line": 393,
+          "end_line": 393
+        },
+        {
+          "author": "Michael Budde",
+          "start_line": 397,
+          "end_line": 397
+        },
+        {
+          "author": "Jason Smith",
+          "start_line": 401,
+          "end_line": 401
+        },
+        {
+          "author": "Gautham Pai",
+          "start_line": 405,
+          "end_line": 405
+        },
+        {
+          "author": "David Trejo",
+          "start_line": 409,
+          "end_line": 409
+        },
+        {
+          "author": "Paul Vorbach",
+          "start_line": 413,
+          "end_line": 413
+        },
+        {
+          "author": "George Ornbo",
+          "start_line": 417,
+          "end_line": 417
+        },
+        {
+          "author": "Tim Oxley",
+          "start_line": 421,
+          "end_line": 421
+        },
+        {
+          "author": "Tyler Green",
+          "start_line": 425,
+          "end_line": 425
+        },
+        {
+          "author": "Dave Pacheco",
+          "start_line": 429,
+          "end_line": 429
+        },
+        {
+          "author": "Danila Gerasimov",
+          "start_line": 433,
+          "end_line": 433
+        },
+        {
+          "author": "Rod Vagg",
+          "start_line": 437,
+          "end_line": 437
+        },
+        {
+          "author": "Christian Howe",
+          "start_line": 441,
+          "end_line": 441
+        },
+        {
+          "author": "Andrew Lunny",
+          "start_line": 445,
+          "end_line": 445
+        },
+        {
+          "author": "Henrik Hodne",
+          "start_line": 449,
+          "end_line": 449
+        },
+        {
+          "author": "Adam Blackburn",
+          "start_line": 453,
+          "end_line": 453
+        },
+        {
+          "author": "Kris Windham",
+          "start_line": 457,
+          "end_line": 457
+        },
+        {
+          "author": "Jens Grunert",
+          "start_line": 461,
+          "end_line": 461
+        },
+        {
+          "author": "Joost-Wim Boekesteijn",
+          "start_line": 465,
+          "end_line": 465
+        },
+        {
+          "author": "Dalmais Maxence",
+          "start_line": 469,
+          "end_line": 469
+        },
+        {
+          "author": "Marcus Ekwall",
+          "start_line": 473,
+          "end_line": 473
+        },
+        {
+          "author": "Aaron Stacy",
+          "start_line": 477,
+          "end_line": 477
+        },
+        {
+          "author": "Phillip Howell",
+          "start_line": 481,
+          "end_line": 481
+        },
+        {
+          "author": "Domenic Denicola",
+          "start_line": 485,
+          "end_line": 485
+        },
+        {
+          "author": "James Halliday",
+          "start_line": 489,
+          "end_line": 489
+        },
+        {
+          "author": "Jeremy Cantrell",
+          "start_line": 493,
+          "end_line": 493
+        },
+        {
+          "author": "Ribettes",
+          "start_line": 497,
+          "end_line": 497
+        },
+        {
+          "author": "Don Park",
+          "start_line": 501,
+          "end_line": 501
+        },
+        {
+          "author": "Einar Otto Stangvik",
+          "start_line": 505,
+          "end_line": 505
+        },
+        {
+          "author": "Kei Son",
+          "start_line": 509,
+          "end_line": 509
+        },
+        {
+          "author": "Nicolas Morel",
+          "start_line": 513,
+          "end_line": 513
+        },
+        {
+          "author": "Mark Dube",
+          "start_line": 517,
+          "end_line": 517
+        },
+        {
+          "author": "Nathan Rajlich",
+          "start_line": 521,
+          "end_line": 521
+        },
+        {
+          "author": "Maxim Bogushevich",
+          "start_line": 525,
+          "end_line": 525
+        },
+        {
+          "author": "Meaglin",
+          "start_line": 529,
+          "end_line": 529
+        },
+        {
+          "author": "Ben Evans",
+          "start_line": 533,
+          "end_line": 533
+        },
+        {
+          "author": "Nathan Zadoks",
+          "start_line": 537,
+          "end_line": 537
+        },
+        {
+          "author": "Brian White",
+          "start_line": 541,
+          "end_line": 541
+        },
+        {
+          "author": "Jed Schmidt",
+          "start_line": 545,
+          "end_line": 545
+        },
+        {
+          "author": "Ian Livingstone",
+          "start_line": 549,
+          "end_line": 549
+        },
+        {
+          "author": "Patrick Pfeiffer",
+          "start_line": 553,
+          "end_line": 553
+        },
+        {
+          "author": "Paul Miller",
+          "start_line": 557,
+          "end_line": 557
+        },
+        {
+          "author": "Ryan Emery",
+          "start_line": 561,
+          "end_line": 561
+        },
+        {
+          "author": "Carl Lange",
+          "start_line": 565,
+          "end_line": 565
+        },
+        {
+          "author": "Jan Lehnardt",
+          "start_line": 569,
+          "end_line": 569
+        },
+        {
+          "author": "Stuart P. Bentley",
+          "start_line": 573,
+          "end_line": 573
+        },
+        {
+          "author": "Johan Sköld",
+          "start_line": 577,
+          "end_line": 577
+        },
+        {
+          "author": "Stuart Knightley",
+          "start_line": 581,
+          "end_line": 581
+        },
+        {
+          "author": "Niggler",
+          "start_line": 585,
+          "end_line": 585
+        },
+        {
+          "author": "Paolo Fragomeni",
+          "start_line": 589,
+          "end_line": 589
+        },
+        {
+          "author": "Jaakko Manninen",
+          "start_line": 593,
+          "end_line": 593
+        },
+        {
+          "author": "Luke Arduini",
+          "start_line": 597,
+          "end_line": 597
+        },
+        {
+          "author": "Larz Conwell",
+          "start_line": 601,
+          "end_line": 601
+        },
+        {
+          "author": "Marcel Klehr",
+          "start_line": 606,
+          "end_line": 606
+        },
+        {
+          "author": "Robert Kowalski",
+          "start_line": 610,
+          "end_line": 610
+        },
+        {
+          "author": "Forbes Lindesay",
+          "start_line": 614,
+          "end_line": 614
+        },
+        {
+          "author": "Vaz Allen",
+          "start_line": 618,
+          "end_line": 618
+        },
+        {
+          "author": "Jake Verbaten",
+          "start_line": 622,
+          "end_line": 622
+        },
+        {
+          "author": "Schabse Laks",
+          "start_line": 626,
+          "end_line": 626
+        },
+        {
+          "author": "Florian Margaine",
+          "start_line": 630,
+          "end_line": 630
+        },
+        {
+          "author": "Johan Nordberg",
+          "start_line": 634,
+          "end_line": 634
+        },
+        {
+          "author": "Ian Babrou",
+          "start_line": 638,
+          "end_line": 638
+        },
+        {
+          "author": "Di Wu",
+          "start_line": 642,
+          "end_line": 642
+        },
+        {
+          "author": "Mathias Bynens",
+          "start_line": 646,
+          "end_line": 646
+        },
+        {
+          "author": "Matt McClure",
+          "start_line": 650,
+          "end_line": 650
+        },
+        {
+          "author": "Matt Lunn",
+          "start_line": 654,
+          "end_line": 654
+        },
+        {
+          "author": "Alexey Kreschuk",
+          "start_line": 658,
+          "end_line": 658
+        },
+        {
+          "author": "Robert Gieseke",
+          "start_line": 666,
+          "end_line": 666
+        },
+        {
+          "author": "François Frisch",
+          "start_line": 670,
+          "end_line": 670
+        },
+        {
+          "author": "Trevor Burnham",
+          "start_line": 674,
+          "end_line": 674
+        },
+        {
+          "author": "Alan Shaw",
+          "start_line": 678,
+          "end_line": 678
+        },
+        {
+          "author": "TJ Holowaychuk",
+          "start_line": 682,
+          "end_line": 682
+        },
+        {
+          "author": "Nicholas Kinsey",
+          "start_line": 686,
+          "end_line": 686
+        },
+        {
+          "author": "Paulo Cesar",
+          "start_line": 690,
+          "end_line": 690
+        },
+        {
+          "author": "Elan Shanker",
+          "start_line": 694,
+          "end_line": 694
+        },
+        {
+          "author": "Jon Spencer",
+          "start_line": 698,
+          "end_line": 698
+        },
+        {
+          "author": "Jason Diamond",
+          "start_line": 702,
+          "end_line": 702
+        },
+        {
+          "author": "Maximilian Antoni",
+          "start_line": 706,
+          "end_line": 706
+        },
+        {
+          "author": "Thom Blake",
+          "start_line": 710,
+          "end_line": 710
+        },
+        {
+          "author": "Jess Martin",
+          "start_line": 714,
+          "end_line": 714
+        },
+        {
+          "author": "Spain Train",
+          "start_line": 718,
+          "end_line": 718
+        },
+        {
+          "author": "Alex Rodionov",
+          "start_line": 722,
+          "end_line": 722
+        },
+        {
+          "author": "Matt Colyer",
+          "start_line": 726,
+          "end_line": 726
+        },
+        {
+          "author": "Evan You",
+          "start_line": 730,
+          "end_line": 730
+        },
+        {
+          "author": "Gabriel Falkenberg",
+          "start_line": 738,
+          "end_line": 738
+        },
+        {
+          "author": "Alexej Yaroshevich",
+          "start_line": 742,
+          "end_line": 742
+        },
+        {
+          "author": "Quim Calpe",
+          "start_line": 746,
+          "end_line": 746
+        },
+        {
+          "author": "Steve Mason",
+          "start_line": 750,
+          "end_line": 750
+        },
+        {
+          "author": "Wil Moore III",
+          "start_line": 754,
+          "end_line": 754
+        },
+        {
+          "author": "Sergey Belov",
+          "start_line": 758,
+          "end_line": 758
+        },
+        {
+          "author": "Tom Huang",
+          "start_line": 762,
+          "end_line": 762
+        },
+        {
+          "author": "CamilleM",
+          "start_line": 766,
+          "end_line": 766
+        },
+        {
+          "author": "Sébastien Santoro",
+          "start_line": 770,
+          "end_line": 770
+        },
+        {
+          "author": "Evan Lucas",
+          "start_line": 774,
+          "end_line": 774
+        },
+        {
+          "author": "Quinn Slack",
+          "start_line": 778,
+          "end_line": 778
+        },
+        {
+          "author": "Alex Kocharin",
+          "start_line": 782,
+          "end_line": 782
+        },
+        {
+          "author": "Daniel Santiago",
+          "start_line": 786,
+          "end_line": 786
+        },
+        {
+          "author": "Denis Gladkikh",
+          "start_line": 790,
+          "end_line": 790
+        },
+        {
+          "author": "Andrew Horton",
+          "start_line": 794,
+          "end_line": 794
+        },
+        {
+          "author": "Zeke Sikelianos",
+          "start_line": 798,
+          "end_line": 798
+        },
+        {
+          "author": "Dylan Greene",
+          "start_line": 802,
+          "end_line": 802
+        },
+        {
+          "author": "Franck Cuny",
+          "start_line": 806,
+          "end_line": 806
+        },
+        {
+          "author": "Yeonghoon Park",
+          "start_line": 810,
+          "end_line": 810
+        },
+        {
+          "author": "Rafael de Oleza",
+          "start_line": 814,
+          "end_line": 814
+        },
+        {
+          "author": "Mikola Lysenko",
+          "start_line": 818,
+          "end_line": 818
+        },
+        {
+          "author": "Yazhong Liu",
+          "start_line": 822,
+          "end_line": 822
+        },
+        {
+          "author": "Neil Gentleman",
+          "start_line": 826,
+          "end_line": 826
+        },
+        {
+          "author": "Kris Kowal",
+          "start_line": 830,
+          "end_line": 830
+        },
+        {
+          "author": "Alex Gorbatchev",
+          "start_line": 834,
+          "end_line": 834
+        },
+        {
+          "author": "Shawn Wildermuth",
+          "start_line": 838,
+          "end_line": 838
+        },
+        {
+          "author": "Wesley de Souza",
+          "start_line": 842,
+          "end_line": 842
+        },
+        {
+          "author": "J. Tangelder",
+          "start_line": 850,
+          "end_line": 850
+        },
+        {
+          "author": "Jean Lauliac",
+          "start_line": 854,
+          "end_line": 854
+        },
+        {
+          "author": "Andrey Kislyuk",
+          "start_line": 858,
+          "end_line": 858
+        },
+        {
+          "author": "Thorsten Lorenz",
+          "start_line": 862,
+          "end_line": 862
+        },
+        {
+          "author": "Julian Gruber",
+          "start_line": 866,
+          "end_line": 866
+        },
+        {
+          "author": "Benjamin Coe",
+          "start_line": 870,
+          "end_line": 870
+        },
+        {
+          "author": "Alex Ford",
+          "start_line": 874,
+          "end_line": 874
+        },
+        {
+          "author": "Matt Hickford",
+          "start_line": 878,
+          "end_line": 878
+        },
+        {
+          "author": "Sean McGivern",
+          "start_line": 882,
+          "end_line": 882
+        },
+        {
+          "author": "C J Silverio",
+          "start_line": 886,
+          "end_line": 886
+        },
+        {
+          "author": "Robin Tweedie",
+          "start_line": 890,
+          "end_line": 890
+        },
+        {
+          "author": "Miroslav Bajtoš",
+          "start_line": 894,
+          "end_line": 894
+        },
+        {
+          "author": "David Glasser",
+          "start_line": 898,
+          "end_line": 898
+        },
+        {
+          "author": "Gianluca Casati",
+          "start_line": 902,
+          "end_line": 902
+        },
+        {
+          "author": "Forrest L Norvell",
+          "start_line": 906,
+          "end_line": 906
+        },
+        {
+          "author": "Karsten Tinnefeld",
+          "start_line": 910,
+          "end_line": 910
+        },
+        {
+          "author": "Bryan Burgers",
+          "start_line": 914,
+          "end_line": 914
+        },
+        {
+          "author": "David Beitey",
+          "start_line": 918,
+          "end_line": 918
+        },
+        {
+          "author": "Zach Pomerantz",
+          "start_line": 926,
+          "end_line": 926
+        },
+        {
+          "author": "Chris Williams",
+          "start_line": 930,
+          "end_line": 930
+        },
+        {
+          "author": "Mick Thompson",
+          "start_line": 938,
+          "end_line": 938
+        },
+        {
+          "author": "Felix Rabe",
+          "start_line": 942,
+          "end_line": 942
+        },
+        {
+          "author": "Michael Hayes",
+          "start_line": 946,
+          "end_line": 946
+        },
+        {
+          "author": "Chris Dickinson",
+          "start_line": 950,
+          "end_line": 950
+        },
+        {
+          "author": "Bradley Meck",
+          "start_line": 954,
+          "end_line": 954
+        },
+        {
+          "author": "Andrew Terris",
+          "start_line": 962,
+          "end_line": 962
+        },
+        {
+          "author": "Michael Nisi",
+          "start_line": 966,
+          "end_line": 966
+        },
+        {
+          "author": "Adam Meadows",
+          "start_line": 974,
+          "end_line": 974
+        },
+        {
+          "author": "Chulki Lee",
+          "start_line": 978,
+          "end_line": 978
+        },
+        {
+          "author": "Kenan Yildirim",
+          "start_line": 990,
+          "end_line": 990
+        },
+        {
+          "author": "Laurie Voss",
+          "start_line": 994,
+          "end_line": 994
+        },
+        {
+          "author": "Rebecca Turner",
+          "start_line": 998,
+          "end_line": 998
+        },
+        {
+          "author": "Hunter Loftis",
+          "start_line": 1002,
+          "end_line": 1002
+        },
+        {
+          "author": "Peter Richardson",
+          "start_line": 1006,
+          "end_line": 1006
+        },
+        {
+          "author": "Jussi Kalliokoski",
+          "start_line": 1010,
+          "end_line": 1010
+        },
+        {
+          "author": "Filip Weiss",
+          "start_line": 1014,
+          "end_line": 1014
+        },
+        {
+          "author": "Timo Weiß",
+          "start_line": 1018,
+          "end_line": 1018
+        },
+        {
+          "author": "Christopher Hiller",
+          "start_line": 1022,
+          "end_line": 1022
+        },
+        {
+          "author": "Jérémy Lal",
+          "start_line": 1026,
+          "end_line": 1026
+        },
+        {
+          "author": "Anders Janmyr",
+          "start_line": 1030,
+          "end_line": 1030
+        },
+        {
+          "author": "Chris Meyers",
+          "start_line": 1034,
+          "end_line": 1034
+        },
+        {
+          "author": "Ludwig Magnusson",
+          "start_line": 1038,
+          "end_line": 1038
+        },
+        {
+          "author": "Wout Mertens",
+          "start_line": 1042,
+          "end_line": 1042
+        },
+        {
+          "author": "Nick Santos",
+          "start_line": 1046,
+          "end_line": 1046
+        },
+        {
+          "author": "Terin Stock",
+          "start_line": 1050,
+          "end_line": 1050
+        },
+        {
+          "author": "Faiq Raza",
+          "start_line": 1054,
+          "end_line": 1054
+        },
+        {
+          "author": "Thomas Torp",
+          "start_line": 1058,
+          "end_line": 1058
+        },
+        {
+          "author": "Sam Mikes",
+          "start_line": 1062,
+          "end_line": 1062
+        },
+        {
+          "author": "Mat Tyndall",
+          "start_line": 1066,
+          "end_line": 1066
+        },
+        {
+          "author": "Tauren Mills",
+          "start_line": 1070,
+          "end_line": 1070
+        },
+        {
+          "author": "Ron Martinez",
+          "start_line": 1074,
+          "end_line": 1074
+        },
+        {
+          "author": "Kazuhito Hokamura",
+          "start_line": 1078,
+          "end_line": 1078
+        },
+        {
+          "author": "Tristan Davies",
+          "start_line": 1082,
+          "end_line": 1082
+        },
+        {
+          "author": "David Volm",
+          "start_line": 1086,
+          "end_line": 1086
+        },
+        {
+          "author": "Lin Clark",
+          "start_line": 1090,
+          "end_line": 1090
+        },
+        {
+          "author": "Ben Page",
+          "start_line": 1094,
+          "end_line": 1094
+        },
+        {
+          "author": "Jeff Jo",
+          "start_line": 1098,
+          "end_line": 1098
+        },
+        {
+          "author": "Mark J. Titorenko",
+          "start_line": 1106,
+          "end_line": 1106
+        },
+        {
+          "author": "Oddur Sigurdsson",
+          "start_line": 1110,
+          "end_line": 1110
+        },
+        {
+          "author": "Eric Mill",
+          "start_line": 1114,
+          "end_line": 1114
+        },
+        {
+          "author": "Gabriel Barros",
+          "start_line": 1118,
+          "end_line": 1118
+        },
+        {
+          "author": "KevinSheedy",
+          "start_line": 1122,
+          "end_line": 1122
+        },
+        {
+          "author": "Aleksey Smolenchuk",
+          "start_line": 1126,
+          "end_line": 1126
+        },
+        {
+          "author": "Ed Morley",
+          "start_line": 1130,
+          "end_line": 1130
+        },
+        {
+          "author": "Blaine Bublitz",
+          "start_line": 1134,
+          "end_line": 1134
+        },
+        {
+          "author": "Andrey Fedorov",
+          "start_line": 1138,
+          "end_line": 1138
+        },
+        {
+          "author": "Daijiro Wachi",
+          "start_line": 1142,
+          "end_line": 1142
+        },
+        {
+          "author": "Luc Thevenard",
+          "start_line": 1146,
+          "end_line": 1146
+        },
+        {
+          "author": "Aria Stewart",
+          "start_line": 1150,
+          "end_line": 1150
+        },
+        {
+          "author": "Charlie Rudolph",
+          "start_line": 1154,
+          "end_line": 1154
+        },
+        {
+          "author": "Vladimir Rutsky",
+          "start_line": 1158,
+          "end_line": 1158
+        },
+        {
+          "author": "Isaac Murchie",
+          "start_line": 1162,
+          "end_line": 1162
+        },
+        {
+          "author": "Marcin Wosinek",
+          "start_line": 1166,
+          "end_line": 1166
+        },
+        {
+          "author": "David Marr",
+          "start_line": 1170,
+          "end_line": 1170
+        },
+        {
+          "author": "Bryan English",
+          "start_line": 1174,
+          "end_line": 1174
+        },
+        {
+          "author": "Anthony Zotti",
+          "start_line": 1178,
+          "end_line": 1178
+        },
+        {
+          "author": "Karl Horky",
+          "start_line": 1182,
+          "end_line": 1182
+        },
+        {
+          "author": "Jordan Harband",
+          "start_line": 1186,
+          "end_line": 1186
+        },
+        {
+          "author": "Guðlaugur Stefán Egilsson",
+          "start_line": 1190,
+          "end_line": 1190
+        },
+        {
+          "author": "Helge Skogly Holm",
+          "start_line": 1194,
+          "end_line": 1194
+        },
+        {
+          "author": "Peter A. Shevtsov",
+          "start_line": 1198,
+          "end_line": 1198
+        },
+        {
+          "author": "Alain Kalker",
+          "start_line": 1202,
+          "end_line": 1202
+        },
+        {
+          "author": "Bryant Williams",
+          "start_line": 1206,
+          "end_line": 1206
+        },
+        {
+          "author": "Jonas Weber",
+          "start_line": 1210,
+          "end_line": 1210
+        },
+        {
+          "author": "Tim Whidden",
+          "start_line": 1214,
+          "end_line": 1214
+        },
+        {
+          "author": "Andreas",
+          "start_line": 1218,
+          "end_line": 1218
+        },
+        {
+          "author": "Karolis Narkevicius",
+          "start_line": 1222,
+          "end_line": 1222
+        },
+        {
+          "author": "Adrian Lynch",
+          "start_line": 1226,
+          "end_line": 1226
+        },
+        {
+          "author": "Richard Littauer",
+          "start_line": 1230,
+          "end_line": 1230
+        },
+        {
+          "author": "Oli Evans",
+          "start_line": 1234,
+          "end_line": 1234
+        },
+        {
+          "author": "Matt Brennan",
+          "start_line": 1238,
+          "end_line": 1238
+        },
+        {
+          "author": "Jeff Barczewski",
+          "start_line": 1242,
+          "end_line": 1242
+        },
+        {
+          "author": "Danny Fritz",
+          "start_line": 1246,
+          "end_line": 1246
+        },
+        {
+          "author": "Takaya Kobayashi",
+          "start_line": 1250,
+          "end_line": 1250
+        },
+        {
+          "author": "Ra'Shaun Stovall",
+          "start_line": 1254,
+          "end_line": 1254
+        },
+        {
+          "author": "Julien Meddah",
+          "start_line": 1258,
+          "end_line": 1258
+        },
+        {
+          "author": "Michiel Sikma",
+          "start_line": 1262,
+          "end_line": 1262
+        },
+        {
+          "author": "Jakob Krigovsky",
+          "start_line": 1266,
+          "end_line": 1266
+        },
+        {
+          "author": "Charmander",
+          "start_line": 1270,
+          "end_line": 1270
+        },
+        {
+          "author": "Erik Wienhold",
+          "start_line": 1274,
+          "end_line": 1274
+        },
+        {
+          "author": "James Butler",
+          "start_line": 1278,
+          "end_line": 1278
+        },
+        {
+          "author": "Kevin Kragenbrink",
+          "start_line": 1282,
+          "end_line": 1282
+        },
+        {
+          "author": "Arnaud Rinquin",
+          "start_line": 1286,
+          "end_line": 1286
+        },
+        {
+          "author": "Mike MacCana",
+          "start_line": 1290,
+          "end_line": 1290
+        },
+        {
+          "author": "Antti Mattila",
+          "start_line": 1294,
+          "end_line": 1294
+        },
+        {
+          "author": "Matt Zorn",
+          "start_line": 1302,
+          "end_line": 1302
+        },
+        {
+          "author": "Kyle Mitchell",
+          "start_line": 1306,
+          "end_line": 1306
+        },
+        {
+          "author": "Jeremiah Senkpiel",
+          "start_line": 1310,
+          "end_line": 1310
+        },
+        {
+          "author": "Michael Klein",
+          "start_line": 1314,
+          "end_line": 1314
+        },
+        {
+          "author": "Simen Bekkhus",
+          "start_line": 1318,
+          "end_line": 1318
+        },
+        {
+          "author": "Victor",
+          "start_line": 1322,
+          "end_line": 1322
+        },
+        {
+          "author": "Clay Carpenter",
+          "start_line": 1330,
+          "end_line": 1330
+        },
+        {
+          "author": "Nick Malaguti",
+          "start_line": 1338,
+          "end_line": 1338
+        },
+        {
+          "author": "Cedric Nelson",
+          "start_line": 1342,
+          "end_line": 1342
+        },
+        {
+          "author": "Kat Marchán",
+          "start_line": 1346,
+          "end_line": 1346
+        },
+        {
+          "author": "Andrew",
+          "start_line": 1350,
+          "end_line": 1350
+        },
+        {
+          "author": "Eduardo Pinho",
+          "start_line": 1354,
+          "end_line": 1354
+        },
+        {
+          "author": "Rachel Hutchison",
+          "start_line": 1358,
+          "end_line": 1358
+        },
+        {
+          "author": "Ryan Temple",
+          "start_line": 1362,
+          "end_line": 1362
+        },
+        {
+          "author": "Eugene Sharygin",
+          "start_line": 1366,
+          "end_line": 1366
+        },
+        {
+          "author": "Nick Heiner",
+          "start_line": 1370,
+          "end_line": 1370
+        },
+        {
+          "author": "James Talmage",
+          "start_line": 1374,
+          "end_line": 1374
+        },
+        {
+          "author": "Joseph Dykstra",
+          "start_line": 1382,
+          "end_line": 1382
+        },
+        {
+          "author": "Joshua Egan",
+          "start_line": 1386,
+          "end_line": 1386
+        },
+        {
+          "author": "Thomas Cort",
+          "start_line": 1390,
+          "end_line": 1390
+        },
+        {
+          "author": "Thaddee Tyl",
+          "start_line": 1394,
+          "end_line": 1394
+        },
+        {
+          "author": "Steve Klabnik",
+          "start_line": 1398,
+          "end_line": 1398
+        },
+        {
+          "author": "Andrew Murray",
+          "start_line": 1402,
+          "end_line": 1402
+        },
+        {
+          "author": "Stephan Bönnemann",
+          "start_line": 1406,
+          "end_line": 1406
+        },
+        {
+          "author": "Kyle M. Tarplee",
+          "start_line": 1410,
+          "end_line": 1410
+        },
+        {
+          "author": "Derek Peterson",
+          "start_line": 1414,
+          "end_line": 1414
+        },
+        {
+          "author": "Greg Whiteley",
+          "start_line": 1418,
+          "end_line": 1418
         }
       ],
       "files_count": 0,


### PR DESCRIPTION
## Summary

- Treat `contributor`, `contributors`, and `x_contributors` arrays as explicit authorship credits in validated JSON and YAML metadata.
- Preserve one author record per structured declaration, including object entries with a `name` field.
- Exclude credit-looking values in code/schema structures and package inventories while retaining credits under document metadata wrappers.

## Issues

- Covers: follow-up findings from #1391

## Scope and exclusions

- Included: array-valued author/contributor credits in package-like JSON and YAML metadata plus structural cleanup of code/example and package-inventory fields.
- Explicit exclusions: free-form contributor prose, embedded multi-document test formats, and package-parser party output.

## How to verify

- Scan Perl 5.38.4 with `provenant --copyright --json out.json perl-5.38.4`. Relative to #1407, this adds 16 explicit contributor records across eight CPAN metadata files with no removals and no copyright/holder changes. The InfoZIP 3.0 control scan is unchanged in all three fields.
- Inspect `cpan/CPAN-Meta/corpus/CL018_yaml.meta`: Provenant recovers seven explicitly listed contributors that ScanCode omits.
- Inspect the full-tallies fixture's `scan/package.json`: its root npm contributor roster is now reflected in file, global, key-file, facet, detail, and parent-directory author tallies; nested package inventory authors remain excluded.

## Intentional differences from Python

- Provenant includes explicit extension contributor arrays and emits entries independently. ScanCode misses these credits in the benchmark fixtures and joins other structured lists into one value.

## Follow-up work

- Created or intentionally deferred: embedded structured documents, explicit prose author sections, and malformed/template author cleanup remain in later stacked branches.

## Expected-output fixture changes

- Files changed: `tallies.expected.json`, `tallies_details.expected.json`, `tallies_key_files.expected.json`, and `tallies_by_facet.expected.json` under `testdata/summarycode-golden/tallies/full_tallies/`.
- Why the new expected output is correct: the fixture contains a root npm `contributors` array with 291 accepted independent names. The updated author-only facets record those intentional detections and their derived tallies; structural tests separately prove nested package inventories do not leak authors.
