### PR TITLE
fix(copyright): recover bounded author action credits

### DIFF
--- a/src/copyright/detector/author_heuristics/mod.rs
+++ b/src/copyright/detector/author_heuristics/mod.rs
@@ -11,4 +11,8 @@ mod pod_sections;
 
 pub(super) use cleanup::*;
 pub(super) use extraction::*;
-pub(super) use pod_sections::*;
+pub(crate) use pod_sections::is_pod_author_heading;
+pub(super) use pod_sections::{
+    extract_pod_author_section_contact_authors, extract_pod_author_section_contactless_authors,
+    extract_pod_author_section_narrative_credit_authors,
+};

--- a/src/copyright/detector/author_heuristics/pod_sections.rs
+++ b/src/copyright/detector/author_heuristics/pod_sections.rs
@@ -12,6 +12,17 @@ use crate::models::LineNumber;
 
 use super::refine_particle_name;
 
+pub(crate) fn is_pod_author_heading(line: &str) -> bool {
+    static AUTHOR_HEADING_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^=head\d+\s+authors?(?:\s+(?:and|&)\s+(?:maintenance|maintainers?|modification\s+history))?\s*$",
+        )
+        .expect("valid POD author heading regex")
+    });
+
+    AUTHOR_HEADING_RE.is_match(line)
+}
+
 fn extract_contact_authors_from_paragraph(
     paragraph: &str,
     start_line: LineNumber,
@@ -90,9 +101,6 @@ fn walk_author_section_paragraphs(
     raw_lines: &[&str],
     mut visit: impl FnMut(&str, LineNumber, LineNumber),
 ) {
-    static AUTHOR_HEADING_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?i)^=head\d+\s+authors?\s*$").expect("valid POD author heading regex")
-    });
     static HEADING_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)^=head\d+\b").expect("valid POD heading regex"));
     static BLOCK_DIRECTIVE_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -130,7 +138,7 @@ fn walk_author_section_paragraphs(
                 &mut paragraph_end,
                 &mut visit,
             );
-            in_author_section = AUTHOR_HEADING_RE.is_match(prepared);
+            in_author_section = is_pod_author_heading(prepared);
             continue;
         }
         if !in_author_section {
@@ -209,11 +217,20 @@ fn walk_author_section_paragraphs(
 
 fn strip_trailing_author_date(candidate: &str) -> String {
     static TRAILING_DATE_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?i),?\s+\d{1,2}(?:st|nd|rd|th)?\s+[a-z]+\s+\d{4}\.?$")
-            .expect("valid trailing author date regex")
+        Regex::new(
+            r"(?i),?\s+(?:(?:in\s+)?(?:\d{1,2}(?:st|nd|rd|th)?\s+)?[a-z]+\s+\d{4}|(?:\d{4}-\d{2}-\d{2})|(?:\d{4}(?:-\d{2,4})?))\.?$",
+        )
+        .expect("valid trailing author date regex")
+    });
+    static TRAILING_POD_URL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)\s+(?:L\s+)?https?://\S+.*$").expect("valid trailing POD URL regex")
     });
 
