### PR TITLE
fix(copyright): recover contactless POD authors

### DIFF
--- a/src/copyright/detector/author_heuristics/pod_sections.rs
+++ b/src/copyright/detector/author_heuristics/pod_sections.rs
@@ -84,38 +84,39 @@ fn extract_contact_authors_from_paragraph(
     authors
 }
 
-/// Recover contact-backed identities from bounded POD AUTHOR(S) sections.
-pub(in super::super) fn extract_pod_author_section_contact_authors(
+fn walk_author_section_paragraphs(
     raw_lines: &[&str],
-) -> Vec<AuthorDetection> {
+    mut visit: impl FnMut(&str, LineNumber, LineNumber),
+) {
     static AUTHOR_HEADING_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^=head\d+\s+authors?\s*$").expect("valid POD author heading regex")
     });
     static HEADING_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^=head\d+\b").expect("valid POD heading regex"));
     static BLOCK_DIRECTIVE_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?i)^=(?:over|back|item|cut)\b").expect("valid POD block directive regex")
+        Regex::new(r"(?i)^=(?:over|back)\b").expect("valid POD block directive regex")
+    });
+    static ITEM_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^=item\b\s*(?:[*+-]\s*)?(?P<value>.*)$").expect("valid POD item regex")
     });
 
-    let mut authors = Vec::new();
     let mut in_author_section = false;
     let mut paragraph = String::new();
     let mut paragraph_start = None;
     let mut paragraph_end = None;
 
