### PR TITLE
fix(copyright): recover bounded POD author credits

### DIFF
--- a/src/copyright/detector/author_heuristics/mod.rs
+++ b/src/copyright/detector/author_heuristics/mod.rs
@@ -7,6 +7,8 @@ mod tests;
 
 mod cleanup;
 mod extraction;
+mod pod_sections;
 
 pub(super) use cleanup::*;
 pub(super) use extraction::*;
+pub(super) use pod_sections::*;

--- a/src/copyright/detector/author_heuristics/pod_sections.rs
+++ b/src/copyright/detector/author_heuristics/pod_sections.rs
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Provenant contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::copyright::prepare::prepare_text_line;
+use crate::copyright::refiner::refine_author;
+use crate::copyright::types::AuthorDetection;
+use crate::models::LineNumber;
+
+fn extract_contact_authors_from_paragraph(
+    paragraph: &str,
+    start_line: LineNumber,
+    end_line: LineNumber,
+) -> Vec<AuthorDetection> {
+    static CONTACT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)<[^<>]*(?:@|\bat\b|\[at\]|\(at\))[^<>]*>|\([^()\s]*@[^()]*\)|[\w.+-]+@[\w.-]+\.[a-z]{2,}(?:\s*\([^()]{2,80}\))?",
+        )
+        .unwrap()
+    });
+    static NON_AUTHOR_CONTACT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^(?:(?:this|the)\s+(?:module|software|library|program)\s+is\s+)?(?:copyright\b|please\s+reports?\s+bugs?\b|send\s+(?:patches|bugs?)\b)",
+        )
+        .unwrap()
+    });
+    static ROLE_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^(?:(?:based\s+on\s+ideas|with\s+contributions)\s+from|(?:(?:original|current|previous|prior)\s+)?(?:authors?(?:\s+and\s+maintainers?)?|maintainers?|external\s+protocol|stream\s+protocol|wake-on-lan|original\s+pingecho(?:\(\))?))\s*(?::|\bare\b|\bwas\b)?\s*",
+        )
+        .unwrap()
+    });
+    static EMAIL_THEN_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)(?P<email>[\w.+-]+@[\w.-]+\.[a-z]{2,})\s*\((?P<name>[\p{L}][^()]{1,80})\)\s*$",
+        )
+        .unwrap()
+    });
+
+    let lower = paragraph.to_ascii_lowercase();
+    let mut authors = Vec::new();
+    let mut previous_contact_end = 0;
+    for contact in CONTACT_RE.find_iter(paragraph) {
+        let prefix = &lower[previous_contact_end..contact.start()];
+        let attribution_start = prefix.rfind(" by ").map_or(previous_contact_end, |offset| {
+            previous_contact_end + offset + 4
+        });
+        let candidate = paragraph[attribution_start..contact.end()]
+            .trim()
+            .trim_start_matches(|ch: char| ch.is_ascii_punctuation() || ch.is_whitespace())
+            .trim_start_matches("and ")
+            .trim_start_matches("or ")
+            .trim();
+        previous_contact_end = contact.end();
+
+        if candidate.is_empty() || NON_AUTHOR_CONTACT_RE.is_match(candidate) {
+            continue;
+        }
+        let candidate = ROLE_PREFIX_RE.replace(candidate, "");
+        let candidate = candidate.trim();
+        if candidate.is_empty() || candidate.split_whitespace().count() > 8 {
+            continue;
+        }
+        let author = if let Some(captures) = EMAIL_THEN_NAME_RE.captures(candidate) {
+            let email = captures.name("email").map(|matched| matched.as_str());
+            let name = captures.name("name").map(|matched| matched.as_str());
+            match (name.and_then(refine_author), email) {
+                (Some(name), Some(email)) => Some(format!("{name} <{email}>")),
+                _ => None,
+            }
+        } else {
+            refine_author(candidate)
+        };
+        let Some(author) = author else { continue };
+        authors.push(AuthorDetection {
+            author,
+            start_line,
+            end_line,
+        });
+    }
+    authors
+}
+
+/// Recover contact-backed identities from bounded POD AUTHOR(S) sections.
+pub(in super::super) fn extract_pod_author_section_contact_authors(
+    raw_lines: &[&str],
+) -> Vec<AuthorDetection> {
+    static AUTHOR_HEADING_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^=head\d+\s+authors?\s*$").expect("valid POD author heading regex")
+    });
+    static HEADING_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^=head\d+\b").expect("valid POD heading regex"));
+    static BLOCK_DIRECTIVE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^=(?:over|back|item|cut)\b").expect("valid POD block directive regex")
+    });
+
+    let mut authors = Vec::new();
+    let mut in_author_section = false;
+    let mut paragraph = String::new();
+    let mut paragraph_start = None;
+    let mut paragraph_end = None;
+
+    let flush_paragraph = |paragraph: &mut String,
+                           paragraph_start: &mut Option<LineNumber>,
+                           paragraph_end: &mut Option<LineNumber>,
+                           authors: &mut Vec<AuthorDetection>| {
+        if let (Some(start_line), Some(end_line)) = (*paragraph_start, *paragraph_end) {
+            authors.extend(extract_contact_authors_from_paragraph(
+                paragraph, start_line, end_line,
+            ));
+        }
+        paragraph.clear();
+        *paragraph_start = None;
+        *paragraph_end = None;
+    };
+
+    for (index, raw_line) in raw_lines.iter().enumerate() {
+        let prepared = prepare_text_line(raw_line);
+        let prepared = prepared.trim();
+        if HEADING_RE.is_match(prepared) {
+            flush_paragraph(
+                &mut paragraph,
+                &mut paragraph_start,
+                &mut paragraph_end,
+                &mut authors,
+            );
+            in_author_section = AUTHOR_HEADING_RE.is_match(prepared);
+            continue;
+        }
+        if !in_author_section {
+            continue;
+        }
+        if prepared.is_empty() || BLOCK_DIRECTIVE_RE.is_match(prepared) {
+            flush_paragraph(
+                &mut paragraph,
+                &mut paragraph_start,
+                &mut paragraph_end,
+                &mut authors,
+            );
+            if prepared.eq_ignore_ascii_case("=cut") {
+                in_author_section = false;
+            }
+            continue;
+        }
+        if paragraph.len() + prepared.len() > 4096 {
+            flush_paragraph(
+                &mut paragraph,
+                &mut paragraph_start,
+                &mut paragraph_end,
+                &mut authors,
+            );
+        }
+        if prepared.len() > 4096 {
+            continue;
+        }
+        if !paragraph.is_empty() {
+            paragraph.push(' ');
+        }
+        paragraph.push_str(prepared);
+        let line = LineNumber::from_0_indexed(index);
+        paragraph_start.get_or_insert(line);
+        paragraph_end = Some(line);
+    }
+    flush_paragraph(
+        &mut paragraph,
+        &mut paragraph_start,
+        &mut paragraph_end,
+        &mut authors,
+    );
+
+    authors
+}

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -355,6 +355,10 @@ fn run_author_extraction_and_repairs(
     super::author_heuristics::repair_hyphenated_prose_tail_authors(raw_lines, authors);
     super::author_heuristics::drop_embedded_authors_title_phrases(raw_lines, authors);
     seen.rebuild_authors_from(authors);
+
+    let mut new_a = super::author_heuristics::extract_pod_author_section_contact_authors(raw_lines);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
 }
 
 // Copyright postprocess phase fn; the long argument list threads the shared detection-pipeline state.

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -470,6 +470,97 @@ author:
 }
 
 #[test]
