### PR TITLE
fix(copyright): recover bounded POD contributor rosters

### DIFF
--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -103,6 +103,30 @@ pub(in super::super) fn refine_author_with_optional_handle_suffix(
     refine_author(trimmed)
 }
 
+pub(in super::super) fn refine_particle_name(candidate: &str) -> Option<String> {
+    const NAME_PARTICLES: &[&str] = &[
+        "al", "bin", "da", "de", "del", "della", "der", "di", "dos", "du", "la", "le", "the",
+        "van", "von", "y",
+    ];
+
+    let candidate = candidate.trim().trim_end_matches('.').trim();
+    let words: Vec<&str> = candidate.split_whitespace().collect();
+    if words.len() < 3 || words.len() > 6 {
+        return None;
+    }
+    let mut uppercase_words = 0;
+    for word in words {
+        let normalized = word.trim_matches(|ch: char| !ch.is_alphanumeric());
+        let first = normalized.chars().find(|ch| ch.is_alphabetic())?;
+        if first.is_uppercase() {
+            uppercase_words += 1;
+        } else if !NAME_PARTICLES.contains(&normalized.to_ascii_lowercase().as_str()) {
+            return None;
+        }
+    }
+    (uppercase_words >= 2).then(|| candidate.to_string())
+}
+
 pub(in super::super) fn drop_authors_embedded_in_copyrights(
     copyrights: &[CopyrightDetection],
     authors: &mut Vec<AuthorDetection>,

--- a/src/copyright/detector/author_heuristics/pod_sections.rs
+++ b/src/copyright/detector/author_heuristics/pod_sections.rs
@@ -10,6 +10,8 @@ use crate::copyright::refiner::refine_author;
 use crate::copyright::types::AuthorDetection;
 use crate::models::LineNumber;
 
+use super::refine_particle_name;
+
 fn extract_contact_authors_from_paragraph(
     paragraph: &str,
     start_line: LineNumber,
@@ -214,6 +216,15 @@ fn strip_trailing_author_date(candidate: &str) -> String {
     TRAILING_DATE_RE.replace(candidate, "").trim().to_string()
 }
 
+fn is_collective_noun(word: &str) -> bool {
+    matches!(
+        word.trim_matches(|ch: char| !ch.is_alphanumeric())
+            .to_ascii_lowercase()
+            .as_str(),
+        "contributors" | "developers" | "gang" | "group" | "porters" | "project" | "team"
+    )
+}
+
 fn refine_contactless_author(candidate: &str) -> Option<String> {
     const NON_NAME_WORDS: &[&str] = &[
         "author",
@@ -234,7 +245,8 @@ fn refine_contactless_author(candidate: &str) -> Option<String> {
         return None;
     }
     let candidate = strip_trailing_author_date(candidate);
-    let author = refine_author(candidate.trim_end_matches('.').trim())?;
+    let candidate = candidate.trim_end_matches('.').trim();
+    let author = refine_particle_name(candidate).or_else(|| refine_author(candidate))?;
     let words: Vec<&str> = author.split_whitespace().collect();
     if words.is_empty() || words.len() > 6 {
         return None;
@@ -261,27 +273,31 @@ fn refine_contactless_author(candidate: &str) -> Option<String> {
         .filter(|ch| ch.is_uppercase() || ch.is_lowercase())
         .collect();
     let uppercase_words = cased_words.iter().filter(|ch| ch.is_uppercase()).count();
-    let has_collective_noun = words.iter().any(|word| {
-        matches!(
-            word.trim_matches(|ch: char| !ch.is_alphanumeric())
-                .to_ascii_lowercase()
-                .as_str(),
-            "contributors" | "developers" | "gang" | "group" | "porters" | "project" | "team"
-        )
-    });
-    if cased_words.is_empty() || uppercase_words >= 2 || words.len() == 1 || has_collective_noun {
+    let has_collective_noun = words.iter().any(|word| is_collective_noun(word));
+    if cased_words.is_empty()
+        || uppercase_words >= 2
+        || (words.len() == 1 && uppercase_words == 1)
+        || has_collective_noun
+    {
         Some(author)
     } else {
         None
     }
 }
 
-fn extract_contactless_authors_from_paragraph(
-    paragraph: &str,
-    start_line: LineNumber,
-    end_line: LineNumber,
-) -> Vec<AuthorDetection> {
-    let normalized = strip_trailing_author_date(paragraph).replace(", and ", ", ");
+fn contactless_author_values(paragraph: &str) -> Vec<String> {
+    let mut normalized = strip_trailing_author_date(paragraph)
+        .trim_end_matches('.')
+        .trim()
+        .to_string();
+    for suffix in [", and others", " and others", ", et al", " et al"] {
+        if normalized.to_ascii_lowercase().ends_with(suffix) {
+            let end = normalized.len() - suffix.len();
+            normalized.truncate(end);
+            break;
+        }
+    }
+    let normalized = normalized.replace(", and ", ", ");
     let mut comma_parts: Vec<&str> = normalized
         .split(',')
         .map(str::trim)
@@ -304,10 +320,13 @@ fn extract_contactless_authors_from_paragraph(
                 .all(|part| part.split_whitespace().count() >= 2))
     {
         comma_parts
-    } else if let Some((left, right)) = normalized.split_once(" and ") {
+    } else if let Some((left, right)) = normalized.split_once(" and ")
+        && (!normalized.split_whitespace().any(is_collective_noun)
+            || left.split_whitespace().count() >= 2)
+    {
         vec![left.trim(), right.trim()]
     } else {
-        vec![paragraph.trim()]
+        vec![normalized.trim()]
     };
     let candidate_count = candidates.len();
     let refined: Vec<String> = candidates
@@ -319,6 +338,81 @@ fn extract_contactless_authors_from_paragraph(
     }
 
     refined
+}
+
+fn extract_contactless_authors_from_paragraph(
+    paragraph: &str,
+    start_line: LineNumber,
+    end_line: LineNumber,
+) -> Vec<AuthorDetection> {
+    contactless_author_values(paragraph)
+        .into_iter()
+        .map(|author| AuthorDetection {
+            author,
+            start_line,
+            end_line,
+        })
+        .collect()
+}
+
+fn truncate_credit_roster(value: &str) -> &str {
+    let lower = value.to_ascii_lowercase();
+    let end = [" for ", ", and many ", " and many ", " over the years"]
+        .into_iter()
+        .filter_map(|boundary| lower.find(boundary))
+        .min()
+        .unwrap_or(value.len());
+
+    let roster = value[..end].trim().trim_matches(&[' ', ',', '.', ';'][..]);
+    roster
+        .strip_suffix(" and")
+        .or_else(|| roster.strip_suffix(" And"))
+        .unwrap_or(roster)
+        .trim_end()
+}
+
+fn extract_narrative_credit_authors_from_paragraph(
+    paragraph: &str,
+    start_line: LineNumber,
+    end_line: LineNumber,
+) -> Vec<AuthorDetection> {
+    static CREDIT_CUE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)\b(?:(?:with\s+)?(?:contributions?|(?:invaluable|valuable)\s+help|help|advice)\s+from|(?:with\s+)?thanks\s+to|supplied\s+by|attributable\s+to)\b",
+        )
+        .expect("valid POD narrative credit cue regex")
+    });
+    static SUBJECT_CREDIT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^(?P<names>.+?)\s+(?:has|have)\s+(?:added|contributed|created|maintained|provided|updated|written)\b",
+        )
+        .expect("valid POD subject credit regex")
+    });
+
+    let mut rosters = Vec::new();
+    let cues: Vec<_> = CREDIT_CUE_RE.find_iter(paragraph).collect();
+    if let Some(first) = cues.first() {
+        let prefix = paragraph[..first.start()].trim();
+        if !prefix.is_empty() && (prefix.contains(',') || prefix.contains(" and ")) {
+            rosters.extend(contactless_author_values(prefix));
+        }
+        for (index, cue) in cues.iter().enumerate() {
+            let tail_end = cues
+                .get(index + 1)
+                .map_or(paragraph.len(), |next| next.start());
+            let tail = truncate_credit_roster(&paragraph[cue.end()..tail_end]);
+            if !tail.is_empty() {
+                rosters.extend(contactless_author_values(tail));
+            }
+        }
+    }
+    if let Some(captures) = SUBJECT_CREDIT_RE.captures(paragraph)
+        && let Some(names) = captures.name("names")
+    {
+        rosters.extend(contactless_author_values(names.as_str()));
+    }
+
+    rosters
         .into_iter()
         .map(|author| AuthorDetection {
             author,
@@ -355,4 +449,43 @@ pub(in super::super) fn extract_pod_author_section_contactless_authors(
     });
 
     authors
+}
+
+/// Recover cue-backed contributor rosters from bounded POD AUTHOR(S) sections.
+pub(in super::super) fn extract_pod_author_section_narrative_credit_authors(
+    raw_lines: &[&str],
+) -> Vec<AuthorDetection> {
+    let mut authors = Vec::new();
+    walk_author_section_paragraphs(raw_lines, |paragraph, start_line, end_line| {
+        authors.extend(extract_narrative_credit_authors_from_paragraph(
+            paragraph, start_line, end_line,
+        ));
+    });
+
+    authors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::contactless_author_values;
+
+    #[test]
+    fn contactless_rosters_keep_particle_names_and_mixed_collectives() {
+        assert_eq!(
+            contactless_author_values(
+                "Gisle Aas, James Duncan, Hugo van der Sanden, Robin Houston, and Rafael Garcia-Suarez."
+            ),
+            [
+                "Gisle Aas",
+                "James Duncan",
+                "Hugo van der Sanden",
+                "Robin Houston",
+                "Rafael Garcia-Suarez",
+            ]
+        );
+        assert_eq!(
+            contactless_author_values("Larry Wall and the Perl Porters."),
+            ["Larry Wall", "the Perl Porters"]
+        );
+    }
 }

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -364,6 +364,11 @@ fn run_author_extraction_and_repairs(
         super::author_heuristics::extract_pod_author_section_contactless_authors(raw_lines);
     seen.dedup_new_authors(&mut new_a, 0);
     authors.extend(new_a);
+
+    let mut new_a =
+        super::author_heuristics::extract_pod_author_section_narrative_credit_authors(raw_lines);
+    seen.dedup_new_authors(&mut new_a, 0);
+    authors.extend(new_a);
 }
 
 // Copyright postprocess phase fn; the long argument list threads the shared detection-pipeline state.

--- a/src/copyright/detector/postprocess_transforms/mod.rs
+++ b/src/copyright/detector/postprocess_transforms/mod.rs
@@ -16,6 +16,7 @@ use crate::models::LineNumber;
 
 use super::author_heuristics::{
     looks_like_structured_json_author_fallback, refine_author_with_optional_handle_suffix,
+    refine_particle_name,
 };
 use super::seen_text::SeenTextSets;
 use super::token_utils::{group_by, normalize_whitespace};
@@ -71,6 +72,7 @@ pub fn refine_final_authors(authors: &mut Vec<AuthorDetection>) {
             let author = if let Some(author) = refine_author(&a.author) {
                 author
             } else if refine_author_with_optional_handle_suffix(&a.author).is_some()
+                || refine_particle_name(&a.author).is_some()
                 || looks_like_structured_json_author_fallback(&a.author)
                 || looks_like_collective_institution_author(&a.author)
             {
@@ -110,9 +112,18 @@ fn looks_like_collective_institution_author(author: &str) -> bool {
                 .is_some_and(|ch| ch.is_uppercase())
         })
         .count();
+    let has_collective_noun = lower.split_whitespace().any(|word| {
+        matches!(
+            word.trim_matches(|ch: char| !ch.is_alphanumeric()),
+            "contributors" | "developers" | "group" | "porters" | "project" | "team"
+        )
+    });
 
     uppercase_word_count >= 2
-        && (lower.contains(" at the ") || lower.contains(" of the ") || trimmed.contains(". "))
+        && (has_collective_noun
+            || lower.contains(" at the ")
+            || lower.contains(" of the ")
+            || trimmed.contains(". "))
 }
 
 fn is_trademark_boilerplate_line(line: &str) -> bool {

--- a/src/copyright/detector/postprocess_transforms_test.rs
+++ b/src/copyright/detector/postprocess_transforms_test.rs
@@ -103,6 +103,19 @@ fn test_refine_final_authors_keeps_obfuscated_angle_contact_author() {
 }
 
 #[test]
+fn test_refine_final_authors_keeps_named_collective() {
+    let mut authors = vec![AuthorDetection {
+        author: "the Perl Porters".to_string(),
+        start_line: LineNumber::ONE,
+        end_line: LineNumber::ONE,
+    }];
+
+    refine_final_authors(&mut authors);
+
+    assert_eq!(authors[0].author, "the Perl Porters");
+}
+
+#[test]
 fn test_derive_holder_from_simple_copyright_string_keeps_iso_date_holder() {
     assert_eq!(
         derive_holder_from_simple_copyright_string("Copyright (c) 2006-07-24 John Boolage"),

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -570,6 +570,8 @@ Yves Orton, Kenichi Ishigaki and Max Maischein
 
 Tim Bunce, 2nd June 1995.
 
+Larry Wall and others
+
 =head1 NOTES
 "#;
     let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
@@ -584,6 +586,7 @@ Tim Bunce, 2nd June 1995.
         "Kenichi Ishigaki",
         "Max Maischein",
         "Tim Bunce",
+        "Larry Wall",
     ] {
         assert!(values.contains(&expected), "authors: {authors:?}");
     }
@@ -655,6 +658,99 @@ Outside Person
 
     assert!(values.contains(&"Tokuhiro Matsuno"), "authors: {authors:?}");
     assert!(!values.contains(&"Outside Person"), "authors: {authors:?}");
+}
+
+#[test]
+fn test_pod_author_section_recovers_cue_backed_narrative_rosters() {
+    let input = r#"=head1 AUTHORS
+
+David Fiander and Peter Prymmer with thanks to Dennis Longnecker
+and William Raffloer for valuable reports. Thanks to Mike MacIsaac and
+Egon Terwedow for feedback. Thanks to Ignasi Roca for diagnostics.
+
+Mike Fulton and Karl Williamson have provided later updates.
+
+=head1 NOTES
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    for expected in [
+        "David Fiander",
+        "Peter Prymmer",
+        "Dennis Longnecker",
+        "William Raffloer",
+        "Mike MacIsaac",
+        "Egon Terwedow",
+        "Ignasi Roca",
+        "Mike Fulton",
+        "Karl Williamson",
+    ] {
+        assert!(values.contains(&expected), "authors: {authors:?}");
+    }
+}
+
+#[test]
+fn test_pod_author_section_recovers_narrative_roster_after_contact() {
+    let input = r#"=head1 AUTHOR
+
+Stephen McCamant <stephen@example.com>, based on an earlier version by
+Malcolm Beattie <malcolm@example.com>, with contributions from Gisle Aas,
+James Duncan, Hugo van der Sanden, Robin Houston, and Rafael Garcia-Suarez.
+
+Nicholas Clark <nicholas@example.com>, collating wisdom supplied by
+Slaven Rezic and Tim Bunce.
+
+This code is attributable to Larry Wall and the Perl Porters.
+
+=head1 NOTES
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    for expected in [
+        "Gisle Aas",
+        "James Duncan",
+        "Hugo van der Sanden",
+        "Robin Houston",
+        "Rafael Garcia-Suarez",
+        "Slaven Rezic",
+        "Tim Bunce",
+        "Larry Wall",
+        "the Perl Porters",
+    ] {
+        assert!(values.contains(&expected), "authors: {authors:?}");
+    }
+}
+
+#[test]
+fn test_pod_author_section_does_not_treat_generic_credit_objects_as_names() {
+    let input = r#"=head1 AUTHOR
+
+Documentation with contributions from examples.
+
+Research and Development Team
+
+=head1 NOTES
+"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(!values.contains(&"Documentation"), "authors: {authors:?}");
+    assert!(!values.contains(&"examples"), "authors: {authors:?}");
+    assert!(
+        values.contains(&"Research and Development Team"),
+        "authors: {authors:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Recover bounded contributor rosters from narrative sentences inside POD `AUTHOR` and `AUTHORS` sections.
- Support contribution, thanks, supplied-by, attribution, and subject-provided cues without treating unrelated prose as names.
- Preserve valid name particles and contributor collectives while trimming dates, roles, and non-person continuations.

## Issues

- Covers: follow-up findings from #1391

## Scope and exclusions

- Included: cue-backed narrative credits inside structurally bounded POD author sections.
- Explicit exclusions: unbounded prose, operational contacts, copyright-only contacts, and generic contribution objects.

## How to verify

- Scan Perl 5.38.4 with `provenant --copyright --json out.json perl-5.38.4`. Relative to #1411, this adds 57 valid author values across 15 files, removes none, introduces no duplicates, and leaves copyright and holder output unchanged.
- Compare the same 15 files with ScanCode: ScanCode reports any author in nine and exactly matches none of the recovered values.
- Scan InfoZIP 3.0 as a control: author, copyright, and holder output is byte-for-byte unchanged from #1411.

## Intentional differences from Python

- Provenant treats bounded, grammatically cued contributor sentences as authorship evidence. ScanCode generally misses these rosters, while Provenant keeps extraction section-bounded and rejects generic prose objects.

## Follow-up work

- Created or intentionally deferred: source-header credits and malformed legacy author cleanup remain in later stacked branches.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: focused detector tests cover cue families, name particles, collectives, exclusions, and section boundaries; the Perl and InfoZIP comparisons provide positive and negative corpus evidence.
