### PR TITLE
fix(copyright): recover chained action credits

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -490,6 +490,12 @@ pub(in super::super) fn extract_line_local_attribution_authors(
         )
         .unwrap()
     });
+    static CHAINED_SUBJECT_CREDIT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)^(?:this\s+)?[^,\r\n]{1,100}?\s+is\s+by\s+(?P<who>[^,;\r\n]{2,80}),\s*(?:adapted|authored|implemented|merged|modified|ported|revised|updated|written)\s+by\b",
+        )
+        .unwrap()
+    });
     let mut authors: Vec<AuthorDetection> = prepared_cache
         .iter_non_empty()
         .filter_map(|line| {
@@ -525,13 +531,31 @@ pub(in super::super) fn extract_line_local_attribution_authors(
         .collect();
 
     for line in prepared_cache.iter_non_empty() {
+        if let Some(author) = CHAINED_SUBJECT_CREDIT_RE
+            .captures(line.prepared)
+            .and_then(|captures| captures.name("who"))
+            .and_then(|matched| refine_author(matched.as_str()))
+            .filter(|author| looks_like_contactless_person_name(author))
+        {
+            authors.push(AuthorDetection {
+                author,
+                start_line: line.line_number,
+                end_line: line.line_number,
+            });
+        }
+
         let Some(clause) = CHAINED_ATTRIBUTION_CLAUSE_RE
             .captures(line.prepared)
             .and_then(|captures| captures.name("clause"))
         else {
             continue;
         };
-        let Some(author) = extract_line_local_attribution_author(clause.as_str(), false) else {
+        let Some(author) =
+            extract_line_local_attribution_author(clause.as_str(), false).or_else(|| {
+                let author = extract_line_local_attribution_author(clause.as_str(), true)?;
+                looks_like_contactless_person_name(&author).then_some(author)
+            })
+        else {
             continue;
         };
         authors.push(AuthorDetection {

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -1770,6 +1770,32 @@ fn test_chained_active_attributions_are_distinct_authors() {
 }
 
 #[test]
+fn test_chained_action_attribution_keeps_contactless_people() {
+    let input = concat!(
+        "Created by Rodney Brown from an earlier version, modified by Chr. Spieler.\n",
+        "This stat() is by Paul Wells, modified by Paul Kienitz.\n",
+        "Output created by Release Tool, modified by Build Generator.\n",
+        "The output is by default, modified by Build Generator.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(values.contains(&"Rodney Brown"), "authors: {values:?}");
+    assert!(values.contains(&"Chr. Spieler"), "authors: {values:?}");
+    assert!(values.contains(&"Paul Wells"), "authors: {values:?}");
+    assert!(values.contains(&"Paul Kienitz"), "authors: {values:?}");
+    assert!(
+        values
+            .iter()
+            .all(|author| !author.contains("Build Generator")),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
 fn test_wrapped_contribution_role_supports_leading_by_author() {
     let input = concat!(
         "AUTHORS\n",


### PR DESCRIPTION
## Summary

- Recover contactless people from explicit trailing action clauses such as `modified by NAME`.
- Recover the first credited person from bounded `subject is by NAME, modified by NAME` chains.
- Require person-shaped names so tool and generator subjects remain rejected.

## Issues

- Covers: #1391

## Scope and exclusions

- Included: line-local chained action attribution recovery.
- Explicit exclusions: unrelated source-comment prefixes and collective maintainer attribution, which are separate follow-up layers.

## How to verify

- Scan Info-ZIP 3.0 with `--copyright`; `win32/crc_i386.c` should include `Chr. Spieler`, and `amiga/stat.c` should include both `Paul Wells` and `Paul Kienitz`.
- The same before/after corpus scan leaves author output unchanged for Perl 5.38.4, musl, Dancer2, and Valgrind, and leaves copyright and holder output unchanged across all five targets.

## Intentional differences from Python

- Provenant additionally recovers `Paul Wells` from `This stat() is by Paul Wells, modified by Paul Kienitz`; ScanCode only reports the second person.

## Follow-up work

- Created or intentionally deferred: source-comment action credits and contactless collective maintainer credits will be handled in subsequent stacked PRs.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: focused unit coverage exercises the new positive and negative boundaries.