### PR TITLE
fix(release): rely on inferred Homebrew version

### DIFF
--- a/.github/homebrew/provenant.rb.tmpl
+++ b/.github/homebrew/provenant.rb.tmpl
@@ -1,7 +1,6 @@
 class Provenant < Formula
   desc "Fast Rust code scanner for licenses, copyrights, and package provenance"
   homepage "https://github.com/getprovenant/provenant"
-  version "@@VERSION@@"
   license "Apache-2.0"
 
   on_macos do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,7 +385,6 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          version="${TAG#v}"
           mkdir -p shas
           for arch in macos-aarch64 macos-x86_64 linux-aarch64 linux-x86_64; do
             gh release download "$TAG" --repo "${{ github.repository }}" \
@@ -395,7 +394,6 @@ jobs:
           # Render to a temp file (not into the tap checkout): the push step
           # re-syncs the tap on each attempt and re-applies this rendered formula.
           sed \
-            -e "s|@@VERSION@@|${version}|g" \
             -e "s|@@TAG@@|${TAG}|g" \
             -e "s|@@SHA_MACOS_ARM@@|$(sha macos-aarch64)|" \
             -e "s|@@SHA_MACOS_INTEL@@|$(sha macos-x86_64)|" \
@@ -428,7 +426,9 @@ jobs:
           for attempt in 1 2 3 4 5; do
             git fetch --quiet origin main
             git reset --quiet --hard origin/main
-            current="$(sed -nE 's/^  version "([^"]+)"/\1/p' "$formula" | head -1)"
+            # Homebrew infers the version from the GitHub release URL, so read
+            # the current version from that URL for the downgrade guard.
+            current="$(sed -nE 's|.*releases/download/v([^/]+)/.*|\1|p' "$formula" | head -1)"
             if [ -n "$current" ] && [ "$current" != "$version" ]; then
               newest="$(printf '%s\n%s\n' "$current" "$version" | sort -V | tail -1)"
               if [ "$newest" = "$current" ]; then


### PR DESCRIPTION
## Summary

- Remove the explicit Homebrew formula version now rejected by Homebrew 6.0.14 and newer as redundant with the GitHub release URL.
- Keep release bump race protection by deriving the currently published tap version from its release URL.
- Stop rendering the now-unused version placeholder.

## Issues

- Covers the Homebrew tap CI failures affecting formula bumps from 1.0.4 through 1.0.10.

## Scope and exclusions

- Included: the formula template and stable-release tap bump automation.
- Explicit exclusions: the current tap formula is repaired in getprovenant/homebrew-tap#1.

## How to verify

- Render the template with the v1.0.10 tag and published checksums; confirm Ruby syntax succeeds, no placeholders remain, and the downgrade guard extracts version 1.0.10 from the release URL.

## Follow-up work

- Created or intentionally deferred: getprovenant/homebrew-tap#1 removes the redundant version from the currently published formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)