### PR TITLE
fix(copyright): recognize mixed POD author headings

### DIFF
--- a/src/copyright/detector/author_heuristics/pod_sections.rs
+++ b/src/copyright/detector/author_heuristics/pod_sections.rs
@@ -15,7 +15,7 @@ use super::refine_particle_name;
 pub(crate) fn is_pod_author_heading(line: &str) -> bool {
     static AUTHOR_HEADING_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)^=head\d+\s+authors?(?:\s+(?:and|&)\s+(?:maintenance|maintainers?|modification\s+history))?\s*$",
+            r"(?i)^=head\d+\s+authors?(?:\s*(?:,?\s*(?:and|&)|,)\s*(?:copyright(?:\s+information)?|license|maintenance|maintainers?|modification\s+history))*\s*$",
         )
         .expect("valid POD author heading regex")
     });
@@ -518,7 +518,21 @@ pub(in super::super) fn extract_pod_author_section_narrative_credit_authors(
 
 #[cfg(test)]
 mod tests {
-    use super::contactless_author_values;
+    use super::{contactless_author_values, is_pod_author_heading};
+
+    #[test]
+    fn mixed_author_headings_remain_author_sections() {
+        for heading in [
+            "=head1 AUTHOR AND COPYRIGHT",
+            "=head1 Author and Copyright Information",
+            "=head2 AUTHOR, COPYRIGHT, AND LICENSE",
+            "=head3 AUTHORS & MAINTENANCE",
+        ] {
+            assert!(is_pod_author_heading(heading), "heading: {heading}");
+        }
+        assert!(!is_pod_author_heading("=head1 COPYRIGHT"));
+        assert!(!is_pod_author_heading("=head1 AUTHOR AND DESCRIPTION"));
+    }
 
     #[test]
     fn contactless_rosters_keep_particle_names_and_mixed_collectives() {

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -675,6 +675,34 @@ fn test_bounded_pod_author_action_credits_are_authors() {
 }
 
 #[test]
+fn test_mixed_pod_author_copyright_heading_keeps_maintainer_credit() {
+    let input = concat!(
+        "=head1 AUTHOR AND COPYRIGHT\n",
+        "\n",
+        "Copyright 2013 Tom Christiansen; now maintained by Perl5 Porters.\n",
+        "\n",
+        "This documentation is free and may be redistributed.\n",
+        "\n",
+        "=head1 DESCRIPTION\n",
+        "\n",
+        "The output is maintained by Build Generator.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(values.contains(&"Perl5 Porters"), "authors: {values:?}");
+    assert!(
+        values
+            .iter()
+            .all(|author| !author.contains("Build Generator")),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
 fn test_pod_author_modification_history_recovers_embedded_action_credit() {
     let input = concat!(
         "=head1 Author and Modification History\n",


### PR DESCRIPTION
## Summary

- Treat bounded POD headings that combine `AUTHOR(S)` with copyright, license, maintenance, or modification-history topics as author sections.
- Accept common separator and casing variants without treating copyright-only or unrelated mixed headings as author evidence.
- Keep the existing bounded section termination rules intact.

## Issues

- Covers: #1391

## Scope and exclusions

- Included: POD author-section heading classification.
- Explicit exclusions: maintainer credits outside bounded author sections, handled separately.

## How to verify

- Scan Perl 5.38.4 with `--copyright`; `pod/perlopentut.pod`, `pod/perlretut.pod`, and `cpan/libnet/lib/Net/libnetFAQ.pod` should recover their maintainer credits.
- Before/after corpus scans add exactly those three valid findings; Info-ZIP, musl, Dancer2, and Valgrind author output is unchanged, and copyright/holder output is unchanged across all five targets.

## Intentional differences from Python

- Provenant recognizes the section structurally and keeps richer contact data where present instead of relying on ScanCode rendering.

## Follow-up work

- Created or intentionally deferred: explicit collective maintainer credits outside author sections remain for the next stacked PR.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: focused unit coverage verifies accepted and rejected heading shapes plus bounded extraction behavior.