### PR TITLE
fix(copyright): recover contact-backed action credits

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -242,11 +242,15 @@ fn trim_attribution_tail(who: &str) -> String {
 
 fn trim_contact_attribution_suffix(who: &str) -> String {
     static CONTACT_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?i)(?:<[^>\s]+@[^>\s]+>|\([^()\s]*@[^()]*\)|\b[\w.+-]+@[\w.-]+\.[a-z]{2,})")
+        Regex::new(r"(?i)(?:<[^>\s]+@[^>\s]+>|\([^()\s]*@[^()]*\)|\[[^\[\]\s]*@[^\[\]]*\]|\b[\w.+-]+@[\w.-]+\.[a-z]{2,})")
             .unwrap()
     });
-    static NON_AUTHOR_SUFFIX_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?i)^(?:(?:on\s+)?\d|in\s+\d{4}\b|for\s+\p{L})").unwrap());
+    static NON_AUTHOR_SUFFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^(?:(?:on\s+)?\d|in\s+\d{4}\b|for(?:\s|$)|(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+\d)",
+        )
+        .unwrap()
+    });
 
     let Some(contact) = CONTACT_RE.find_iter(who).last() else {
         return who.to_string();
@@ -398,19 +402,19 @@ fn extract_line_local_attribution_author(
 ) -> Option<String> {
     static ACTION_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)^(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:(?:written|authored|revised|overhauled|implemented)\s+by|original\s+by|(?:updated|modified|ported|adapted)(?:\s+to\s+.*?)?\s+by|(?:first|last)\s+modified\b.{0,40}?\s+by|merged\b.{0,80}?\s+by):?\s+(?P<who>.+)$",
+            r"(?i)^(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:(?:authored|configured|contributed|created|improved|implemented|overhauled|revised|written|[\p{L}\d][\p{L}\d-]{0,30}-ified)\s+by|original\s+by|(?:adapted|edited|modified|ported|updated)(?:\s+to\s+.*?)?\s+by|(?:first|last)\s+modified\b.{0,40}?\s+by|merged\b.{0,80}?\s+by)[ \t]*:?[ \t]+(?P<who>.+)$",
         )
         .unwrap()
     });
     static CONTACT_CONTRIBUTION_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)^(?:.{1,80}\s+)?(?:code|driver|hints?|kernel|stuff|support|work|patch(?:es)?|implementation|maintenance|module|program|software)\b.*\s+by\s+(?P<who>.+(?:@|\s+at\s+.+\s+dot\s+).*)$",
+            r"(?i)^(?:.{1,80}\s+)?(?:code|copy|driver|editor|hints?|kernel|stuff|support|work|patch(?:es)?|implementation|maintenance|module|program|software)\b.*\s+by\s+(?P<who>.+(?:@|\s+at\s+.+\s+dot\s+).*)$",
         )
         .unwrap()
     });
     static CONTACT_CHANGE_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)\b(?:backport(?:ed)?|changes?|fix(?:ed)?|reported|suggested|added|updated|modified|revised|overhauled|implemented|futzed|tweaked|threaded|enabled|done)\b[^\r\n]{0,120}?\bby\s+(?P<who>.+(?:@|\s+at\s+.+\s+dot\s+).*)$",
+            r"(?i)\b(?:backport(?:ed)?|changes?|fix(?:ed)?|reported|suggested|added|configured|contributed|edited|improved|updated|modified|revised|overhauled|implemented|futzed|tweaked|threaded|enabled|done)\b[^\r\n]{0,120}?\bby\s*:?[ \t]+(?P<who>.+(?:@|\s+at\s+.+\s+dot\s+).*)$",
         )
         .unwrap()
     });
@@ -439,6 +443,12 @@ fn extract_line_local_attribution_author(
         .or_else(|| CONTACT_CONTRIBUTION_BY_RE.captures(normalized))
         .or_else(|| CONTACT_CHANGE_BY_RE.captures(normalized))?;
     let who = captures.name("who")?.as_str().trim();
+    if normalized_lower.contains("configured by")
+        && who.split_whitespace().count() == 1
+        && who.contains('@')
+    {
+        return None;
+    }
     let has_contact = who.contains('@')
         || who.contains('<')
         || (who.to_ascii_lowercase().contains(" at ")

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -523,6 +523,12 @@ fn test_source_header_credit_variants_are_authors() {
         "# Last modified May 2020 by:\n",
         "# David Romano, david@example.net\n",
         "# Original by first@example.net, modified by second@example.net\n",
+        "# Configured by: Config Author, config@example.net\n",
+        "# Improved by Jake Hamby <jake@example.net> to support both compilers\n",
+        "# Originally contributed by: Mark Kettenis <mark@example.net> Dec 1998\n",
+        "# DCL-ified by Peter Prymmer <peter@example.net> 22-DEC-1995\n",
+        "(contributed by Peter J. Holzer, peter@example.net)\n",
+        "DataBase Editor by Janick Bergeron [janick@example.net] for testing\n",
     );
     let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
     let values: Vec<&str> = authors
@@ -538,6 +544,12 @@ fn test_source_header_credit_variants_are_authors() {
         "David Romano, david@example.net",
         "first@example.net",
         "second@example.net",
+        "Config Author, config@example.net",
+        "Jake Hamby <jake@example.net>",
+        "Mark Kettenis <mark@example.net>",
+        "Peter Prymmer <peter@example.net>",
+        "Peter J. Holzer, peter@example.net",
+        "Janick Bergeron janick@example.net",
     ] {
         assert!(values.contains(&expected), "missing {expected}: {values:?}");
     }
@@ -551,6 +563,8 @@ fn test_source_header_credit_words_without_people_are_not_authors() {
         "Compiler hints by default improve diagnostics.\n",
         "This file uses a compiler written by\n",
         "Jean Example. Send mail to support@example.net for a copy.\n",
+        "Configured by root@localhost\n",
+        "* Configured by     : root@localhost\n",
     );
     let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
 


### PR DESCRIPTION
## Summary

- recover explicit contact-backed action credits such as `Configured by`, `Improved by`, `Originally contributed by`, language-specific `-ified by`, and artifact-role `by` lines
- normalize bracketed contacts and bound trailing dates, project clauses, and chained attributions
- reject configured machine-account placeholders after consuming aligned punctuation

## Issues

- Covers: #1391

## Scope and exclusions

- Included: bounded action-attribution cues with contact evidence, plus contactless handling only in already-bounded author sections
- Explicit exclusions: broad prose attribution without contact or structural author context

## How to verify

- Scan Perl 5.38.4 with `--copyright` and compare against the parent: author records increase from 2,665 to 2,676, recovering 11 net explicit credits while splitting one chained README attribution into precise spans; copyright and holder records are unchanged.
- Scan InfoZIP 3.0 with the same flags and observe identical author, copyright, and holder records to the parent.
- Check that both `Configured by root@localhost` and aligned `Configured by     : root@localhost` produce no author.

## Intentional differences from Python

- ScanCode output is used as evidence, not a correctness target. This layer accepts bounded action vocabulary when a contact or author-section boundary proves intent, including valid credits that ScanCode misses.

## Follow-up work

- Created or intentionally deferred: contactless narrative attribution remains a separate benchmark-gated layer.

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: unit and scanner contracts cover the new behavior without changing checked-in golden output.