### PR TITLE
fix(copyright): reject schema field author candidates

### DIFF
--- a/src/copyright/detector/author_heuristics_test.rs
+++ b/src/copyright/detector/author_heuristics_test.rs
@@ -2088,3 +2088,20 @@ fn test_originally_by_author() {
         a
     );
 }
+
+#[test]
+fn test_schema_author_column_does_not_create_an_author() {
+    let content = "\
+CREATE TABLE author(
+    id INTEGER PRIMARY KEY,
+    name text NOT NULL
+);
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,
+    author INTEGER REFERENCES author (id),
+    title text NOT NULL
+);";
+    let (_copyrights, _holders, authors) = super::super::detect_copyrights_from_text(content);
+
+    assert!(authors.is_empty(), "authors: {authors:?}");
+}

--- a/src/copyright/refiner/author.rs
+++ b/src/copyright/refiner/author.rs
@@ -100,6 +100,10 @@ pub fn refine_author(s: &str) -> Option<String> {
         return None;
     }
 
+    if looks_like_schema_declaration_fragment(&a) {
+        return None;
+    }
+
     if contains_code_call_fragment(&a) {
         return None;
     }

--- a/src/copyright/refiner/junk.rs
+++ b/src/copyright/refiner/junk.rs
@@ -924,6 +924,68 @@ pub(super) fn looks_like_generic_field_label_token(s: &str) -> bool {
     is_explicit_generic_field_label_token(s) || looks_like_generic_field_label_shape(s)
 }
 
+/// Return true if an author candidate is the type-and-constraint tail of a
+/// relational schema field, such as `INTEGER REFERENCES (id)`.
+///
+/// Author grammars can encounter a column named `author` and interpret the
+/// remainder of its declaration as a credited party. Requiring both a leading
+/// SQL data type and a structural constraint keeps this bounded to declarations
+/// rather than rejecting organizations whose names happen to contain words such
+/// as "Integer" or "Text".
+pub(super) fn looks_like_schema_declaration_fragment(s: &str) -> bool {
+    const DATA_TYPES: &[&str] = &[
+        "bigint",
+        "binary",
+        "blob",
+        "bool",
+        "boolean",
+        "char",
+        "date",
+        "decimal",
+        "double",
+        "float",
+        "int",
+        "integer",
+        "numeric",
+        "real",
+        "serial",
+        "smallint",
+        "text",
+        "timestamp",
+        "uuid",
+        "varchar",
+    ];
+
+    let trimmed = s.trim();
+    if trimmed.is_empty() || trimmed.len() > 160 {
+        return false;
+    }
+
+    let words: Vec<String> = trimmed
+        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_')
+        .filter(|word| !word.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect();
+    if !words
+        .first()
+        .is_some_and(|word| DATA_TYPES.contains(&word.as_str()))
+    {
+        return false;
+    }
+
+    let has_pair = |left: &str, right: &str| {
+        words
+            .windows(2)
+            .any(|pair| pair[0] == left && pair[1] == right)
+    };
+    let has_parenthesized_constraint = (words.iter().any(|word| word == "references")
+        || words.iter().any(|word| word == "check"))
+        && trimmed.contains('(')
+        && trimmed.contains(')');
+
+    has_parenthesized_constraint || has_pair("primary", "key") || has_pair("not", "null")
+}
+
 pub(super) fn contains_code_call_fragment(s: &str) -> bool {
     static NATURAL_PAREN_VARIANT_RE: LazyLock<Regex> = LazyLock::new(|| {
         compile_static_regex(r"\b[a-z][a-z-]{5,}\((?:-)?[a-z-]{1,8}\)(?:$|[^A-Za-z0-9_])")

--- a/src/copyright/refiner/tests.rs
+++ b/src/copyright/refiner/tests.rs
@@ -2795,6 +2795,18 @@ fn test_refine_author_drops_code_call_and_graphql_fragments() {
 }
 
 #[test]
+fn test_refine_author_drops_schema_declaration_fragments() {
+    assert_eq!(refine_author("INTEGER REFERENCES (id)"), None);
+    assert_eq!(refine_author("VARCHAR(255) NOT NULL"), None);
+    assert_eq!(refine_author("INTEGER PRIMARY KEY"), None);
+    assert_eq!(refine_author("TEXT CHECK (length(name) > 0)"), None);
+    assert_eq!(
+        refine_author("Integer Research Group"),
+        Some("Integer Research Group".to_string())
+    );
+}
+
+#[test]
 fn test_refine_author_drops_point_to_the_phrase() {
     assert_eq!(refine_author("point to the"), None);
 }


### PR DESCRIPTION
## Summary

- reject author candidates that structurally match a SQL type-and-constraint field declaration
- preserve ordinary names that merely begin with a type-like word
- cover the Dancer2 schema false positive with refiner and end-to-end regression tests

## Issues

- Covers: follow-up found during final validation of #1391

## Scope and exclusions

- Included: bounded author-candidate refinement for relational schema fragments
- Explicit exclusions: no broad SQL file suppression and no ScanCode-output imitation

## How to verify

- Scan Dancer2 and confirm `lib/Dancer2/Manual/Cookbook.pod` no longer reports `INTEGER REFERENCES (id)` as an author while `Dancer Core` and `Dancer Core Developers` remain.

## Intentional differences from Python

- Provenant retains the genuine `Dancer Core Developers` attribution that ScanCode misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)