### PR TITLE
fix(copyright): recover narrative author attributions

### DIFF
--- a/src/copyright/detector/author_heuristics/cleanup.rs
+++ b/src/copyright/detector/author_heuristics/cleanup.rs
@@ -381,10 +381,19 @@ pub(in super::super) fn drop_shadowed_author_prefixes(authors: &mut Vec<AuthorDe
                 .trim_start_matches([',', ';'])
                 .trim_start()
                 .to_ascii_lowercase();
+            let ends_with_initial = candidate
+                .split_whitespace()
+                .next_back()
+                .map(|word| word.trim_matches(|ch: char| !ch.is_alphabetic()))
+                .is_some_and(|word| {
+                    let mut chars = word.chars();
+                    chars.next().is_some_and(char::is_uppercase) && chars.next().is_none()
+                });
             (other.end_line == author.end_line
                 && (tail.starts_with(',')
                     || tail.starts_with(';')
                     || normalized_tail.starts_with("and ")))
+                || (ends_with_initial && other.end_line >= author.end_line)
                 || normalized_tail.starts_with("with contributions from ")
                 || normalized_tail.starts_with("and contributions from ")
         })

--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -612,7 +612,19 @@ pub(in super::super) fn extract_subject_attribution_authors(
 ) -> Vec<AuthorDetection> {
     static SUBJECT_ATTRIBUTION_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)\b(?:was|were|is|are|has\s+been|have\s+been)\s+(?:originally\s+)?(?:written|created|authored|developed|maintained)\s+by\s+(?P<who>.+)$",
+            r"(?i)\b(?:was|were|is|are|has\s+been|have\s+been)\s+(?:originally\s+)?(?:written|rewritten|created|authored|developed|maintained)\s+by\s+(?P<who>.+)$",
+        )
+        .unwrap()
+    });
+    static FIRST_PERSON_ATTRIBUTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)\bas\s+authored\s+by\s+me,\s*(?P<who>.+?)(?:,\s*(?:(?:is|are|was|were)\b.*)?|$)",
+        )
+        .unwrap()
+    });
+    static PROVENANCE_ATTRIBUTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)\b(?:documentation|code|implementation|work|text|material)\b[^\r\n]{0,80}?\b(?:taken|copied|derived|adapted|borrowed)\s+from\b[^\r\n]{1,120}?\s+by\s+(?P<who>.+)$",
         )
         .unwrap()
     });
