### PR TITLE
fix(copyright): recover source header author credits

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -242,7 +242,8 @@ fn trim_attribution_tail(who: &str) -> String {
 
 fn trim_contact_attribution_suffix(who: &str) -> String {
     static CONTACT_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?i)(?:<[^>\s]+@[^>\s]+>|\b[\w.+-]+@[\w.-]+\.[a-z]{2,})").unwrap()
+        Regex::new(r"(?i)(?:<[^>\s]+@[^>\s]+>|\([^()\s]*@[^()]*\)|\b[\w.+-]+@[\w.-]+\.[a-z]{2,})")
+            .unwrap()
     });
     static NON_AUTHOR_SUFFIX_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^(?:(?:on\s+)?\d|in\s+\d{4}\b|for\s+\p{L})").unwrap());
@@ -397,13 +398,13 @@ fn extract_line_local_attribution_author(
 ) -> Option<String> {
     static ACTION_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)^(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:(?:written|authored|revised|overhauled|implemented)\s+by|(?:updated|modified|ported|adapted)(?:\s+to\s+.*?)?\s+by)\s+(?P<who>.+)$",
+            r"(?i)^(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:(?:written|authored|revised|overhauled|implemented)\s+by|original\s+by|(?:updated|modified|ported|adapted)(?:\s+to\s+.*?)?\s+by|(?:first|last)\s+modified\b.{0,40}?\s+by|merged\b.{0,80}?\s+by):?\s+(?P<who>.+)$",
         )
         .unwrap()
     });
     static CONTACT_CONTRIBUTION_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)^(?:.{1,80}\s+)?(?:code|driver|kernel|stuff|support|work|patch(?:es)?|implementation|maintenance|module|program|software)\b.*\s+by\s+(?P<who>.+(?:@|\s+at\s+.+\s+dot\s+).*)$",
+            r"(?i)^(?:.{1,80}\s+)?(?:code|driver|hints?|kernel|stuff|support|work|patch(?:es)?|implementation|maintenance|module|program|software)\b.*\s+by\s+(?P<who>.+(?:@|\s+at\s+.+\s+dot\s+).*)$",
         )
         .unwrap()
     });
@@ -415,6 +416,12 @@ fn extract_line_local_attribution_author(
     });
     static COPYRIGHT_TAIL_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\s*(?:,\s*copyright\b|\(c\)\s*\d{4})\b.*$").unwrap());
+    static CHAINED_ATTRIBUTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i),\s*(?:adapted|authored|implemented|merged|modified|ported|revised|updated|written)\s+by\b.*$",
+        )
+        .unwrap()
+    });
     static CONTACT_SENTENCE_TAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^(?P<head>.*\b[\w.+-]+@[\w.-]+\.[a-z]{2,})(?:\.\s+|;\s+)[A-Z].*$").unwrap()
     });
@@ -440,6 +447,7 @@ fn extract_line_local_attribution_author(
         return None;
     }
     let who = trim_following_sentence_clause(who);
+    let who = CHAINED_ATTRIBUTION_RE.replace(&who, "");
     let who = COPYRIGHT_TAIL_RE.replace(&who, "");
     let who = CONTACT_SENTENCE_TAIL_RE
         .captures(&who)
