### PR TITLE
fix(copyright): recover collective maintainer credits

### DIFF
--- a/src/copyright/detector/author_heuristics/extraction.rs
+++ b/src/copyright/detector/author_heuristics/extraction.rs
@@ -276,7 +276,8 @@ fn trim_contact_attribution_suffix(who: &str) -> String {
 
 fn trim_following_sentence_clause(who: &str) -> String {
     static FOLLOWING_SENTENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?is)^(?P<head>.+?)\.\s+(?:it|this|these|those|the|a|an|no)\b.*$").unwrap()
+        Regex::new(r"(?is)^(?P<head>.+?)\.\s+(?:it|this|these|those|the|a|an|no|please|thus)\b.*$")
+            .unwrap()
     });
 
     let trimmed = who.trim();
@@ -664,7 +665,7 @@ pub(in super::super) fn extract_subject_attribution_authors(
 ) -> Vec<AuthorDetection> {
     static SUBJECT_ATTRIBUTION_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)\b(?:was|were|is|are|has\s+been|have\s+been)\s+(?:originally\s+)?(?:written|rewritten|created|authored|developed|maintained)\s+by\s+(?P<who>.+)$",
+            r"(?i)\b(?:was|were|is|are|has\s+been|have\s+been)\s+(?:(?:currently|now|originally)\s+)?(?:written|rewritten|created|authored|developed|maintained)\s+by\s+(?P<who>.+)$",
         )
         .unwrap()
     });