-    let flush_paragraph = |paragraph: &mut String,
-                           paragraph_start: &mut Option<LineNumber>,
-                           paragraph_end: &mut Option<LineNumber>,
-                           authors: &mut Vec<AuthorDetection>| {
-        if let (Some(start_line), Some(end_line)) = (*paragraph_start, *paragraph_end) {
-            authors.extend(extract_contact_authors_from_paragraph(
-                paragraph, start_line, end_line,
-            ));
-        }
-        paragraph.clear();
-        *paragraph_start = None;
-        *paragraph_end = None;
-    };
+    let flush_paragraph =
+        |paragraph: &mut String,
+         paragraph_start: &mut Option<LineNumber>,
+         paragraph_end: &mut Option<LineNumber>,
+         visit: &mut dyn FnMut(&str, LineNumber, LineNumber)| {
+            if let (Some(start_line), Some(end_line)) = (*paragraph_start, *paragraph_end) {
+                visit(paragraph, start_line, end_line);
+            }
+            paragraph.clear();
+            *paragraph_start = None;
+            *paragraph_end = None;
+        };
 
     for (index, raw_line) in raw_lines.iter().enumerate() {
         let prepared = prepare_text_line(raw_line);
@@ -125,7 +126,7 @@ pub(in super::super) fn extract_pod_author_section_contact_authors(
                 &mut paragraph,
                 &mut paragraph_start,
                 &mut paragraph_end,
-                &mut authors,
+                &mut visit,
             );
             in_author_section = AUTHOR_HEADING_RE.is_match(prepared);
             continue;
@@ -133,16 +134,48 @@ pub(in super::super) fn extract_pod_author_section_contact_authors(
         if !in_author_section {
             continue;
         }
-        if prepared.is_empty() || BLOCK_DIRECTIVE_RE.is_match(prepared) {
+        if prepared.len() >= 3
+            && prepared.len() <= 16
+            && prepared.chars().all(|ch| !ch.is_alphanumeric())
+        {
             flush_paragraph(
                 &mut paragraph,
                 &mut paragraph_start,
                 &mut paragraph_end,
-                &mut authors,
+                &mut visit,
+            );
+            in_author_section = false;
+            continue;
+        }
+        if prepared.is_empty()
+            || prepared.eq_ignore_ascii_case("=cut")
+            || BLOCK_DIRECTIVE_RE.is_match(prepared)
+        {
+            flush_paragraph(
+                &mut paragraph,
+                &mut paragraph_start,
+                &mut paragraph_end,
+                &mut visit,
             );
             if prepared.eq_ignore_ascii_case("=cut") {
                 in_author_section = false;
             }
+            continue;
+        }
+        let item_value = ITEM_RE
+            .captures(prepared)
+            .and_then(|captures| captures.name("value"))
+            .map(|matched| matched.as_str().trim());
+        if item_value.is_some() {
+            flush_paragraph(
+                &mut paragraph,
+                &mut paragraph_start,
+                &mut paragraph_end,
+                &mut visit,
+            );
+        }
+        let prepared = item_value.unwrap_or(prepared);
+        if prepared.is_empty() {
             continue;
         }
         if paragraph.len() + prepared.len() > 4096 {
@@ -150,7 +183,7 @@ pub(in super::super) fn extract_pod_author_section_contact_authors(
                 &mut paragraph,
                 &mut paragraph_start,
                 &mut paragraph_end,
-                &mut authors,
+                &mut visit,
             );
         }
         if prepared.len() > 4096 {
@@ -168,8 +201,158 @@ pub(in super::super) fn extract_pod_author_section_contact_authors(
         &mut paragraph,
         &mut paragraph_start,
         &mut paragraph_end,
-        &mut authors,
+        &mut visit,
     );
+}
+
+fn strip_trailing_author_date(candidate: &str) -> String {
+    static TRAILING_DATE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i),?\s+\d{1,2}(?:st|nd|rd|th)?\s+[a-z]+\s+\d{4}\.?$")
+            .expect("valid trailing author date regex")
+    });
+
+    TRAILING_DATE_RE.replace(candidate, "").trim().to_string()
+}
+
+fn refine_contactless_author(candidate: &str) -> Option<String> {
+    const NON_NAME_WORDS: &[&str] = &[
+        "author",
+        "authors",
+        "by",
+        "copyright",
+        "from",
+        "help",
+        "maintainer",
+        "maintainers",
+        "protocol",
+        "thanks",
+        "version",
+        "with",
+    ];
+
+    if candidate.len() > 160 || candidate.chars().any(|ch| matches!(ch, '@' | ';' | '=')) {
+        return None;
+    }
+    let candidate = strip_trailing_author_date(candidate);
+    let author = refine_author(candidate.trim_end_matches('.').trim())?;
+    let words: Vec<&str> = author.split_whitespace().collect();
+    if words.is_empty() || words.len() > 6 {
+        return None;
+    }
+    if words.iter().any(|word| {
+        let normalized = word
+            .trim_matches(|ch: char| !ch.is_alphanumeric())
+            .to_ascii_lowercase();
+        NON_NAME_WORDS.contains(&normalized.as_str())
+    }) {
+        return None;
+    }
+    if author.chars().any(|ch| {
+        !(ch.is_alphanumeric()
+            || ch.is_whitespace()
+            || matches!(ch, '.' | ',' | '-' | '\'' | '’' | '&'))
+    }) {
+        return None;
+    }
+
+    let cased_words: Vec<char> = words
+        .iter()
+        .filter_map(|word| word.chars().find(|ch| ch.is_alphabetic()))
+        .filter(|ch| ch.is_uppercase() || ch.is_lowercase())
+        .collect();
+    let uppercase_words = cased_words.iter().filter(|ch| ch.is_uppercase()).count();
+    let has_collective_noun = words.iter().any(|word| {
+        matches!(
+            word.trim_matches(|ch: char| !ch.is_alphanumeric())
+                .to_ascii_lowercase()
+                .as_str(),
+            "contributors" | "developers" | "gang" | "group" | "porters" | "project" | "team"
+        )
+    });
+    if cased_words.is_empty() || uppercase_words >= 2 || words.len() == 1 || has_collective_noun {
+        Some(author)
+    } else {
+        None
+    }
+}
+
+fn extract_contactless_authors_from_paragraph(
+    paragraph: &str,
+    start_line: LineNumber,
+    end_line: LineNumber,
+) -> Vec<AuthorDetection> {
+    let normalized = strip_trailing_author_date(paragraph).replace(", and ", ", ");
+    let mut comma_parts: Vec<&str> = normalized
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect();
+    if comma_parts.len() >= 2
+        && let Some(last) = comma_parts.pop()
+    {
+        if let Some((left, right)) = last.split_once(" and ") {
+            comma_parts.push(left.trim());
+            comma_parts.push(right.trim());
+        } else {
+            comma_parts.push(last);
+        }
+    }
+    let candidates = if comma_parts.len() >= 2
+        && (comma_parts.len() >= 3
+            || comma_parts
+                .iter()
+                .all(|part| part.split_whitespace().count() >= 2))
+    {
+        comma_parts
+    } else if let Some((left, right)) = normalized.split_once(" and ") {
+        vec![left.trim(), right.trim()]
+    } else {
+        vec![paragraph.trim()]
+    };
+    let candidate_count = candidates.len();
+    let refined: Vec<String> = candidates
+        .into_iter()
+        .filter_map(refine_contactless_author)
+        .collect();
+    if refined.len() != candidate_count {
+        return Vec::new();
+    }
+
+    refined
+        .into_iter()
+        .map(|author| AuthorDetection {
+            author,
+            start_line,
+            end_line,
+        })
+        .collect()
+}
+
+/// Recover contact-backed identities from bounded POD AUTHOR(S) sections.
+pub(in super::super) fn extract_pod_author_section_contact_authors(
+    raw_lines: &[&str],
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
+    walk_author_section_paragraphs(raw_lines, |paragraph, start_line, end_line| {
+        authors.extend(extract_contact_authors_from_paragraph(
+            paragraph, start_line, end_line,
+        ));
+    });
+    authors
+}
+
+/// Recover short name and collective credits from bounded POD AUTHOR(S) sections.
+pub(in super::super) fn extract_pod_author_section_contactless_authors(
+    raw_lines: &[&str],
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
+    walk_author_section_paragraphs(raw_lines, |paragraph, start_line, end_line| {
+        if !paragraph.contains('@') {
+            authors.extend(extract_contactless_authors_from_paragraph(
+                paragraph, start_line, end_line,
+            ));
+        }
+    });
 
     authors
 }

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -359,6 +359,11 @@ fn run_author_extraction_and_repairs(
     let mut new_a = super::author_heuristics::extract_pod_author_section_contact_authors(raw_lines);
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
+
+    let mut new_a =
+        super::author_heuristics::extract_pod_author_section_contactless_authors(raw_lines);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
 }
 
 // Copyright postprocess phase fn; the long argument list threads the shared detection-pipeline state.

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -561,6 +561,103 @@ Send patches and ideas to patches@example.com.
 }
 
 #[test]
