### PR TITLE
fix(copyright): bound and normalize author candidates

### DIFF
--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -616,6 +616,35 @@ pub(in super::super) fn drop_authors_after_sentence_final_label(
     });
 }
 
+/// Drop an object phrase misread as a name after a subject-role construction,
+/// such as `Kent was the author or maintainer of 178 CPAN distributions`.
+/// Here `author` is a predicate describing the named subject, not a label that
+/// introduces the words following `of`.
+pub(in super::super) fn drop_subject_role_object_authors(
+    raw_lines: &[&str],
+    authors: &mut Vec<AuthorDetection>,
+) {
+    static SUBJECT_ROLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?ix)
+            \b\p{Lu}[\p{L}\p{M}'’.-]*
+            (?:\s+\p{Lu}[\p{L}\p{M}'’.-]*){0,5}
+            \s+(?:is|was)\s+(?:the\s+)?
+            (?:author|maintainer)
+            (?:\s+or\s+(?:author|maintainer))?
+            \s+of\b
+            ",
+        )
+        .expect("valid subject-role author regex")
+    });
+
+    authors.retain(|author| {
+        let start = author.start_line.get().saturating_sub(1);
+        let end = author.end_line.get().min(raw_lines.len());
+        start >= end || !SUBJECT_ROLE_RE.is_match(&raw_lines[start..end].join(" "))
+    });
+}
+
 /// Drop a weak compact author phrase when it was harvested without a bounded
 /// label or attribution. Lowercase names remain valid with explicit evidence.
 pub(in super::super) fn drop_weak_prose_authors(

--- a/src/copyright/detector/phases/postprocess.rs
+++ b/src/copyright/detector/phases/postprocess.rs
@@ -350,6 +350,7 @@ fn run_author_extraction_and_repairs(
     super::author_heuristics::drop_markup_element_value_authors(raw_lines, authors);
     super::author_heuristics::drop_markup_declaration_authors(raw_lines, authors);
     super::author_heuristics::drop_authors_after_sentence_final_label(raw_lines, authors);
+    super::author_heuristics::drop_subject_role_object_authors(raw_lines, authors);
     super::author_heuristics::drop_weak_prose_authors(raw_lines, authors);
     super::author_heuristics::repair_complete_by_line_author_boundaries(raw_lines, authors);
     super::author_heuristics::repair_hyphenated_prose_tail_authors(raw_lines, authors);

--- a/src/copyright/detector/tests_author_pipeline.rs
+++ b/src/copyright/detector/tests_author_pipeline.rs
@@ -251,6 +251,62 @@ fn test_json_author_array_keeps_explicit_email_identity() {
 }
 
 #[test]
+fn test_json_author_array_keeps_punctuated_obfuscated_contact() {
+    let input = r#"{
+  "name": "example-package",
+  "author": ["Masaaki Goshima (goccy) <goccy(at)cpan.org>"]
+}"#;
+    let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+
+    assert_eq!(
+        authors
+            .iter()
+            .map(|author| author.author.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Masaaki Goshima (goccy) goccy at cpan.org"],
+        "authors: {authors:?}"
+    );
+}
+
+#[test]
+fn test_author_cleanup_uses_grammatical_boundaries_and_deduplicates_quotes() {
+    let inputs = [
+        (
+            "C<Devel::PPPort>, maintained by Paul Marquess, has been added. It is primarily used\n",
+            vec!["Paul Marquess"],
+        ),
+        (
+            "December, 2001; by Nicholas Clark: make timestr recognise the style 'none'\n",
+            vec!["Nicholas Clark"],
+        ),
+        (
+            "# Updated for threads by \"Timur I. Bakeyev\" <bsdi@example.com>\n",
+            vec!["Timur I. Bakeyev <bsdi@example.com>"],
+        ),
+        (
+            "module-starter --module=Foo::Bar --author=\"Your Name\" --email=yourname@cpan.org\n",
+            vec![],
+        ),
+        (
+            "A self-described geek, Kent was the author or maintainer of 178 CPAN distributions, the Perl maintainer for Gentoo. He is mourned by his friends.\n",
+            vec![],
+        ),
+    ];
+
+    for (input, expected) in inputs {
+        let (_copyrights, _holders, authors) = detect_copyrights_from_text(input);
+        assert_eq!(
+            authors
+                .iter()
+                .map(|author| author.author.as_str())
+                .collect::<Vec<_>>(),
+            expected,
+            "input: {input:?}; authors: {authors:?}"
+        );
+    }
+}
+
+#[test]
 fn test_json_author_array_in_query_or_schema_is_not_file_authorship() {
     let input = r#"{
   "name": "query-fixtures",

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -8,10 +8,10 @@ use super::*;
 
 /// Refine a detected author name. Returns `None` if junk or empty.
 pub fn refine_author(s: &str) -> Option<String> {
-    if s.is_empty() {
+    if s.is_empty() || looks_like_template_placeholder_author(s) {
         return None;
     }
-    let had_obfuscated_angle_contact = contains_obfuscated_angle_contact(s);
+    let had_obfuscated_contact = contains_obfuscated_contact(s);
     let mut a = remove_some_extra_words_and_punct(s);
     a = strip_trailing_parenthesized_email_contact(&a);
     a = strip_trailing_at_handle(&a);
@@ -19,6 +19,8 @@ pub fn refine_author(s: &str) -> Option<String> {
     a = truncate_trailing_revision_metadata(&a);
     a = truncate_trailing_contact_metadata(&a);
     a = truncate_trailing_email_prose(&a);
+    a = truncate_trailing_lowercase_clause_after_name(&a);
+    a = truncate_trailing_change_action_after_name(&a);
     a = truncate_prose_sentence_after_name(&a);
     a = strip_leading_maintainers_label(&a);
     a = strip_trailing_javadoc_tags(&a);
@@ -102,7 +104,7 @@ pub fn refine_author(s: &str) -> Option<String> {
         return None;
     }
 
-    if looks_like_prose_fragment_author(&a) && !had_obfuscated_angle_contact {
+    if looks_like_prose_fragment_author(&a) && !had_obfuscated_contact {
         return None;
     }
 
@@ -117,11 +119,15 @@ pub fn refine_author(s: &str) -> Option<String> {
     }
 }
 
-fn contains_obfuscated_angle_contact(s: &str) -> bool {
+fn contains_obfuscated_contact(s: &str) -> bool {
     static OBFUSCATED_ANGLE_CONTACT_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)<\s*(?P<inner>[^<>]*\bat\b[^<>]*)\s*>").unwrap());
+    static NORMALIZED_OBFUSCATED_CONTACT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)\b[a-z0-9._%+-]+\s+at\s+[a-z0-9.-]+\.[a-z]{2,}\b")
+            .expect("valid normalized obfuscated contact regex")
+    });
 
-    OBFUSCATED_ANGLE_CONTACT_RE.is_match(s)
+    OBFUSCATED_ANGLE_CONTACT_RE.is_match(s) || NORMALIZED_OBFUSCATED_CONTACT_RE.is_match(s)
 }
 
 fn collapse_repeated_angle_contact(s: &str) -> String {
@@ -395,6 +401,81 @@ fn truncate_trailing_revision_metadata(s: &str) -> String {
     name.to_string()
 }
 
+/// Stop a parser overrun when a complete personal name is followed by a
+/// lowercase explanatory clause. Comma-inverted names remain untouched because
+/// their post-comma token starts with an uppercase letter.
+fn truncate_trailing_lowercase_clause_after_name(s: &str) -> String {
+    static LOWERCASE_CLAUSE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?x)
+            ^(?P<name>
+                \p{Lu}[\p{L}\p{M}'’.-]*
+                (?:\s+(?:\p{Lu}[\p{L}\p{M}'’.-]*|\p{Lu}\.)){1,5}
+            )
+            \s*,\s+
+            (?P<tail>\p{Ll}.*)
+            $",
+        )
+        .expect("valid lowercase author clause regex")
+    });
+
+    let trimmed = s.trim();
+    let Some(captures) = LOWERCASE_CLAUSE_RE.captures(trimmed) else {
+        return s.to_string();
+    };
+    let name = captures
+        .name("name")
+        .map(|matched| matched.as_str())
+        .unwrap_or("")
+        .trim();
+    let tail = captures
+        .name("tail")
+        .map(|matched| matched.as_str())
+        .unwrap_or("")
+        .trim();
+
+    if !name.is_empty()
+        && !looks_like_conjoined_author_tail(tail)
+        && !looks_like_comma_separated_author_tail(tail)
+        && looks_like_prose_fragment_author(tail)
+    {
+        name.to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+/// Stop at an unpunctuated change-description verb after a complete name.
+/// Some token streams discard the source colon in `by Name: changed ...`, so
+/// the remaining lowercase action is the reliable grammatical boundary.
+fn truncate_trailing_change_action_after_name(s: &str) -> String {
+    static CHANGE_ACTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?x)
+            ^(?P<name>
+                \p{Lu}[\p{L}\p{M}'’.-]*
+                (?:\s+(?:\p{Lu}[\p{L}\p{M}'’.-]*|\p{Lu}\.)){1,5}
+            )
+            \s+
+            (?:
+                add(?:ed|ing|s)?|chang(?:e|ed|ing|es)|fix(?:ed|ing|es)?|
+                implement(?:ed|ing|s)?|ma(?:ke|de|king|kes)|port(?:ed|ing|s)?|
+                recogni[sz](?:e|ed|ing|es)|return(?:ed|ing|s)?|
+                support(?:ed|ing|s)?|updat(?:e|ed|ing|es)|us(?:e|ed|ing|es)
+            )
+            (?:\s+.*)?
+            $",
+        )
+        .expect("valid author change-action regex")
+    });
+
+    let trimmed = s.trim();
+    CHANGE_ACTION_RE
+        .captures(trimmed)
+        .and_then(|captures| captures.name("name"))
+        .map_or_else(|| s.to_string(), |matched| matched.as_str().to_string())
+}
+
 /// Stop after a complete email contact when the remaining text is a prose
 /// clause. Conjoined contacts remain intact as an author list.
 fn truncate_trailing_email_prose(s: &str) -> String {
@@ -474,7 +555,7 @@ fn truncate_trailing_contact_metadata(s: &str) -> String {
 
 fn strip_dangling_quote_before_contact(s: &str) -> String {
     static DANGLING_QUOTE_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?P<name>\p{L})['`’]\s+(?P<contact><[^>]*@[^>]*>)")
+        Regex::new(r#"(?P<name>\p{L})["'`’]\s+(?P<contact><[^>]*@[^>]*>)"#)
             .expect("valid dangling author quote regex")
     });
 
@@ -579,6 +660,15 @@ fn looks_like_translation_placeholder_author(s: &str) -> bool {
 
     let trimmed = s.trim();
     trimmed.eq_ignore_ascii_case("Requires translation") || AUTHOR_PLACEHOLDER_RE.is_match(trimmed)
+}
+
+fn looks_like_template_placeholder_author(s: &str) -> bool {
+    let lower = normalize_whitespace(s).to_ascii_lowercase();
+    lower == "your name"
+        || lower.starts_with("your name ")
+        || lower == "author name"
+        || lower.starts_with("author name ")
+        || lower.contains("yourname@")
 }
 
 fn contains_no_copyright_clause(s: &str) -> bool {
@@ -868,11 +958,19 @@ fn looks_like_leading_the_institution_author(s: &str) -> bool {
 fn normalize_obfuscated_angle_contact(s: &str) -> String {
     static OBFUSCATED_ANGLE_CONTACT_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)<\s*(?P<inner>[^<>]*\bat\b[^<>]*)\s*>").unwrap());
+    static PUNCTUATED_SEPARATOR_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)[\(\[\{]\s*(?P<separator>at|dot)\s*[\)\]\}]")
+            .expect("valid punctuated obfuscated contact separator regex")
+    });
 
     let replaced = OBFUSCATED_ANGLE_CONTACT_RE
         .replace_all(s, |caps: &regex::Captures| {
             caps.name("inner")
-                .map(|m| format!(" {} ", m.as_str().trim()))
+                .map(|matched| {
+                    let normalized =
+                        PUNCTUATED_SEPARATOR_RE.replace_all(matched.as_str(), " ${separator} ");
+                    format!(" {} ", normalize_whitespace(&normalized))
+                })
                 .unwrap_or_default()
         })
         .into_owned();
@@ -1497,6 +1595,21 @@ fn looks_like_conjoined_author_tail(tail: &str) -> bool {
         .expect("valid conjoined author regex")
     });
     CONJOINED_NAME_RE.is_match(tail.trim().trim_end_matches('.'))
+}
+
+fn looks_like_comma_separated_author_tail(tail: &str) -> bool {
+    static COMMA_NAME_TAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?x)
+            ^[\p{L}\p{M}0-9._'’-]{1,32}\s*,\s*(?:and\s+)?
+            \p{Lu}[\p{L}\p{M}'’.-]*
+            (?:\s+(?:\p{Lu}[\p{L}\p{M}'’.-]*|\p{Lu}\.)){1,5}
+            $",
+        )
+        .expect("valid comma-separated author tail regex")
+    });
+
+    COMMA_NAME_TAIL_RE.is_match(tail.trim().trim_end_matches('.'))
 }
 
 /// Truncate a trailing website/homepage label followed by a URL.

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -1952,6 +1952,56 @@ fn test_refine_author_normalizes_angle_bracket_email_comma_spacing() {
 fn test_refine_author_keeps_obfuscated_angle_contact_author() {
     let result = refine_author("Deepak M <m.deepak at intel.com>");
     assert_eq!(result, Some("Deepak M m.deepak at intel.com".to_string()));
+
+    let result = refine_author("Masaaki Goshima (goccy) <goccy(at)cpan.org>");
+    assert_eq!(
+        result,
+        Some("Masaaki Goshima (goccy) goccy at cpan.org".to_string())
+    );
+}
+
+#[test]
+fn test_refine_author_stops_at_lowercase_explanatory_clauses() {
+    assert_eq!(
+        refine_author("Paul Marquess, has been added. It is primarily used"),
+        Some("Paul Marquess".to_string())
+    );
+    assert_eq!(
+        refine_author(
+            "Larry Wall, gave rise to the free distribution policy. Perl is supported by users"
+        ),
+        Some("Larry Wall".to_string())
+    );
+    assert_eq!(
+        refine_author("Nicholas Clark make timestr recognise the style"),
+        Some("Nicholas Clark".to_string())
+    );
+    assert_eq!(
+        refine_author("Wall, Larry"),
+        Some("Wall, Larry".to_string())
+    );
+    assert_eq!(
+        refine_author("Warren Jasper, ds, Frank Hess"),
+        Some("Warren Jasper, ds, Frank Hess".to_string())
+    );
+}
+
+#[test]
+fn test_refine_author_normalizes_quoted_names_before_contacts() {
+    assert_eq!(
+        refine_author("Timur I. Bakeyev\" <bsdi@example.com>"),
+        Some("Timur I. Bakeyev <bsdi@example.com>".to_string())
+    );
+    assert_eq!(
+        refine_author("Sisyphus\" <bugs@example.com>"),
+        Some("Sisyphus <bugs@example.com>".to_string())
+    );
+}
+
+#[test]
+fn test_refine_author_drops_template_identity_placeholders() {
+    assert_eq!(refine_author("Your Name -email yourname@cpan.org"), None);
+    assert_eq!(refine_author("Author Name <author@example.com>"), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Stop author candidates at grammatical lowercase prose and change-action boundaries while preserving conjoined and handle-bearing rosters.
- Normalize quoted names and punctuated obfuscated contacts idempotently across repeated refinement.
- Reject identity templates and subject-role object phrases that are not file authorship.

## Issues

- Covers: follow-up findings from #1391

## Scope and exclusions

- Included: generic final author refinement and grammar-context cleanup.
- Explicit exclusions: repository-specific values, filename checks, and package-party extraction.

## How to verify

- Scan Perl 5.38.4 with `provenant scan --copyright --json out.json perl-5.38.4`. Relative to #1412, seven malformed or false author values disappear and six supported values appear: three clean replacements (`Larry Wall`, `Nicholas Clark`, `Paul Marquess`), two newly recovered Benchmark contributors, and one structured obfuscated-contact author. Quoted duplicates, a command template, and an obituary object phrase are removed. Copyright and holder output is unchanged.
- Scan InfoZIP 3.0 as a control. Its only author delta is two occurrences of `Greg Roelofs newt (at) pobox.com` normalized to the idempotent `Greg Roelofs newt at pobox.com`; copyright and holder output is unchanged.
- Run `cargo test --lib copyright::detector`, `cargo test --test copyright_golden --features golden-tests`, and `cargo test --test post_processing_golden --profile ci-release --features golden-tests`.

## Intentional differences from Python

- ScanCode's token grammar avoids some of these Provenant overrun shapes but misses both Benchmark contributors, and it reduces the structured obfuscated-contact author to `Masaaki Goshima`. Provenant retains the supported identity and contact while enforcing explicit grammar boundaries.

## Follow-up work

- Created or intentionally deferred: source-header credit recovery remains in the next stacked branch.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: focused unit and end-to-end tests cover prose/action boundaries, list preservation, quote normalization, templates, subject-role constructions, and repeated obfuscated-contact refinement; both broad golden suites pass unchanged.