@@ -720,11 +721,19 @@ pub(in super::super) fn extract_subject_attribution_authors(
         {
             who = head.as_str().to_string();
         }
-        let who = trim_attribution_tail(&who);
-        let Some(author) = refine_author(&who) else {
+        let who = trim_attribution_tail(&trim_following_sentence_clause(&who));
+        let Some(author) = looks_like_contactless_named_collective(&who)
+            .then(|| who.to_string())
+            .or_else(|| refine_notice_collective_author(&who))
+            .or_else(|| refine_author(&who))
+        else {
             continue;
         };
-        if !has_contact && !in_pod_author_section && !looks_like_contactless_person_name(&author) {
+        if !has_contact
+            && !in_pod_author_section
+            && !looks_like_contactless_person_name(&author)
+            && !looks_like_contactless_named_collective(&author)
+        {
             continue;
         }
         authors.push(AuthorDetection {
@@ -1111,6 +1120,43 @@ fn looks_like_contactless_person_name(who: &str) -> bool {
     }
 
     uppercase_words >= 2
+}
+
+fn looks_like_contactless_named_collective(who: &str) -> bool {
+    const COLLECTIVE_WORDS: &[&str] = &[
+        "authors",
+        "committers",
+        "contributors",
+        "developers",
+        "foundation",
+        "gang",
+        "group",
+        "maintainers",
+        "porters",
+        "team",
+    ];
+    const GENERIC_WORDS: &[&str] = &["a", "an", "project", "the"];
+
+    if who.contains('@') || who.split_whitespace().count() > 8 {
+        return false;
+    }
+
+    let words: Vec<&str> = who
+        .split(|ch: char| !ch.is_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .collect();
+    let has_collective_word = words
+        .iter()
+        .any(|word| COLLECTIVE_WORDS.contains(&word.to_ascii_lowercase().as_str()));
+    let has_named_identity = words.iter().any(|word| {
+        let lower = word.to_ascii_lowercase();
+        !GENERIC_WORDS.contains(&lower.as_str())
+            && !COLLECTIVE_WORDS.contains(&lower.as_str())
+            && (word.chars().any(|ch| ch.is_uppercase())
+                || word.chars().any(|ch| ch.is_ascii_digit()))
+    });
+
+    has_collective_word && has_named_identity
 }
 
 fn looks_like_written_by_and_continuation(line: &str) -> bool {

--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -479,6 +479,34 @@ fn test_contactless_narrative_attributions_require_person_names() {
 }
 
 #[test]
+fn test_subject_maintainer_attribution_keeps_named_collectives() {
+    let input = concat!(
+        "Filter::Simple is now maintained by the Perl5-Porters. Please submit bugs.\n",
+        "This package is currently maintained by the Perl Toolchain Gang.\n",
+        "This package is now maintained by the Safe Team. Thus, use the supported API.\n",
+        "The cache is maintained by the package manager.\n",
+    );
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(input);
+    let values: Vec<&str> = authors
+        .iter()
+        .map(|author| author.author.as_str())
+        .collect();
+
+    assert!(values.contains(&"the Perl5-Porters"), "authors: {values:?}");
+    assert!(
+        values.contains(&"the Perl Toolchain Gang"),
+        "authors: {values:?}"
+    );
+    assert!(values.contains(&"the Safe Team"), "authors: {values:?}");
+    assert!(
+        values
+            .iter()
+            .all(|author| !author.contains("package manager")),
+        "authors: {values:?}"
+    );
+}
+
+#[test]
 fn test_contact_backed_change_attributions_cover_varied_actions() {
     let input = concat!(
         "- Updated backport to 5.6.1 by Steffen Mueller <smueller@cpan.org>.\n",

--- a/src/scanner/process/copyright.rs
+++ b/src/scanner/process/copyright.rs
@@ -423,7 +423,7 @@ fn raw_span_has_author_attribution(raw_span: &str) -> bool {
 fn raw_span_has_explicit_contactless_author_attribution(raw_span: &str) -> bool {
     static EXPLICIT_ATTRIBUTION_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"(?i)(?:\b(?:rewritten\s+by|as\s+authored\s+by\s+me,|(?:documentation|code|implementation|work|text|material)\b[^\r\n]{0,80}?\b(?:taken|copied|derived|adapted|borrowed)\s+from\b[^\r\n]{1,120}?\s+by)\b|[.;]\s*(?:adapted|authored|configured|contributed|created|developed|edited|implemented|improved|modified|ported|revised|updated|written)\s+by\b)",
+            r"(?i)(?:\b(?:rewritten\s+by|(?:is|are)\s+(?:currently\s+|now\s+)?maintained\s+by|as\s+authored\s+by\s+me,|(?:documentation|code|implementation|work|text|material)\b[^\r\n]{0,80}?\b(?:taken|copied|derived|adapted|borrowed)\s+from\b[^\r\n]{1,120}?\s+by)\b|[.;]\s*(?:adapted|authored|configured|contributed|created|developed|edited|implemented|improved|modified|ported|revised|updated|written)\s+by\b)",
         )
         .expect("valid explicit contactless author attribution regex")
     });

--- a/src/scanner/process/copyright_test.rs
+++ b/src/scanner/process/copyright_test.rs
@@ -1207,6 +1207,7 @@ fn test_extract_copyright_information_keeps_explicit_contactless_code_attributio
         "Fcntl, Socket, and Sys::Syslog have been rewritten by Nicholas Clark to use the new API.\n",
         "Most of the documentation is taken from JSON::XS by Marc Lehmann\n",
         "sub helper { # Compatibility code. Written by Alexandr Ciornii, version 0.23.\n",
+        "Filter::Simple is now maintained by the Perl5-Porters. Please submit bugs.\n",
     );
     let mut builder = FileInfoBuilder::default();
     extract_copyright_information(&mut builder, Path::new("Credits.pm"), text, 120.0, false);
@@ -1220,6 +1221,7 @@ fn test_extract_copyright_information_keeps_explicit_contactless_code_attributio
     assert!(values.contains(&"Nicholas Clark"), "authors: {values:?}");
     assert!(values.contains(&"Marc Lehmann"), "authors: {values:?}");
     assert!(values.contains(&"Alexandr Ciornii"), "authors: {values:?}");
+    assert!(values.contains(&"the Perl5-Porters"), "authors: {values:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Recover explicit passive maintainer attributions for short named collectives outside bounded author sections.
- Require a collective role noun plus a distinct identity token, while rejecting unqualified package-manager prose.
- Stop at common following-sentence boundaries and preserve explicit collective evidence through code-shaped-span filtering.

## Issues

- Covers: #1391

## Scope and exclusions

- Included: `is/are [now/currently] maintained by` collective credits.
- Explicit exclusions: vague role descriptions without a named identity.

## How to verify

- Scan Perl 5.38.4 with `--copyright`; `dist/Filter-Simple/lib/Filter/Simple.pm` and `dist/Safe/README` should report their Perl Porters collectives.
- Before/after corpus scans add exactly those two valid authors and tighten one existing author span; Info-ZIP, musl, Dancer2, and Valgrind output is unchanged, and copyright/holder output is unchanged across all five targets.

## Intentional differences from Python

- These two collective credits are Provenant improvements beyond ScanCode output on the benchmark target.

## Follow-up work

- Created or intentionally deferred: none identified for this attribution family.

## Expected-output fixture changes

- Files changed: none.
- Why the new expected output is correct: focused detector and scanner tests cover named collectives, sentence boundaries, and non-author prose.