@@ -645,10 +657,6 @@ pub(in super::super) fn extract_subject_attribution_authors(
         let has_contact = raw_who.contains('@')
             || raw_who.contains('<')
             || (lower.contains(" at ") && lower.contains(" dot "));
-        if !has_contact && !in_pod_author_section {
-            continue;
-        }
-
         let mut who = NON_AUTHOR_CLAUSE_RE.replace(raw_who, "").into_owned();
         if let Some(contact_end) = who.find('>') {
             let tail = who[contact_end + 1..].trim_start();
@@ -664,11 +672,74 @@ pub(in super::super) fn extract_subject_attribution_authors(
         let Some(author) = refine_author(&who) else {
             continue;
         };
+        if !has_contact && !in_pod_author_section && !looks_like_contactless_person_name(&author) {
+            continue;
+        }
         authors.push(AuthorDetection {
             author,
             start_line: line.line_number,
             end_line: line.line_number,
         });
+    }
+
+    for line in prepared_cache.iter_non_empty() {
+        let next_line = prepared_cache.line(line.line_number.next());
+        let combined = next_line
+            .filter(|next| !next.prepared.is_empty())
+            .map(|next| format!("{} {}", line.prepared, next.prepared));
+        let matched = combined
+            .as_deref()
+            .and_then(|text| {
+                FIRST_PERSON_ATTRIBUTION_RE
+                    .captures(text)
+                    .and_then(|captures| {
+                        let who = captures.name("who")?;
+                        let full_match = captures.get(0)?;
+                        if full_match.start() >= line.prepared.len() {
+                            return None;
+                        }
+                        let end_line = if who.end() <= line.prepared.len() {
+                            line.line_number
+                        } else {
+                            next_line.map_or(line.line_number, |next| next.line_number)
+                        };
+                        Some((who.as_str(), end_line))
+                    })
+            })
+            .or_else(|| {
+                FIRST_PERSON_ATTRIBUTION_RE
+                    .captures(line.prepared)
+                    .and_then(|captures| captures.name("who"))
+                    .map(|who| (who.as_str(), line.line_number))
+            });
+        if let Some((raw_who, end_line)) = matched
+            && let Some(author) = refine_author(raw_who)
+            && looks_like_contactless_person_name(&author)
+        {
+            authors.push(AuthorDetection {
+                author,
+                start_line: line.line_number,
+                end_line,
+            });
+        }
+
+        let Some(raw_who) = PROVENANCE_ATTRIBUTION_RE
+            .captures(line.prepared)
+            .and_then(|captures| captures.name("who"))
+            .map(|who| who.as_str())
+        else {
+            continue;
+        };
+        let Some(author) = refine_author(raw_who) else {
+            continue;
+        };
+        if looks_like_contactless_person_name(&author) {
+            authors.push(AuthorDetection {
+                author,
+                start_line: line.line_number,
+                end_line: line.line_number,
+            });
+        }
     }
     authors
 }
@@ -939,6 +1010,55 @@ fn looks_like_plaintext_roster_author_candidate(who: &str) -> bool {
         && !words
             .iter()
             .any(|word| is_contributed_non_person_token(word))
+}
+
+fn looks_like_contactless_person_name(who: &str) -> bool {
+    const NAME_PARTICLES: &[&str] = &[
+        "al", "bin", "da", "de", "del", "della", "der", "di", "dos", "du", "la", "le", "van",
+        "von", "y",
+    ];
+
+    if who.contains('@') || who.chars().any(|ch| ch.is_ascii_digit()) {
+        return false;
+    }
+
+    let words: Vec<&str> = who.split_whitespace().collect();
+    if !(2..=6).contains(&words.len()) {
+        return false;
+    }
+
+    let mut uppercase_words = 0;
+    for word in words {
+        let normalized = word.trim_matches(|ch: char| {
+            !ch.is_alphabetic() && ch != '\'' && ch != '’' && ch != '.' && ch != '-'
+        });
+        if matches!(
+            normalized.to_ascii_lowercase().as_str(),
+            "archive"
+                | "compiler"
+                | "generator"
+                | "module"
+                | "package"
+                | "program"
+                | "project"
+                | "release"
+                | "software"
+                | "team"
+                | "tool"
+        ) {
+            return false;
+        }
+        let Some(first) = normalized.chars().find(|ch| ch.is_alphabetic()) else {
+            return false;
+        };
+        if first.is_uppercase() {
+            uppercase_words += 1;
+        } else if !NAME_PARTICLES.contains(&normalized.to_ascii_lowercase().as_str()) {
+            return false;
+        }
+    }
+
+    uppercase_words >= 2
 }
 
 fn looks_like_written_by_and_continuation(line: &str) -> bool {

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -435,6 +435,50 @@ fn test_subject_attribution_uses_bounded_pod_author_section() {
 }
 
 #[test]
+fn test_contactless_narrative_attributions_require_person_names() {
+    let input = concat!(
+        "Fcntl and Socket have been rewritten by Nicholas Clark to use the new API.\n",
+        "The entire library package, as authored by me, Ozan S.\n",
+        "Yigit, is hereby placed in the public domain.\n",
+        "The manual, as authored by me, Ada Lovelace,\n",
+        "Most of the documentation is taken from JSON::XS by Marc Lehmann\n",
+        "Archives were created by Release Tool 2.0.\n",
+        "This file is written by Callgrind, and it is upwards compatible.\n",
+        "Perl is developed by a global team of volunteers.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    for expected in [
+        "Nicholas Clark",
+        "Ozan S. Yigit",
+        "Ada Lovelace",
+        "Marc Lehmann",
+    ] {
+        assert!(values.contains(&expected), "missing {expected}: {values:?}");
+    }
+    for rejected in ["Release Tool", "Callgrind", "global team of volunteers"] {
+        assert!(
+            values.iter().all(|author| !author.contains(rejected)),
+            "unexpected {rejected}: {values:?}"
+        );
+    }
+    let ozan = authors
+        .iter()
+        .find(|author| author.author == "Ozan S. Yigit")
+        .expect("wrapped first-person attribution");
+    assert_eq!((ozan.start_line.get(), ozan.end_line.get()), (2, 3));
+    let ada = authors
+        .iter()
+        .find(|author| author.author == "Ada Lovelace")
+        .expect("single-line first-person attribution");
+    assert_eq!((ada.start_line.get(), ada.end_line.get()), (4, 4));
+}
+
+#[test]
 fn test_contact_backed_change_attributions_cover_varied_actions() {
     let input = concat!(
         "- Updated backport to 5.6.1 by Steffen Mueller <smueller@cpan.org>.\n",

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -140,6 +140,7 @@ pub(super) fn extract_copyright_information(
             && (!looks_like_source_code(&raw_span)
                 || (has_author_contact_evidence(&author.author)
                     && raw_span_has_author_attribution(&raw_span))
+                || raw_span_has_explicit_contactless_author_attribution(&raw_span)
                 || (raw_span_has_author_attribution(&raw_span)
                     && span_is_in_pod_author_section(&raw_lines, author.start_line)))
             && seen_authors.insert((author.author.clone(), author.start_line, author.end_line))
@@ -417,6 +418,16 @@ pub(super) fn has_author_contact_evidence(author: &str) -> bool {
 fn raw_span_has_author_attribution(raw_span: &str) -> bool {
     static BY_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)\bby\b").unwrap());
     BY_RE.is_match(raw_span)
+}
+
+fn raw_span_has_explicit_contactless_author_attribution(raw_span: &str) -> bool {
+    static EXPLICIT_ATTRIBUTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)\b(?:rewritten\s+by|as\s+authored\s+by\s+me,|(?:documentation|code|implementation|work|text|material)\b[^\r\n]{0,80}?\b(?:taken|copied|derived|adapted|borrowed)\s+from\b[^\r\n]{1,120}?\s+by)\b",
+        )
+        .expect("valid explicit contactless author attribution regex")
+    });
+    EXPLICIT_ATTRIBUTION_RE.is_match(raw_span)
 }
 
 fn span_is_in_pod_author_section(raw_lines: &[&str], start_line: LineNumber) -> bool {

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1202,6 +1202,25 @@ fn test_extract_copyright_information_keeps_attributed_author_in_pod_code_span()
 }
 
 #[test]
+fn test_extract_copyright_information_keeps_explicit_contactless_code_attributions() {
+    let text = concat!(
+        "Fcntl, Socket, and Sys::Syslog have been rewritten by Nicholas Clark to use the new API.\n",
+        "Most of the documentation is taken from JSON::XS by Marc Lehmann\n",
+    );
+    let mut builder = FileInfoBuilder::default();
+    extract_copyright_information(&mut builder, Path::new("Credits.pm"), text, 120.0, false);
+
+    let file = build_single_file(builder);
+    let values: Vec<&str> = file
+        .authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+    assert!(values.contains(&"Nicholas Clark"), "authors: {values:?}");
+    assert!(values.contains(&"Marc Lehmann"), "authors: {values:?}");
+}
+
+#[test]
 fn test_extract_copyright_information_drops_code_line_with_embedded_email_literal() {
     // A C++ source line whose argument list embeds an email literal must still be
     // rejected: the namespace/address-of code signals are not bypassed by the


### PR DESCRIPTION
## Summary

- recover contactless passive, first-person, and provenance-style author credits when the candidate has person-name structure
- join bounded wrapped first-person credits and remove incomplete initial-only prefixes once the full name is known
- preserve explicit narrative credits through the scanner source-code guard without weakening arbitrary source-code rejection

## Issues

- Covers: #1391

## Scope and exclusions

- Included: `rewritten by`, `as authored by me, Name`, and artifact provenance such as `documentation is taken from ... by Name`
- Explicit exclusions: tool names, generated artifacts, generic teams, numeric product identities, and arbitrary contactless `by` prose

## How to verify

- Scan Perl 5.38.4 with `--copyright`: exactly three author records are added over the parent—Nicholas Clark, Ozan S. Yigit, and Marc Lehmann—with no copyright or holder changes.
- Repeat on InfoZIP 3.0, musl, Dancer2, and Valgrind 3.25.1: author, copyright, and holder results are identical to the parent.
- Full common-profile compare artifacts: `.provenant/compare-runs/20260903T040653Z-perl-5.38.4-58241` and `.provenant/compare-runs/20260903T040825Z-zip30-58597`.

## Intentional differences from Python

- Provenant keeps the explicit Ozan S. Yigit credit that ScanCode misses and reports Marc Lehmann from the direct documentation provenance statement, while rejecting ScanCode author noise such as product names and prose fragments.
- Provenant keeps GPL references in InfoZIP change history as clues rather than treating removed GPL code as an applicable file license.

## Follow-up work

- Created or intentionally deferred: the common-profile InfoZIP review exposed one valid abbreviated-name credit (`Chr. Spieler`) still missing; that is isolated to the next stacked layer.

## Expected-output fixture changes

- Files changed: none
- Why the new expected output is correct: focused detector and scanner contracts cover the new behavior without changing checked-in golden output.