@@ -466,6 +474,12 @@ fn extract_line_local_attribution_author(
 pub(in super::super) fn extract_line_local_attribution_authors(
     prepared_cache: &PreparedLines<'_>,
 ) -> Vec<AuthorDetection> {
+    static CHAINED_ATTRIBUTION_CLAUSE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i),\s*(?P<clause>(?:adapted|authored|implemented|merged|modified|ported|revised|updated|written)\s+by\s+.+)$",
+        )
+        .unwrap()
+    });
     let mut authors: Vec<AuthorDetection> = prepared_cache
         .iter_non_empty()
         .filter_map(|line| {
@@ -500,15 +514,34 @@ pub(in super::super) fn extract_line_local_attribution_authors(
         })
         .collect();
 
+    for line in prepared_cache.iter_non_empty() {
+        let Some(clause) = CHAINED_ATTRIBUTION_CLAUSE_RE
+            .captures(line.prepared)
+            .and_then(|captures| captures.name("clause"))
+        else {
+            continue;
+        };
+        let Some(author) = extract_line_local_attribution_author(clause.as_str(), false) else {
+            continue;
+        };
+        authors.push(AuthorDetection {
+            author,
+            start_line: line.line_number,
+            end_line: line.line_number,
+        });
+    }
+
     for (line, next_line) in prepared_cache.adjacent_pairs() {
         let first = line.prepared.trim_end();
         let next = next_line.prepared.trim();
         let first_lower = first.to_ascii_lowercase();
-        let has_by_boundary = first_lower.contains(" by ") || first_lower.ends_with(" by");
+        let ends_with_by_colon = first_lower.ends_with(" by:");
+        let ends_with_by = first_lower.ends_with(" by") || ends_with_by_colon;
+        let has_by_boundary = first_lower.contains(" by ") || ends_with_by;
         if first.contains('@') || !next.contains('@') || !has_by_boundary {
             continue;
         }
-        let attributed_party = if first_lower.ends_with(" by") {
+        let attributed_party = if ends_with_by {
             ""
         } else {
             let Some((_, attributed_party)) = first_lower.rsplit_once(" by ") else {
@@ -524,15 +557,24 @@ pub(in super::super) fn extract_line_local_attribution_authors(
         } else {
             next
         };
+        let next_has_delimited_contact =
+            next.contains('<') || (next.contains('(') && next.contains(')') && next.contains('@'));
+        let next_word_limit = if ends_with_by_colon || (ends_with_by && next_has_delimited_contact)
+        {
+            12
+        } else {
+            3
+        };
         if next
             .split_whitespace()
             .filter(|word| word.chars().any(|ch| ch.is_alphanumeric()))
             .count()
-            > 3
+            > next_word_limit
         {
             continue;
         }
         let bare_contact = next.trim_end_matches('.');
+        let first = first.trim_end_matches(':');
         let joined = if bare_contact.contains('@') && !bare_contact.contains(char::is_whitespace) {
             if bare_contact.starts_with('<') && bare_contact.ends_with('>') {
                 format!("{first} {bare_contact}")

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -512,6 +512,52 @@ fn test_contact_backed_change_attribution_wraps_onto_next_line() {
 }
 
 #[test]
+fn test_source_header_credit_variants_are_authors() {
+    let input = concat!(
+        "# Original by Neil Bowers <neil@example.net>; Tue Oct 4 1994\n",
+        "# XD88/10 platform hints by Kaveh Ghazi (ghazi@example.net) 2/11/92\n",
+        "# Merged with the distribution by\n",
+        "# Andy Dougherty <andy@example.net>\n",
+        "# First modified 6/30/96 by:\n",
+        "# Luther Huffman, Example Systems, Inc., luther@example.net\n",
+        "# Last modified May 2020 by:\n",
+        "# David Romano, david@example.net\n",
+        "# Original by first@example.net, modified by second@example.net\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    for expected in [
+        "Neil Bowers <neil@example.net>",
+        "Kaveh Ghazi (ghazi@example.net)",
+        "Andy Dougherty <andy@example.net>",
+        "Luther Huffman, Example Systems, Inc., luther@example.net",
+        "David Romano, david@example.net",
+        "first@example.net",
+        "second@example.net",
+    ] {
+        assert!(values.contains(&expected), "missing {expected}: {values:?}");
+    }
+}
+
+#[test]
+fn test_source_header_credit_words_without_people_are_not_authors() {
+    let input = concat!(
+        "The result is original by design.\n",
+        "The generated files are merged by the build tool.\n",
+        "Compiler hints by default improve diagnostics.\n",
+        "This file uses a compiler written by\n",
+        "Jean Example. Send mail to support@example.net for a copy.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}
+
+#[test]
 fn test_contact_backed_non_author_by_phrases_are_not_authors() {
     let input = concat!(
         "This package is distributed by Example Support <support@example.net>.\n",

--- a/testdata/copyright-golden/copyrights/misco4/linux-copyrights/net/dccp/ccids/lib/packet_history.c.yml
+++ b/testdata/copyright-golden/copyrights/misco4/linux-copyrights/net/dccp/ccids/lib/packet_history.c.yml
@@ -12,4 +12,5 @@ holders:
   - Nils-Erik Mattsson, Joacim Haggmark, Magnus Erixzon
   - The University of Aberdeen, Scotland, UK
   - The University of Waikato, Hamilton, New Zealand. An
-authors: []
+authors:
+  - Arnaldo Carvalho de Melo <acme@conectiva.com.br>


### PR DESCRIPTION
## Summary

- recover contact-backed `Original by` and artifact-header credits such as `hints by`
- join bounded `... by:` and wrapped action-attribution headers without absorbing following prose
- preserve multiple chained attributions on one source-header line

## Issues

- Covers: #1391

## Scope and exclusions

- Included: generic, contact-backed source-header attribution forms and their continuation boundaries
- Explicit exclusions: unconstrained prose `by` phrases and ScanCode-only render differences

## How to verify

- Scan Perl 5.38.4 with `--copyright`: Kaveh Ghazi, Andy Dougherty, Neil Bowers, and Luther Huffman are newly recovered; David Romano is upgraded to include the declared contact.
- Scan InfoZIP 3.0 with `--copyright`: author, copyright, and holder output is unchanged.

## Intentional differences from Python

- ScanCode output is evidence, not the target contract. This keeps Provenant's cleaner existing renderings and rejects ScanCode false positives while recovering source-backed identities ScanCode itself misses, including Luther Huffman.

## Expected-output fixture changes

- Files changed: `testdata/copyright-golden/copyrights/misco4/linux-copyrights/net/dccp/ccids/lib/packet_history.c.yml`
- Why the new expected output is correct: the fixture explicitly says the DCCP stack changes were written by Arnaldo Carvalho de Melo; the bounded wrapped-attribution logic now recovers that author.
