### PR TITLE
fix(cli): preserve case-distinct paths-file entries

### DIFF
--- a/src/scan_result_shaping/selection.rs
+++ b/src/scan_result_shaping/selection.rs
@@ -91,7 +91,9 @@ pub(crate) fn resolve_paths_file_entries(
     let mut selections = Vec::new();
     let mut frontier = Vec::new();
     let mut missing_entries = Vec::new();
-    let mut seen = HashSet::new();
+    let mut seen_frontier_entries = HashSet::new();
+    let mut seen_selections = HashSet::new();
+    let mut seen_missing_entries = HashSet::new();
 
     for entry in entries {
         let Some(normalized) = normalize_paths_file_entry(entry)? else {
@@ -101,14 +103,18 @@ pub(crate) fn resolve_paths_file_entries(
         let absolute = scan_root.join(&normalized);
         if absolute.exists() {
             let selection = build_selected_path(&normalized, absolute.is_dir());
-            if seen.insert(selection_cache_key(&selection)) {
+            // Preserve real case variants while collapsing aliases on case-insensitive filesystems.
+            let frontier_key = fs::canonicalize(&absolute).unwrap_or_else(|_| absolute.clone());
+            if seen_frontier_entries.insert(frontier_key) {
                 frontier.push(CollectionFrontier {
                     path: PathBuf::from(&normalized),
                     recurse: absolute.is_dir(),
                 });
+            }
+            if seen_selections.insert(selection_cache_key(&selection)) {
                 selections.push(selection);
             }
-        } else if seen.insert(format!("missing:{normalized}")) {
+        } else if seen_missing_entries.insert(normalized.clone()) {
             missing_entries.push(normalized);
         }
     }

--- a/src/scan_result_shaping/selection_test.rs
+++ b/src/scan_result_shaping/selection_test.rs
@@ -273,6 +273,87 @@ fn resolve_paths_file_entries_normalizes_existing_entries_and_tracks_missing() {
 }
 
 #[test]
+fn resolve_paths_file_entries_preserves_case_distinct_frontier_entries() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let scan_root = temp_dir.path().join("repo");
+    fs::create_dir_all(&scan_root).expect("create scan root");
+    fs::write(
+        scan_root.join("Example.js"),
+        "// SPDX-License-Identifier: MIT\n",
+    )
+    .expect("write mixed-case file");
+    fs::write(
+        scan_root.join("example.js"),
+        "// SPDX-License-Identifier: Apache-2.0\n",
+    )
+    .expect("write lowercase file");
+
+    let resolved = resolve_paths_file_entries(
+        &scan_root,
+        &[
+            "Example.js".to_string(),
+            "example.js".to_string(),
+            "./Example.js".to_string(),
+        ],
+    )
+    .expect("case-distinct paths file entries should resolve");
+
+    let case_distinct_files = fs::canonicalize(scan_root.join("Example.js"))
+        .expect("canonicalize mixed-case file")
+        != fs::canonicalize(scan_root.join("example.js")).expect("canonicalize lowercase file");
+    let expected_frontier = if case_distinct_files {
+        vec![
+            CollectionFrontier {
+                path: PathBuf::from("Example.js"),
+                recurse: false,
+            },
+            CollectionFrontier {
+                path: PathBuf::from("example.js"),
+                recurse: false,
+            },
+        ]
+    } else {
+        vec![CollectionFrontier {
+            path: PathBuf::from("Example.js"),
+            recurse: false,
+        }]
+    };
+
+    assert_eq!(
+        resolved.selections,
+        vec![SelectedPath::Exact("example.js".to_string())]
+    );
+    assert_eq!(resolved.frontier, expected_frontier);
+    assert!(resolved.missing_entries.is_empty());
+
+    let mut collected =
+        crate::scanner::collect_selected_paths(&scan_root, &resolved.frontier, 0, &[]);
+    assert!(collected.collection_errors.is_empty());
+    assert_eq!(
+        apply_user_path_filters_to_collected(
+            &mut collected,
+            &scan_root,
+            &resolved.selections,
+            &[],
+            &[],
+        ),
+        0
+    );
+    let mut collected_paths = collected
+        .files
+        .iter()
+        .map(|(path, _)| normalize_scan_relative_path(path, &scan_root))
+        .collect::<Vec<_>>();
+    collected_paths.sort();
+    let expected_paths = if case_distinct_files {
+        vec!["Example.js", "example.js"]
+    } else {
+        vec!["Example.js"]
+    };
+    assert_eq!(collected_paths, expected_paths);
+}
+
+#[test]
 fn resolve_paths_file_entries_rejects_entries_that_escape_root() {
     let temp_dir = tempfile::tempdir().expect("tempdir");
     let scan_root = temp_dir.path().join("repo");


### PR DESCRIPTION
## Summary

- Preserve the original case of each normalized `--paths-file` entry when deduplicating the direct collection frontier.
- Keep case-insensitive selection matching independently deduplicated, avoiding redundant filters without dropping case-distinct files.
- Cover case-distinct collection and exact normalized repeat deduplication in a focused regression test.

## Issues

- Closes #1430

## Scope and exclusions

- Included: `--paths-file` resolution, frontier construction, and regression coverage through collection and selection filtering.
- Explicit exclusions: `--include`/`--exclude` glob semantics and ordinary directory discovery are unchanged.

## How to verify

- On a case-sensitive filesystem, run the issue reproduction with `Example.js` and `example.js`; confirm both file entries appear with their respective license detections. Add `./Example.js` to the paths file and confirm the normalized repeat does not add a third entry.

## Expected-output fixture changes

- Files changed: None.
- Why the new expected output is correct: The behavior is covered by focused Rust assertions rather than serialized golden output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