+fn test_pod_author_section_recovers_multiple_contact_backed_authors() {
+    let input = r#"=head1 AUTHOR
+
+Russ Allbery <russ@example.com>, based heavily on the original module
+by Tom Christiansen <tom@example.com> and its conversion by
+Brad Appleton <brad@example.com>.
+
+=head1 NOTES
+
+Outside Person <outside@example.com>.
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+    for expected in [
+        "Russ Allbery <russ@example.com>",
+        "Tom Christiansen <tom@example.com>",
+        "Brad Appleton <brad@example.com>",
+    ] {
+        assert!(values.contains(&expected), "authors: {authors:?}");
+    }
+    assert!(!values.contains(&"Outside Person <outside@example.com>"));
+}
+
+#[test]
+fn test_pod_author_section_joins_wrapped_name_and_parenthesized_contact() {
+    let input = r#"=head1 AUTHOR
+
+This guide was initially drafted by Jason McIntosh
+(jmac@example.com), under a documentation grant.
+
+=head1 NOTES
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(
+        authors
+            .iter()
+            .any(|author| author.author == "Jason McIntosh (jmac@example.com)"),
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_pod_author_section_normalizes_roles_and_email_name_rosters() {
+    let input = r#"=head1 AUTHORS
+
+Original author: Andy Dougherty <andy@example.com>
+
+Previous maintainers:
+  brown@example.com (Rob Brown)
+  karrer@example.com (Andreas Karrer)
+
+=head1 NOTES
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    for expected in [
+        "Andy Dougherty <andy@example.com>",
+        "Rob Brown <brown@example.com>",
+        "Andreas Karrer <karrer@example.com>",
+    ] {
+        assert!(values.contains(&expected), "authors: {authors:?}");
+    }
+}
+
+#[test]
+fn test_pod_author_section_drops_operational_and_copyright_contacts() {
+    let input = r#"=head1 AUTHOR
+
+This module is copyright 2010 Example Holder <holder@example.com>.
+
+Please report bugs to <bugs@example.com>.
+
+Send patches and ideas to patches@example.com.
+
+=head1 NOTES
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_plain_json_author_string_machine_token_dropped_without_metadata_context() {
     let input = r#""author": "makeappicon", "images": []"#;
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);


### PR DESCRIPTION
## Summary

- Recover contact-backed author identities from bounded POD `AUTHOR` and `AUTHORS` sections.
- Treat POD headings, block directives, blank lines, and a 4 KiB paragraph cap as structural boundaries.
- Normalize common role-prefixed and email-first roster forms while excluding operational and copyright contacts.

## Issues

- Covers: follow-up author-detection gaps found while validating #1391

## Scope and exclusions

- Included: contact-backed POD author paragraphs, multi-author paragraphs, wrapped contacts, role-prefixed rosters, late-phase value deduplication.
- Explicit exclusions: contactless POD credits and unstructured header comments; those require separate evidence rules.

## How to verify

- Scan Perl 5.38.4 with `--copyright` and compare author values against the parent branch. This branch adds 430 author values across 265 files, removes none, and leaves copyright and holder values unchanged.
- Scan Info-ZIP 3.0 with `--copyright`; author, copyright, and holder output should be exactly unchanged from the parent branch.

## Intentional differences from Python

- ScanCode has author output in only 48 of the affected Perl files and exactly matches 12 recovered values. Provenant uses the explicit POD section contract to recover more source-faithful identities while retaining hard section and size bounds.

## Follow-up work

- Created or intentionally deferred: recover contactless names and collectives from the same bounded POD sections in a separately benchmarked stack layer.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: focused end-to-end tests cover the new extraction and boundary behavior without altering existing golden fixtures.