-    TRAILING_DATE_RE.replace(candidate, "").trim().to_string()
+    let without_url = TRAILING_POD_URL_RE.replace(candidate, "");
+    TRAILING_DATE_RE
+        .replace(without_url.as_ref(), "")
+        .trim()
+        .to_string()
 }
 
 fn is_collective_noun(word: &str) -> bool {
@@ -246,7 +263,16 @@ fn refine_contactless_author(candidate: &str) -> Option<String> {
     }
     let candidate = strip_trailing_author_date(candidate);
     let candidate = candidate.trim_end_matches('.').trim();
-    let author = refine_particle_name(candidate).or_else(|| refine_author(candidate))?;
+    let author = refine_particle_name(candidate)
+        .or_else(|| refine_author(candidate))
+        .or_else(|| {
+            let mut chars = candidate.chars();
+            let starts_uppercase = chars.next().is_some_and(char::is_uppercase);
+            let words: Vec<&str> = candidate.split_whitespace().collect();
+            ((starts_uppercase && words.len() == 1 && candidate.chars().all(char::is_alphabetic))
+                || words.iter().any(|word| is_collective_noun(word)))
+            .then(|| candidate.to_string())
+        })?;
     let words: Vec<&str> = author.split_whitespace().collect();
     if words.is_empty() || words.len() > 6 {
         return None;
@@ -357,11 +383,25 @@ fn extract_contactless_authors_from_paragraph(
 
 fn truncate_credit_roster(value: &str) -> &str {
     let lower = value.to_ascii_lowercase();
-    let end = [" for ", ", and many ", " and many ", " over the years"]
-        .into_iter()
-        .filter_map(|boundary| lower.find(boundary))
-        .min()
-        .unwrap_or(value.len());
+    let end = [
+        " for ",
+        ", and many ",
+        " and many ",
+        " and on ",
+        ", based on ",
+        " based on earlier ",
+        ". currently ",
+        ". it ",
+        ". please ",
+        ". the ",
+        ". this ",
+        " in late ",
+        " over the years",
+    ]
+    .into_iter()
+    .filter_map(|boundary| lower.find(boundary))
+    .min()
+    .unwrap_or(value.len());
 
     let roster = value[..end].trim().trim_matches(&[' ', ',', '.', ';'][..]);
     roster
@@ -378,7 +418,7 @@ fn extract_narrative_credit_authors_from_paragraph(
 ) -> Vec<AuthorDetection> {
     static CREDIT_CUE_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)\b(?:(?:with\s+)?(?:contributions?|(?:invaluable|valuable)\s+help|help|advice)\s+from|(?:with\s+)?thanks\s+to|supplied\s+by|attributable\s+to)\b",
+            r"(?i)\b(?:(?:with\s+)?(?:contributions?|(?:invaluable|valuable)\s+help|help|advice)\s+from|with\s+(?:the\s+)?help\s+of|(?:with\s+)?thanks\s+to|supplied\s+by|attributable\s+to|(?:code|documentation|implementation|module|program|software|streamlining|work)\b[^.;]{0,80}?\s+by|(?:authored|created|developed|enhanced|introduced|maintained|modified|originated|rewritten|written)\b[^.;]{0,80}?\s+by)\b",
         )
         .expect("valid POD narrative credit cue regex")
     });
@@ -388,6 +428,12 @@ fn extract_narrative_credit_authors_from_paragraph(
         )
         .expect("valid POD subject credit regex")
     });
+    static LEADING_AUTHOR_BEFORE_ROLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^(?P<names>.+?)\.\s+(?:(?:it|this\s+(?:module|package|program))\s+is\s+)?(?:currently|later|now|previously|subsequently)?\s*$",
+        )
+        .expect("valid leading author before role regex")
+    });
 
     let mut rosters = Vec::new();
     let cues: Vec<_> = CREDIT_CUE_RE.find_iter(paragraph).collect();
