### PR TITLE
docs(benchmarks): record decimal.js-light comparison

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,7 +12,7 @@ The chart below uses a log-log scatter plot: file count on the x-axis, wall-cloc
 
 ![Scan duration vs. file count for Provenant and ScanCode](scan-duration-vs-files.svg)
 
-> Provenant is faster on 254 of 254 recorded runs, with a **19.7× median speedup** and **19.7× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **37.2×** on 10k+ file targets.
+> Provenant is faster on 255 of 255 recorded runs, with a **19.6× median speedup** and **19.6× geometric-mean speedup** overall; the median gap grows from **9.1×** on sub-100-file targets to **37.2×** on 10k+ file targets.
 > Generated from the benchmark timing rows in this document via `cargo run --manifest-path xtask/Cargo.toml --bin generate-benchmark-chart`.
 
 ## Current benchmark examples
@@ -449,6 +449,13 @@ The quick index below links to benchmark sections. Each benchmark entry then rec
 - Run context: 2026-06-23 · macOS 26.5.1 · Apple M5 Pro · 64 GB · arm64 · 4 proc
 - Timing: Provenant `40.89s`; ScanCode `1763.40s`
 - Broader monorepo package and dependency extraction (`138` vs `1` packages, `7720` vs `1815` dependencies) from the root `package-lock.json`, many extension fixture manifests and lockfiles, and embedded Cargo/Docker metadata, plus richer named package identities where ScanCode emits generic lockfile and archive rows
+
+##### [MikeMcl/decimal.js-light @ b2b0c28](https://github.com/MikeMcl/decimal.js-light/tree/b2b0c28e04e4f96d21450d2075ea36064fc9e22d) — **10.08× faster**
+
+- Files: 46
+- Run context: 2026-09-09 · macOS 26.6.2 · Apple M5 Pro · 64 GB · arm64 · 4 proc
+- Timing: Provenant `4.67s`; ScanCode `47.09s`
+- Matched npm package, license, copyright, author, email, and file coverage, with richer assembled holder attribution from manifest author metadata and broader explicit URL capture for README image targets and API documentation links that ScanCode omits
 
 ##### [npm/cli @ 05dbba5](https://github.com/npm/cli/tree/05dbba5b8d727ddb2c098ce0553714eae791c5f2) — **40.20× faster**
 

--- a/docs/scan-duration-vs-files.svg
+++ b/docs/scan-duration-vs-files.svg
@@ -170,6 +170,9 @@ ScanCode: 57.03s</title></rect>
     <rect x="349.56" y="448.21" width="8" height="8" fill="#d97706" rx="1.5"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 ScanCode: 44.92s</title></rect>
+    <rect x="355.82" y="445.99" width="8" height="8" fill="#d97706" rx="1.5"><title>MikeMcl/decimal.js-light @ b2b0c28
+Files: 46
+ScanCode: 47.09s</title></rect>
     <rect x="357.31" y="446.42" width="8" height="8" fill="#d97706" rx="1.5"><title>UCBoulder/tardigrade_micromorphic_tools @ d03a8ca
 Files: 47
 ScanCode: 46.66s</title></rect>
@@ -934,6 +937,9 @@ Provenant: 5.12s</title></circle>
     <circle cx="353.56" cy="555.95" r="4.5" fill="#2563eb"><title>marshallpierce/rust-base64 @ 13f4fe8
 Files: 42
 Provenant: 5.00s</title></circle>
+    <circle cx="359.82" cy="559.18" r="4.5" fill="#2563eb"><title>MikeMcl/decimal.js-light @ b2b0c28
+Files: 46
+Provenant: 4.67s</title></circle>
     <circle cx="361.31" cy="546.87" r="4.5" fill="#2563eb"><title>UCBoulder/tardigrade_micromorphic_tools @ d03a8ca
 Files: 47
 Provenant: 6.06s</title></circle>


### PR DESCRIPTION
## Summary

- Record a benchmark-grade `common` comparison for `MikeMcl/decimal.js-light` at immutable revision `b2b0c28e04e4f96d21450d2075ea36064fc9e22d`.
- Document matched package, license, copyright, author, email, and file coverage, plus source-backed Provenant advantages in holder and URL extraction.
- Regenerate the benchmark chart and aggregate headline for 255 recorded runs.

Compare artifacts: `.provenant/compare-runs/20260909T081928Z-decimal.js-light-13251/`

## Issues

- Covers: benchmark follow-up to merged PR #1431.

## Scope and exclusions

- Included: benchmark evidence and generated benchmark documentation.
- Explicit exclusions: no scanner changes were needed because the comparison had zero ScanCode-favored signals.

## How to verify

- Run `cargo run --manifest-path xtask/Cargo.toml --bin compare-outputs -- --repo-url https://github.com/MikeMcl/decimal.js-light.git --repo-ref b2b0c28e04e4f96d21450d2075ea36064fc9e22d --profile common`; confirm 46 common file paths, zero ScanCode-favored signals, and the documented timing/advantages.

## Intentional differences from Python

- Provenant reports the two explicit Markdown image targets ScanCode omits, retains a valid repeated `decimal.js` documentation link, and carries the manifest author into the assembled npm package holder.

## Follow-up work

- Created or intentionally deferred: None; the target reached the verification exit condition without scanner changes.

## Expected-output fixture changes

- Files changed: None.
- Why the new expected output is correct: No scanner output changed; this PR records the verified comparison and regenerates its chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