+fn test_pod_author_section_recovers_contactless_names_and_rosters() {
+    let input = r#"=head1 AUTHORS
+
+Thomas Dorner
+
+Yves Orton, Kenichi Ishigaki and Max Maischein
+
+Tim Bunce, 2nd June 1995.
+
+=head1 NOTES
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    for expected in [
+        "Thomas Dorner",
+        "Yves Orton",
+        "Kenichi Ishigaki",
+        "Max Maischein",
+        "Tim Bunce",
+    ] {
+        assert!(values.contains(&expected), "authors: {authors:?}");
+    }
+}
+
+#[test]
+fn test_pod_author_section_recovers_collectives_and_list_items() {
+    let input = r#"=head1 AUTHOR
+
+Perl Toolchain Gang
+
+=over
+
+=item * Jarkko Hietaniemi E<lt>jhi@example.comE<gt>
+
+=item * Thomas Dorner
+
+=back
+
+=head1 NOTES
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    for expected in [
+        "Perl Toolchain Gang",
+        "Jarkko Hietaniemi <jhi@example.com>",
+        "Thomas Dorner",
+    ] {
+        assert!(values.contains(&expected), "authors: {authors:?}");
+    }
+}
+
+#[test]
+fn test_pod_author_section_rejects_role_labels_and_narrative() {
+    let input = r#"=head1 AUTHOR
+
+Current maintainers:
+
+External protocol:
+
+First version July 22, 1998.
+
+This section explains who maintains the software.
+
+=head1 NOTES
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
+fn test_pod_author_section_stops_at_embedded_document_fence() {
+    let input = r#"=head1 AUTHOR
+
+Tokuhiro Matsuno
+...
+Outside Person
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(values.contains(&"Tokuhiro Matsuno"), "authors: {authors:?}");
+    assert!(!values.contains(&"Outside Person"), "authors: {authors:?}");
+}
+
+#[test]
 fn test_plain_json_author_string_machine_token_dropped_without_metadata_context() {
     let input = r#""author": "makeappicon", "images": []"#;
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);


### PR DESCRIPTION
## Summary

- Recover short contactless names, collectives, and rosters from bounded POD `AUTHOR` and `AUTHORS` sections.
- Parse POD `=item` payloads as individual records and stop at headings, `=cut`, block boundaries, embedded-document fences, or the existing size cap.
- Split only all-name rosters, detach trailing authored-on dates, and reject role labels and narrative paragraphs.

## Issues

- Covers: follow-up author-detection gaps found while validating #1391

## Scope and exclusions

- Included: short standalone names, collective credits, conservative comma/`and` rosters, POD list items, embedded-document fences.
- Explicit exclusions: narrative contribution lists and non-POD source-header credits; those require separate evidence rules.

## How to verify

- Scan Perl 5.38.4 with `--copyright` and compare author values against #1410. This branch adds 204 author values across 130 files, removes none, introduces no duplicate values, and leaves copyrights and holders unchanged.
- Scan Info-ZIP 3.0 with `--copyright`; author, copyright, and holder output should be exactly unchanged from #1410.

## Intentional differences from Python

- ScanCode has any author output in only 28 affected Perl files and no exact matches for these recovered values. Provenant uses bounded POD structure plus name-shape validation to retain source-faithful names that ScanCode misses.

## Follow-up work

- Created or intentionally deferred: recover narrative contribution rosters inside bounded author sections and static source-header credits in separate benchmarked layers.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: focused end-to-end tests cover the new list, name, collective, date, fence, and rejection behavior without changing existing goldens.