@@ -395,6 +441,11 @@ fn extract_narrative_credit_authors_from_paragraph(
         let prefix = paragraph[..first.start()].trim();
         if !prefix.is_empty() && (prefix.contains(',') || prefix.contains(" and ")) {
             rosters.extend(contactless_author_values(prefix));
+        } else if let Some(names) = LEADING_AUTHOR_BEFORE_ROLE_RE
+            .captures(prefix)
+            .and_then(|captures| captures.name("names"))
+        {
+            rosters.extend(contactless_author_values(names.as_str()));
         }
         for (index, cue) in cues.iter().enumerate() {
             let tail_end = cues
@@ -486,6 +537,14 @@ mod tests {
         assert_eq!(
             contactless_author_values("Larry Wall and the Perl Porters."),
             ["Larry Wall", "the Perl Porters"]
+        );
+        assert_eq!(
+            contactless_author_values("the Perl 5 Porters."),
+            ["the Perl 5 Porters"]
+        );
+        assert_eq!(
+            contactless_author_values("Tels http://example.net/"),
+            ["Tels"]
         );
     }
 }

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -558,6 +558,103 @@ fn test_source_header_credit_words_without_people_are_not_authors() {
 }
 
 #[test]
+fn test_bounded_pod_author_action_credits_are_authors() {
+    let input = concat!(
+        "=head1 AUTHORS and MAINTENANCE\n",
+        "\n",
+        "Original math code by Mark Biggar, rewritten by Tels L<http://example.net/>\n",
+        "in late 2000.\n",
+        "\n",
+        "Separated from the original and shaped with the help of John Peacock.\n",
+        "\n",
+        "Further streamlining (api_version 1 etc.) by Tels 2004-2007.\n",
+        "\n",
+        "Currently maintained by the Perl Toolchain Gang.\n",
+        "\n",
+        "This program was introduced by Andy Dougherty, based on earlier work by ",
+        "Tom Christiansen. It is maintained by the Perl 5 Porters.\n",
+        "\n",
+        "Existing code by Graham Barr. Currently maintained by the Perl Porters. ",
+        "Please report bugs elsewhere.\n",
+        "\n",
+        "=head1 DESCRIPTION\n",
+        "\n",
+        "A component written by Build Generator <tool@example.net>.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    for expected in [
+        "Mark Biggar",
+        "Tels",
+        "John Peacock",
+        "the Perl Toolchain Gang",
+        "Andy Dougherty",
+        "Tom Christiansen",
+        "the Perl 5 Porters",
+        "Graham Barr",
+        "the Perl Porters",
+    ] {
+        assert!(values.contains(&expected), "missing {expected}: {values:?}");
+    }
+    assert!(
+        values
+            .iter()
+            .all(|author| !author.contains("Build Generator")),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
+fn test_pod_author_modification_history_recovers_embedded_action_credit() {
+    let input = concat!(
+        "=head1 Author and Modification History\n",
+        "\n",
+        "Modified by Damian Conway, 2001-09-10, v0.62.\n",
+        "\n",
+        "Modified implicit construction of nested objects.\n",
+        "\n",
+        "Modified by Casey West, 2000-11-08, v0.59.\n",
+        "\n",
+        "Added the ability for compile time class creation.\n",
+        "\n",
+        "Renamed to C<Class::Struct> and modified by Jim Miner, 1997-04-02.\n",
+        "\n",
+        "=cut\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(values.contains(&"Jim Miner"), "authors: {values:?}");
+}
+
+#[test]
+fn test_pod_author_section_keeps_leading_author_before_maintainer_credit() {
+    let input = concat!(
+        "=head1 AUTHOR\n",
+        "\n",
+        "Graham Barr. Currently maintained by the Perl Porters. Please report all ",
+        "bugs elsewhere.\n",
+        "\n",
+        "=cut\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(values.contains(&"Graham Barr"), "authors: {values:?}");
+    assert!(values.contains(&"the Perl Porters"), "authors: {values:?}");
+}
+
+#[test]
 fn test_contact_backed_non_author_by_phrases_are_not_authors() {
     let input = concat!(
         "This package is distributed by Example Support <support@example.net>.\n",

--- a/src/copyright/detector/mod.rs
+++ b/src/copyright/detector/mod.rs
@@ -33,6 +33,8 @@ use super::types::{
     AuthorDetection, CopyrightDetection, HolderDetection, ParseNode, PosTag, TreeLabel,
 };
 
+pub(crate) use author_heuristics::is_pod_author_heading;
+
 const NON_COPYRIGHT_LABELS: &[TreeLabel] = &[];
 const NON_HOLDER_LABELS: &[TreeLabel] = &[TreeLabel::YrRange, TreeLabel::YrAnd];
 const NON_HOLDER_LABELS_MINI: &[TreeLabel] = &[TreeLabel::YrRange, TreeLabel::YrAnd];
@@ -403,7 +405,7 @@ pub fn detect_copyrights_from_text_with_deadline(
         author_heuristics::drop_weak_prose_authors(&raw_lines, &mut authors);
         dedupe_exact_span_copyrights(&mut copyrights);
         dedupe_exact_span_holders(&mut holders);
-        dedupe_exact_span_authors(&mut authors);
+        dedupe_overlapping_authors(&mut authors);
         return (copyrights, holders, authors);
     }
 
@@ -491,7 +493,7 @@ pub fn detect_copyrights_from_text_with_deadline(
 
     dedupe_exact_span_copyrights(&mut copyrights);
     dedupe_exact_span_holders(&mut holders);
-    dedupe_exact_span_authors(&mut authors);
+    dedupe_overlapping_authors(&mut authors);
 
     (copyrights, holders, authors)
 }
@@ -719,7 +721,7 @@ use pattern_extract::{
 };
 use postprocess_transforms::{
     add_missing_holders_for_bare_c_name_year_suffixes, deadline_exceeded,
-    dedupe_exact_span_authors, dedupe_exact_span_copyrights, dedupe_exact_span_holders,
+    dedupe_exact_span_copyrights, dedupe_exact_span_holders, dedupe_overlapping_authors,
     extend_authors_see_url_copyrights, extend_dash_obfuscated_email_suffixes,
     extend_leading_dash_suffixes, extend_multiline_copyright_c_no_year_names,
     extend_multiline_copyright_c_year_holder_continuations, extend_trailing_copy_year_suffixes,

--- a/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
+++ b/src/copyright/detector/postprocess_transforms/dedupe_and_shadow.rs
@@ -816,10 +816,21 @@ pub fn dedupe_exact_span_holders(holders: &mut Vec<HolderDetection>) {
     holders.retain(|h| seen.insert((h.start_line.get(), h.end_line.get(), h.holder.clone())));
 }
 
-pub fn dedupe_exact_span_authors(authors: &mut Vec<AuthorDetection>) {
+/// Collapse duplicate author values emitted for the same source occurrence,
+/// preferring the most precise nested span while preserving disjoint mentions.
+pub fn dedupe_overlapping_authors(authors: &mut Vec<AuthorDetection>) {
     if authors.len() < 2 {
         return;
     }
+    let originals = authors.clone();
+    authors.retain(|author| {
+        !originals.iter().any(|other| {
+            other.author == author.author
+                && other.start_line >= author.start_line
+                && other.end_line <= author.end_line
+                && (other.start_line > author.start_line || other.end_line < author.end_line)
+        })
+    });
     let mut seen: HashSet<(usize, usize, String)> = HashSet::new();
     authors.retain(|a| seen.insert((a.start_line.get(), a.end_line.get(), a.author.clone())));
 }

--- a/src/copyright/detector/postprocess_transforms_test.rs
+++ b/src/copyright/detector/postprocess_transforms_test.rs
@@ -116,6 +116,42 @@ fn test_refine_final_authors_keeps_named_collective() {
 }
 
 #[test]
+fn test_author_dedup_prefers_precise_overlapping_span() {
+    let mut authors = vec![
+        AuthorDetection {
+            author: "Nick Ing-Simmons".to_string(),
+            start_line: LineNumber::new(10).unwrap(),
+            end_line: LineNumber::new(11).unwrap(),
+        },
+        AuthorDetection {
+            author: "Nick Ing-Simmons".to_string(),
+            start_line: LineNumber::new(10).unwrap(),
+            end_line: LineNumber::new(10).unwrap(),
+        },
+        AuthorDetection {
+            author: "Nick Ing-Simmons".to_string(),
+            start_line: LineNumber::new(20).unwrap(),
+            end_line: LineNumber::new(20).unwrap(),
+        },
+    ];
+
+    dedupe_overlapping_authors(&mut authors);
+
+    assert_eq!(authors.len(), 2, "authors: {authors:?}");
+    assert!(
+        authors
+            .iter()
+            .any(|author| author.start_line == LineNumber::new(10).unwrap()
+                && author.end_line == LineNumber::new(10).unwrap())
+    );
+    assert!(
+        authors
+            .iter()
+            .any(|author| author.start_line == LineNumber::new(20).unwrap())
+    );
+}
+
+#[test]
 fn test_derive_holder_from_simple_copyright_string_keeps_iso_date_holder() {
     assert_eq!(
         derive_holder_from_simple_copyright_string("Copyright (c) 2006-07-24 John Boolage"),

--- a/src/copyright/mod.rs
+++ b/src/copyright/mod.rs
@@ -28,6 +28,7 @@ mod refiner;
 mod types;
 
 pub use credits::{detect_credits_authors, is_credits_file};
+pub(crate) use detector::is_pod_author_heading;
 pub(crate) use prepare::prepare_text_line;
 pub(crate) use refiner::has_copyright_year;
 pub(crate) use refiner::looks_like_source_code;

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -139,7 +139,9 @@ pub(super) fn extract_copyright_information(
             && !looks_like_source_code(&author.author)
             && (!looks_like_source_code(&raw_span)
                 || (has_author_contact_evidence(&author.author)
-                    && raw_span_has_author_attribution(&raw_span)))
+                    && raw_span_has_author_attribution(&raw_span))
+                || (raw_span_has_author_attribution(&raw_span)
+                    && span_is_in_pod_author_section(&raw_lines, author.start_line)))
             && seen_authors.insert((author.author.clone(), author.start_line, author.end_line))
     });
 
@@ -415,6 +417,27 @@ pub(super) fn has_author_contact_evidence(author: &str) -> bool {
 fn raw_span_has_author_attribution(raw_span: &str) -> bool {
     static BY_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)\bby\b").unwrap());
     BY_RE.is_match(raw_span)
+}
+
+fn span_is_in_pod_author_section(raw_lines: &[&str], start_line: LineNumber) -> bool {
+    static POD_HEADING_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^=head\d+\b").expect("valid POD heading regex"));
+    let start_index = start_line.get().saturating_sub(1).min(raw_lines.len());
+    raw_lines[..start_index]
+        .iter()
+        .rev()
+        .take(512)
+        .find_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.eq_ignore_ascii_case("=cut") {
+                Some(false)
+            } else if POD_HEADING_RE.is_match(trimmed) {
+                Some(copyright::is_pod_author_heading(trimmed))
+            } else {
+                None
+            }
+        })
+        == Some(true)
 }
 
 fn project_wrapped_copyright_value(rendered: &str, fallback: &str) -> Option<String> {

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1185,6 +1185,23 @@ fn test_extract_copyright_information_rejects_author_in_source_container() {
 }
 
 #[test]
+fn test_extract_copyright_information_keeps_attributed_author_in_pod_code_span() {
+    let text = concat!(
+        "=head1 Author and Modification History\n",
+        "\n",
+        "Renamed to C<Class::Struct> and modified by Jim Miner, 1997-04-02.\n",
+        "\n",
+        "=cut\n",
+    );
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("Struct.pm"), text, 120.0, false);
+
+    let file = build_single_file(builder);
+    assert_eq!(file.authors.len(), 1, "authors: {:?}", file.authors);
+    assert_eq!(file.authors[0].author, "Jim Miner");
+}
+
+#[test]
 fn test_extract_copyright_information_drops_code_line_with_embedded_email_literal() {
     // A C++ source line whose argument list embeds an email literal must still be
     // rejected: the namespace/address-of code signals are not bypassed by the


### PR DESCRIPTION
## Summary

- recognize action-backed credits inside bounded POD author sections, including `rewritten by`, `maintained by`, earlier-work, and help cues
- support explicit author-section heading variants such as `AUTHORS and MAINTENANCE` and `Author and Modification History`
- retain explicit contactless POD attributions through the scanner source-code guard and collapse only overlapping duplicate author spans

## Issues

- Covers: #1391

## Scope and exclusions

- Included: structurally bounded POD author sections and explicit attribution cues
- Explicit exclusions: free-form action prose outside author sections and uncertain attribution text

## How to verify

- Scan Perl 5.38.4 with `--copyright`: 42 source-backed authors are added across 35 files, with no removals; examples include Jim Miner, Andy Lester, Mark Biggar, Tels, the Perl Toolchain Gang, and the Perl 5 Porters.
- Scan InfoZIP 3.0 with `--copyright`: author, copyright, and holder output is unchanged.

## Intentional differences from Python

- This does not reproduce ScanCode's token rendering or its prose false positives. It uses ScanCode deltas to identify missing evidence, then recovers additional valid credits that ScanCode also misses, while preserving Provenant's bounded scanner contract.

## Follow-up work

- Created or intentionally deferred: none for bounded POD author action credits.
