### PR TITLE
fix(copyright): recover source comment action credits

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -224,6 +224,15 @@ fn strip_leading_dash_bullet(line: &str) -> &str {
         .unwrap_or_else(|| line.trim())
 }
 
+fn strip_leading_source_credit_marker(line: &str) -> &str {
+    let trimmed = strip_leading_dash_bullet(line);
+    ["$!", "&"]
+        .iter()
+        .find_map(|marker| trimmed.strip_prefix(marker))
+        .map(str::trim_start)
+        .unwrap_or(trimmed)
+}
+
 fn trim_attribution_tail(who: &str) -> String {
     static WITH_HELP_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(?i)\s+with\s+the\s+help\s+of\b.*$").unwrap());
@@ -402,7 +411,7 @@ fn extract_line_local_attribution_author(
 ) -> Option<String> {
     static ACTION_BY_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)^(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:(?:authored|configured|contributed|created|improved|implemented|overhauled|revised|written|[\p{L}\d][\p{L}\d-]{0,30}-ified)\s+by|original\s+by|(?:adapted|edited|modified|ported|updated)(?:\s+to\s+.*?)?\s+by|(?:first|last)\s+modified\b.{0,40}?\s+by|merged\b.{0,80}?\s+by)[ \t]*:?[ \t]+(?P<who>.+)$",
+            r"(?i)^(?:original(?:ly)?\s+)?(?:original\s+driver\s+)?(?:(?:authored|configured|contributed|created|improved|implemented|overhauled|revised|[\p{L}\d][\p{L}\d-]{0,30}-ified)\s+by|written(?:\s+\d{1,4}[-/.]\d{1,2}[-/.]\d{1,4})?\s+by|original\s+by|(?:adapted|edited|modified|ported|updated)(?:\s+to\s+.*?)?\s+by|(?:first|last)\s+modified\b.{0,40}?\s+by|merged\b.{0,80}?\s+by)[ \t]*:?[ \t]+(?P<who>.+)$",
         )
         .unwrap()
     });
@@ -430,7 +439,7 @@ fn extract_line_local_attribution_author(
         Regex::new(r"(?i)^(?P<head>.*\b[\w.+-]+@[\w.-]+\.[a-z]{2,})(?:\.\s+|;\s+)[A-Z].*$").unwrap()
     });
 
-    let normalized = strip_leading_dash_bullet(line);
+    let normalized = strip_leading_source_credit_marker(line);
     let normalized_lower = normalized.to_ascii_lowercase();
     if normalized_lower.find(" by ").is_some_and(|by_index| {
         let prefix = &normalized_lower[..by_index];
@@ -496,6 +505,12 @@ pub(in super::super) fn extract_line_local_attribution_authors(
         )
         .unwrap()
     });
+    static INLINE_SENTENCE_ACTION_CREDIT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?i)[.;]\s*(?:adapted|authored|configured|contributed|created|developed|edited|implemented|improved|modified|ported|revised|updated|written)\s+by\s+(?P<who>[^,;\r\n]{2,80}),",
+        )
+        .unwrap()
+    });
     let mut authors: Vec<AuthorDetection> = prepared_cache
         .iter_non_empty()
         .filter_map(|line| {
@@ -531,6 +546,19 @@ pub(in super::super) fn extract_line_local_attribution_authors(
         .collect();
 
     for line in prepared_cache.iter_non_empty() {
+        if let Some(author) = INLINE_SENTENCE_ACTION_CREDIT_RE
+            .captures(line.prepared)
+            .and_then(|captures| captures.name("who"))
+            .and_then(|matched| refine_author(matched.as_str()))
+            .filter(|author| looks_like_contactless_person_name(author))
+        {
+            authors.push(AuthorDetection {
+                author,
+                start_line: line.line_number,
+                end_line: line.line_number,
+            });
+        }
+
         if let Some(author) = CHAINED_SUBJECT_CREDIT_RE
             .captures(line.prepared)
             .and_then(|captures| captures.name("who"))

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -571,6 +571,9 @@ fn test_source_header_credit_variants_are_authors() {
         "# Improved by Jake Hamby <jake@example.net> to support both compilers\n",
         "# Originally contributed by: Mark Kettenis <mark@example.net> Dec 1998\n",
         "# DCL-ified by Peter Prymmer <peter@example.net> 22-DEC-1995\n",
+        "$! DCL-ified by VMS Author <vms@example.net> 22-DEC-1995\n",
+        "& Written 02-05-05 by Macro Author (macro@example.net)\n",
+        "sub helper { # Compatibility code. Written by Alexandr Ciornii, version 0.23.\n",
         "(contributed by Peter J. Holzer, peter@example.net)\n",
         "DataBase Editor by Janick Bergeron [janick@example.net] for testing\n",
     );
@@ -592,6 +595,9 @@ fn test_source_header_credit_variants_are_authors() {
         "Jake Hamby <jake@example.net>",
         "Mark Kettenis <mark@example.net>",
         "Peter Prymmer <peter@example.net>",
+        "VMS Author <vms@example.net>",
+        "Macro Author (macro@example.net)",
+        "Alexandr Ciornii",
         "Peter J. Holzer, peter@example.net",
         "Janick Bergeron janick@example.net",
     ] {
@@ -609,6 +615,8 @@ fn test_source_header_credit_words_without_people_are_not_authors() {
         "Jean Example. Send mail to support@example.net for a copy.\n",
         "Configured by root@localhost\n",
         "* Configured by     : root@localhost\n",
+        "$! Written 02-05-05 by the build system\n",
+        "value & Written by Build Generator, then cached.\n",
     );
     let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
 

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -423,7 +423,7 @@ fn raw_span_has_author_attribution(raw_span: &str) -> bool {
 fn raw_span_has_explicit_contactless_author_attribution(raw_span: &str) -> bool {
     static EXPLICIT_ATTRIBUTION_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)\b(?:rewritten\s+by|as\s+authored\s+by\s+me,|(?:documentation|code|implementation|work|text|material)\b[^\r\n]{0,80}?\b(?:taken|copied|derived|adapted|borrowed)\s+from\b[^\r\n]{1,120}?\s+by)\b",
+            r"(?i)(?:\b(?:rewritten\s+by|as\s+authored\s+by\s+me,|(?:documentation|code|implementation|work|text|material)\b[^\r\n]{0,80}?\b(?:taken|copied|derived|adapted|borrowed)\s+from\b[^\r\n]{1,120}?\s+by)\b|[.;]\s*(?:adapted|authored|configured|contributed|created|developed|edited|implemented|improved|modified|ported|revised|updated|written)\s+by\b)",
         )
         .expect("valid explicit contactless author attribution regex")
     });

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1206,6 +1206,7 @@ fn test_extract_copyright_information_keeps_explicit_contactless_code_attributio
     let text = concat!(
         "Fcntl, Socket, and Sys::Syslog have been rewritten by Nicholas Clark to use the new API.\n",
         "Most of the documentation is taken from JSON::XS by Marc Lehmann\n",
+        "sub helper { # Compatibility code. Written by Alexandr Ciornii, version 0.23.\n",
     );
     let mut builder = FileInfoBuilder::default();
     extract_copyright_information(&mut builder, Path::new("Credits.pm"), text, 120.0, false);
@@ -1218,6 +1219,7 @@ fn test_extract_copyright_information_keeps_explicit_contactless_code_attributio
         .collect();
     assert!(values.contains(&"Nicholas Clark"), "authors: {values:?}");
     assert!(values.contains(&"Marc Lehmann"), "authors: {values:?}");
+    assert!(values.contains(&"Alexandr Ciornii"), "authors: {values:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Normalize bounded DCL and VOS comment prefixes before evaluating explicit author actions.
- Support date-qualified `written by` source-header credits.
- Recover comma-delimited action-credit sentences embedded in source lines while requiring a person-shaped name.
- Preserve those explicit attributions through the scanner guard for code-shaped spans.

## Issues

- Covers: #1391

## Scope and exclusions

- Included: explicit action credits in source comments and code-adjacent comment sentences.
- Explicit exclusions: collective maintainer credits, handled in the next stacked layer.

## How to verify

- Scan Perl 5.38.4 with `--copyright`; `vms/myconfig.com`, `vos/compile_full_perl.cm`, and `cpan/Win32API-File/Makefile.PL` should report Peter Prymmer, Paul Green, and Alexandr Ciornii respectively.
- Before/after corpus scans add exactly those three authors; Info-ZIP, musl, Dancer2, and Valgrind author output is unchanged, and copyright/holder output is unchanged across all five targets.

## Intentional differences from Python

- None for the three motivating credits; the implementation is evidence-bounded rather than mirroring ScanCode internals.

## Follow-up work

- Created or intentionally deferred: contactless collective maintainer credits and mixed author/copyright POD headings remain for the next stacked PR.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: detector and scanner tests cover the new source-comment boundaries.